### PR TITLE
feat: document governance phase 2 — unified change mainline

### DIFF
--- a/client/src/api/change-event.ts
+++ b/client/src/api/change-event.ts
@@ -61,6 +61,10 @@ const CHANGE_TYPE_MAP: Record<string, string> = {
   process: '工艺变更',
   supplier: '供应商变更',
   equipment: '设备变更',
+  document: '文件变更',
+  record_form: '记录表单变更',
+  product: '产品变更',
+  haccp: 'HACCP变更',
   other: '其他',
 };
 

--- a/client/src/api/change-event.ts
+++ b/client/src/api/change-event.ts
@@ -118,8 +118,8 @@ const changeEventApi = {
     return request.get<ChangeEventFormTask[]>(`/change-events/${id}/form-tasks`);
   },
 
-  fillFormTask(taskId: string, dataJson: Record<string, unknown>) {
-    return request.post<ChangeEventFormTask>(`/change-events/form-tasks/${taskId}/fill`, { dataJson });
+  fillFormTask(taskId: string, payload: { dataJson?: Record<string, unknown>; existingRecordId?: string }) {
+    return request.post<ChangeEventFormTask>(`/change-events/form-tasks/${taskId}/fill`, payload);
   },
 };
 

--- a/client/src/api/change-event.ts
+++ b/client/src/api/change-event.ts
@@ -4,6 +4,31 @@ import request from './request';
 // Types
 // =========================================================================
 
+export interface ChangeEventRelation {
+  id: string;
+  targetType: string;
+  targetId?: string | null;
+  targetRoute?: string | null;
+  targetLabel: string;
+  relationType?: string | null;
+  impactLevel: string;
+  requiredAction?: string | null;
+  status: string;
+}
+
+export interface ChangeEventFormTask {
+  id: string;
+  changeEventId: string;
+  templateId: string;
+  sourceFormCode: string;
+  title: string;
+  status: 'pending' | 'filled' | 'approved';
+  required: boolean;
+  sortOrder: number;
+  template?: { id: string; code: string; name: string; status: string };
+  record?: { id: string; number: string; status: string; createdAt: string } | null;
+}
+
 export interface ChangeEvent {
   id: string;
   company_id: string;
@@ -16,6 +41,8 @@ export interface ChangeEvent {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  relations?: ChangeEventRelation[];
+  formTasks?: ChangeEventFormTask[];
 }
 
 export interface CreateChangeEventPayload {
@@ -81,6 +108,14 @@ const changeEventApi = {
 
   remove(id: string) {
     return request.delete<void>(`/change-events/${id}`);
+  },
+
+  getFormTasks(id: string) {
+    return request.get<ChangeEventFormTask[]>(`/change-events/${id}/form-tasks`);
+  },
+
+  fillFormTask(taskId: string, dataJson: Record<string, unknown>) {
+    return request.post<ChangeEventFormTask>(`/change-events/form-tasks/${taskId}/fill`, { dataJson });
   },
 };
 

--- a/client/src/views/change-event/ChangeEventList.vue
+++ b/client/src/views/change-event/ChangeEventList.vue
@@ -74,6 +74,10 @@
             <el-option label="工艺变更" value="process" />
             <el-option label="供应商变更" value="supplier" />
             <el-option label="设备变更" value="equipment" />
+            <el-option label="文件变更" value="document" />
+            <el-option label="记录表单变更" value="record_form" />
+            <el-option label="产品变更" value="product" />
+            <el-option label="HACCP变更" value="haccp" />
             <el-option label="其他" value="other" />
           </el-select>
         </el-form-item>
@@ -139,10 +143,13 @@
                 </el-tag>
               </template>
             </el-table-column>
-            <el-table-column label="记录" width="140">
+            <el-table-column label="操作" width="140">
               <template #default="{ row }">
                 <el-button v-if="row.record" link type="primary" @click="router.push(`/records/${row.record.id}`)">
                   {{ row.record.number }}
+                </el-button>
+                <el-button v-else-if="row.status === 'pending'" link type="warning" @click="goFillTask(row)">
+                  去填写
                 </el-button>
                 <span v-else>-</span>
               </template>
@@ -535,6 +542,13 @@ function formatDate(dateStr: string | null): string {
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
+  });
+}
+
+function goFillTask(task: { id: string; templateId: string; changeEventId: string }) {
+  router.push({
+    path: `/records/fill/${task.templateId}`,
+    query: { changeEventTaskId: task.id, changeEventId: task.changeEventId },
   });
 }
 

--- a/client/src/views/change-event/ChangeEventList.vue
+++ b/client/src/views/change-event/ChangeEventList.vue
@@ -134,8 +134,8 @@
             <el-table-column prop="title" label="表单名称" min-width="180" show-overflow-tooltip />
             <el-table-column label="状态" width="100">
               <template #default="{ row }">
-                <el-tag :type="row.status === 'filled' ? 'success' : 'warning'" effect="light" size="small">
-                  {{ row.status === 'filled' ? '已填写' : '待填写' }}
+                <el-tag :type="taskStatusMap[row.status]?.type ?? 'warning'" effect="light" size="small">
+                  {{ taskStatusMap[row.status]?.label ?? row.status }}
                 </el-tag>
               </template>
             </el-table-column>
@@ -450,6 +450,14 @@ import changeApprovalApi, {
 } from '@/api/change-approval';
 
 const router = useRouter();
+
+// ── Form task status map ──────────────────────────────────────────────────────
+
+const taskStatusMap: Record<string, { label: string; type: string }> = {
+  filled: { label: '已填写', type: 'success' },
+  approved: { label: '已审批', type: 'success' },
+  pending: { label: '待填写', type: 'warning' },
+};
 
 // ── State ─────────────────────────────────────────────────────────────────────
 

--- a/client/src/views/change-event/ChangeEventList.vue
+++ b/client/src/views/change-event/ChangeEventList.vue
@@ -125,6 +125,31 @@
           </el-descriptions>
         </div>
 
+        <!-- 默认表单 -->
+        <div class="detail-section">
+          <div class="section-title">默认表单</div>
+          <div v-if="!currentEvent.formTasks?.length" class="empty-hint">当前变更类型没有默认表单</div>
+          <el-table v-else :data="currentEvent.formTasks" size="small" stripe>
+            <el-table-column prop="sourceFormCode" label="表单编号" width="150" />
+            <el-table-column prop="title" label="表单名称" min-width="180" show-overflow-tooltip />
+            <el-table-column label="状态" width="100">
+              <template #default="{ row }">
+                <el-tag :type="row.status === 'filled' ? 'success' : 'warning'" effect="light" size="small">
+                  {{ row.status === 'filled' ? '已填写' : '待填写' }}
+                </el-tag>
+              </template>
+            </el-table-column>
+            <el-table-column label="记录" width="140">
+              <template #default="{ row }">
+                <el-button v-if="row.record" link type="primary" @click="router.push(`/records/${row.record.id}`)">
+                  {{ row.record.number }}
+                </el-button>
+                <span v-else>-</span>
+              </template>
+            </el-table-column>
+          </el-table>
+        </div>
+
         <!-- 合规评估记录 -->
         <div class="detail-section">
           <div class="section-header">
@@ -398,6 +423,7 @@
 
 <script setup lang="ts">
 import { ref, reactive, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import type { FormInstance, FormRules } from 'element-plus';
@@ -422,6 +448,8 @@ import changeApprovalApi, {
   getDecisionText,
   getDecisionType,
 } from '@/api/change-approval';
+
+const router = useRouter();
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -571,6 +599,12 @@ async function openDetailDialog(event: ChangeEvent) {
   verificationRecords.value = [];
   approvalRecords.value = [];
   detailDialogVisible.value = true;
+  try {
+    const full = await changeEventApi.getOne(event.id);
+    currentEvent.value = full as unknown as ChangeEvent;
+  } catch {
+    // keep existing event data on error
+  }
   await loadSubRecords(event.id);
 }
 

--- a/client/src/views/change-event/__tests__/ChangeEventList.spec.ts
+++ b/client/src/views/change-event/__tests__/ChangeEventList.spec.ts
@@ -10,6 +10,8 @@ vi.mock('@/api/change-event', () => ({
     create: vi.fn(),
     updateStatus: vi.fn(),
     remove: vi.fn(),
+    getFormTasks: vi.fn().mockResolvedValue([]),
+    fillFormTask: vi.fn().mockResolvedValue({}),
   },
   getChangeTypeText: (type: string) => type,
   getStatusText: (status: string) => status,

--- a/client/src/views/change-event/__tests__/ChangeEventList.spec.ts
+++ b/client/src/views/change-event/__tests__/ChangeEventList.spec.ts
@@ -1,0 +1,107 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import ChangeEventList from '../ChangeEventList.vue';
+import changeEventApi from '@/api/change-event';
+
+vi.mock('@/api/change-event', () => ({
+  default: {
+    getList: vi.fn(),
+    getOne: vi.fn(),
+    create: vi.fn(),
+    updateStatus: vi.fn(),
+    remove: vi.fn(),
+  },
+  getChangeTypeText: (type: string) => type,
+  getStatusText: (status: string) => status,
+  getStatusType: () => 'info',
+}));
+
+vi.mock('@/api/change-compliance-record', () => ({
+  default: {
+    getByEvent: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    remove: vi.fn(),
+  },
+  getRiskText: (level: string) => level,
+  getRiskType: () => 'info',
+}));
+
+vi.mock('@/api/change-verification-record', () => ({
+  default: {
+    getByEvent: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    remove: vi.fn(),
+  },
+  getVerificationResultText: (result: string) => result,
+  getVerificationResultType: () => 'info',
+}));
+
+vi.mock('@/api/change-approval', () => ({
+  default: {
+    getByEvent: vi.fn().mockResolvedValue([]),
+    create: vi.fn(),
+    remove: vi.fn(),
+  },
+  getDecisionText: (decision: string) => decision,
+  getDecisionType: () => 'info',
+}));
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('ChangeEventList', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows generated form tasks in change detail', async () => {
+    vi.mocked(changeEventApi.getList).mockResolvedValue([]);
+    vi.mocked(changeEventApi.getOne).mockResolvedValue({
+      id: 'change1',
+      company_id: '1',
+      change_no: 'CE-2026-0001',
+      title: '配方调整',
+      change_type: 'recipe',
+      description: '调整配方',
+      status: 'pending',
+      initiator_id: null,
+      created_at: '2026-04-27T00:00:00.000Z',
+      updated_at: '2026-04-27T00:00:00.000Z',
+      deleted_at: null,
+      formTasks: [{ id: 'task1', changeEventId: 'change1', templateId: 'tpl1', sourceFormCode: 'GRSS-KF-JL-07', title: '产品验证记录表', status: 'pending', required: true, sortOrder: 0 }],
+    } as any);
+
+    const ElTableStub = {
+      props: ['data'],
+      template: '<div><span v-for="row in (data || [])" :key="row.id">{{ row.sourceFormCode }} {{ row.title }}</span><slot /></div>',
+    };
+
+    const wrapper = mount(ChangeEventList, {
+      global: {
+        stubs: {
+          'el-card': { template: '<div><slot /><slot name="header" /></div>' },
+          'el-table': ElTableStub,
+          'el-table-column': true,
+          'el-dialog': { template: '<div><slot /><slot name="footer" /></div>', props: ['modelValue', 'title'] },
+          'el-button': { template: '<button><slot /></button>' },
+          'el-tag': { template: '<span><slot /></span>' },
+          'el-form': { template: '<form><slot /></form>' },
+          'el-form-item': { template: '<div><slot /></div>' },
+          'el-input': { template: '<input />' },
+          'el-select': { template: '<select><slot /></select>' },
+          'el-option': { template: '<option />' },
+          'el-descriptions': { template: '<dl><slot /></dl>' },
+          'el-descriptions-item': { template: '<dd><slot /></dd>' },
+          'el-icon': { template: '<i><slot /></i>' },
+          'el-date-picker': { template: '<input />' },
+        },
+      },
+    });
+    await flushPromises();
+
+    await (wrapper.vm as any).openDetailDialog({ id: 'change1' });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('产品验证记录表');
+    expect(wrapper.text()).toContain('GRSS-KF-JL-07');
+  });
+});

--- a/client/src/views/records/RecordFill.vue
+++ b/client/src/views/records/RecordFill.vue
@@ -82,6 +82,7 @@ import DynamicForm from '@/components/DynamicForm.vue';
 import { recordTemplateApi } from '@/api/record-template';
 import { instanceApi } from '@/api/record-task';
 import { newRecordApi, type DeviationInfo } from '@/api/new-record';
+import changeEventApi from '@/api/change-event';
 
 const route = useRoute();
 const router = useRouter();
@@ -98,6 +99,8 @@ const deviationForm = reactive<{ reasons: string[] }>({ reasons: [] });
 const currentRecordId = ref('');
 
 const isTaskMode = computed(() => !!route.params.instanceId);
+
+const changeEventTaskId = computed(() => route.query.changeEventTaskId as string | undefined);
 
 const pageTitle = computed(() => {
   if (isTaskMode.value) return '填写任务';
@@ -144,6 +147,12 @@ const buildCreatePayload = () => {
   if (isTaskMode.value) {
     payload.taskInstanceId = route.params.instanceId as string;
   }
+  if (changeEventTaskId.value) {
+    payload.usageType = 'change';
+    payload.sourceType = 'change_event';
+    payload.sourceId = route.query.changeEventId as string;
+    payload.changeEventId = route.query.changeEventId as string;
+  }
   return payload;
 };
 
@@ -157,6 +166,9 @@ const handleSubmit = async () => {
   try {
     const record: any = await newRecordApi.create(buildCreatePayload());
     currentRecordId.value = record.id;
+    if (changeEventTaskId.value) {
+      await changeEventApi.fillFormTask(changeEventTaskId.value, { ...formData });
+    }
     await submitRecord();
   } catch {
     submitting.value = false;

--- a/client/src/views/records/RecordFill.vue
+++ b/client/src/views/records/RecordFill.vue
@@ -167,7 +167,7 @@ const handleSubmit = async () => {
     const record: any = await newRecordApi.create(buildCreatePayload());
     currentRecordId.value = record.id;
     if (changeEventTaskId.value) {
-      await changeEventApi.fillFormTask(changeEventTaskId.value, { ...formData });
+      await changeEventApi.fillFormTask(changeEventTaskId.value, { existingRecordId: record.id });
     }
     await submitRecord();
   } catch {

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   rootDir: '.',
   testRegex: '.*\\.(spec|e2e-spec|test)\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.(t|j)s$': ['ts-jest', { diagnostics: false }],
   },
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: './coverage',

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   rootDir: '.',
   testRegex: '.*\\.(spec|e2e-spec|test)\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': ['ts-jest', { diagnostics: false }],
+    '^.+\\.(t|j)s$': 'ts-jest',
   },
   collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: './coverage',

--- a/server/src/modules/approval/approval.service.ts
+++ b/server/src/modules/approval/approval.service.ts
@@ -120,7 +120,7 @@ export class ApprovalService {
         orderBy: { createdAt: 'desc' },
         take: 100,
       });
-      unifiedTasks = tasks.map((task) => ({ source: 'unified' as const, task }));
+      unifiedTasks = tasks.map((task: any) => ({ source: 'unified' as const, task }));
     } catch {
       // approvalTask 表在旧部署中可能不存在，静默跳过
     }
@@ -196,7 +196,7 @@ export class ApprovalService {
       throw new BusinessException(ErrorCode.VALIDATION_ERROR, '仅支持文档审批');
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       const document = await this.findDocumentForApprovalInTx(tx, approval.documentId!);
       this.validateDocumentStatus(document);
 
@@ -216,7 +216,7 @@ export class ApprovalService {
     const groupId = crypto.randomUUID();
     const chainId = crypto.randomUUID();
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       const approvals: any[] = [];
 
       for (const approverId of approverIds) {
@@ -263,7 +263,7 @@ export class ApprovalService {
     action: string,
     commentOrReason?: string,
   ) {
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       if (action === 'rejected') {
         const updatedApproval = await this.updateApprovalStatus(tx, approval.id, 'rejected', undefined, commentOrReason);
         await tx.approval.updateMany({
@@ -306,7 +306,7 @@ export class ApprovalService {
     const groupId = crypto.randomUUID();
     const chainId = crypto.randomUUID();
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       const approvals: any[] = [];
 
       for (let i = 0; i < approverIds.length; i++) {
@@ -453,7 +453,7 @@ export class ApprovalService {
     action: string,
     commentOrReason?: string,
   ) {
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       if (action === 'rejected') {
         const updatedApproval = await this.updateApprovalStatus(tx, approval.id, 'rejected', undefined, commentOrReason);
         await tx.approval.updateMany({

--- a/server/src/modules/change-event/change-event-default-form-rules.ts
+++ b/server/src/modules/change-event/change-event-default-form-rules.ts
@@ -6,7 +6,9 @@ export const PRODUCT_RND_ONLY_FORM_CODES = new Set([
   'GRSS-KF-JL-01', // 产品开发评审记录：固定挂产品研发流程 Step 4
 ]);
 
-export const CHANGE_EVENT_DEFAULT_FORM_CODES: Record<string, string[]> = {
+export type ChangeType = 'document' | 'record_form' | 'recipe' | 'process' | 'equipment' | 'supplier' | 'haccp' | 'product' | 'other';
+
+export const CHANGE_EVENT_DEFAULT_FORM_CODES: Record<ChangeType, string[]> = {
   document: [],
   record_form: [],
   recipe: [
@@ -31,7 +33,7 @@ export const CHANGE_EVENT_DEFAULT_FORM_CODES: Record<string, string[]> = {
 };
 
 export function getDefaultFormCodesForChangeType(changeType: string): string[] {
-  const codes = CHANGE_EVENT_DEFAULT_FORM_CODES[changeType] ?? [];
+  const codes = CHANGE_EVENT_DEFAULT_FORM_CODES[changeType as ChangeType] ?? [];
   return codes.filter(
     (code) => !RETIRED_CHANGE_FORM_CODES.has(code) && !PRODUCT_RND_ONLY_FORM_CODES.has(code),
   );

--- a/server/src/modules/change-event/change-event-default-form-rules.ts
+++ b/server/src/modules/change-event/change-event-default-form-rules.ts
@@ -1,0 +1,38 @@
+export const RETIRED_CHANGE_FORM_CODES = new Set([
+  'GRSS-KF-JL-03', // 产品更改申请表：由 ChangeEvent + ChangeApproval 承载
+]);
+
+export const PRODUCT_RND_ONLY_FORM_CODES = new Set([
+  'GRSS-KF-JL-01', // 产品开发评审记录：固定挂产品研发流程 Step 4
+]);
+
+export const CHANGE_EVENT_DEFAULT_FORM_CODES: Record<string, string[]> = {
+  document: [],
+  record_form: [],
+  recipe: [
+    'GRSS-KF-JL-07',
+    'GRSS-KF-JL-08',
+  ],
+  process: [
+    'GRSS-KF-JL-08',
+    'GRSS-PZ-JL-22',
+  ],
+  equipment: [
+    'GRSS-PZ-JL-45',
+  ],
+  supplier: [],
+  haccp: [
+    'GRSS-PZ-JL-22',
+  ],
+  product: [
+    'GRSS-KF-JL-07',
+  ],
+  other: [],
+};
+
+export function getDefaultFormCodesForChangeType(changeType: string): string[] {
+  const codes = CHANGE_EVENT_DEFAULT_FORM_CODES[changeType] ?? [];
+  return codes.filter(
+    (code) => !RETIRED_CHANGE_FORM_CODES.has(code) && !PRODUCT_RND_ONLY_FORM_CODES.has(code),
+  );
+}

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -36,7 +36,7 @@ describe('ChangeEventFormTaskService', () => {
   const prisma = {
     recordTemplate: { findMany: jest.fn() },
     changeEventFormTask: { createMany: jest.fn(), findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
-    record: { create: jest.fn() },
+    record: { create: jest.fn(), findUnique: jest.fn() },
     $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
   };
   const recordService = { create: jest.fn() };
@@ -99,6 +99,12 @@ describe('ChangeEventFormTaskService', () => {
       changeEventId: 'change1',
       templateId: 'tpl1',
     });
+    prisma.record.findUnique.mockResolvedValue({
+      id: 'existing-record-1',
+      templateId: 'tpl1',
+      changeEventId: 'change1',
+      deletedAt: null,
+    });
     prisma.changeEventFormTask.update.mockResolvedValue({
       id: 'task1',
       recordId: 'existing-record-1',
@@ -112,5 +118,28 @@ describe('ChangeEventFormTaskService', () => {
     expect(prisma.changeEventFormTask.update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ recordId: 'existing-record-1', status: 'filled' }),
     }));
+  });
+
+  it('throws NotFoundException when existingRecordId does not exist', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue({
+      id: 'task1', recordId: null, status: 'pending', changeEventId: 'change1', templateId: 'tpl1',
+    });
+    prisma.record.findUnique.mockResolvedValue(null);
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+
+    await expect(service.fillTask('task1', {}, 'user1', 'bad-record')).rejects.toThrow(NotFoundException);
+    expect(recordService.create).not.toHaveBeenCalled();
+  });
+
+  it('throws BadRequestException when existingRecord templateId does not match task', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue({
+      id: 'task1', recordId: null, status: 'pending', changeEventId: 'change1', templateId: 'tpl1',
+    });
+    prisma.record.findUnique.mockResolvedValue({
+      id: 'record-wrong', templateId: 'tpl-other', changeEventId: 'change1', deletedAt: null,
+    });
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+
+    await expect(service.fillTask('task1', {}, 'user1', 'record-wrong')).rejects.toThrow(BadRequestException);
   });
 });

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -13,4 +13,19 @@ describe('change event default form rules', () => {
     expect(allCodes).not.toContain('GRSS-KF-JL-03');
     expect(allCodes).not.toContain('GRSS-KF-JL-01');
   });
+
+  it('returns correct codes for recipe change type', () => {
+    const codes = getDefaultFormCodesForChangeType('recipe');
+    expect(codes).toEqual(['GRSS-KF-JL-07', 'GRSS-KF-JL-08']);
+  });
+
+  it('returns empty array for unknown change type', () => {
+    const codes = getDefaultFormCodesForChangeType('unknown_type_xyz');
+    expect(codes).toEqual([]);
+  });
+
+  it('returns empty array for document and record_form change types', () => {
+    expect(getDefaultFormCodesForChangeType('document')).toEqual([]);
+    expect(getDefaultFormCodesForChangeType('record_form')).toEqual([]);
+  });
 });

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
 import { ChangeEventFormTaskService } from './change-event-form-task.service';
 
@@ -36,6 +37,7 @@ describe('ChangeEventFormTaskService', () => {
     recordTemplate: { findMany: jest.fn() },
     changeEventFormTask: { createMany: jest.fn(), findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
     record: { create: jest.fn() },
+    $transaction: jest.fn().mockImplementation(async (fn) => fn(prisma)),
   };
   const recordService = { create: jest.fn() };
 
@@ -66,5 +68,26 @@ describe('ChangeEventFormTaskService', () => {
       skipDuplicates: true,
     });
     expect(result).toHaveLength(1);
+  });
+
+  it('throws NotFoundException when task does not exist', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue(null);
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+
+    await expect(service.fillTask('missing-task', {}, 'user1')).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws ConflictException when task is already filled', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue({ id: 'task1', recordId: 'existing-record', status: 'filled', changeEventId: 'change1', templateId: 'tpl1' });
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+
+    await expect(service.fillTask('task1', {}, 'user1')).rejects.toThrow(ConflictException);
+  });
+
+  it('throws BadRequestException when task status is not pending', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue({ id: 'task1', recordId: null, status: 'approved', changeEventId: 'change1', templateId: 'tpl1' });
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+
+    await expect(service.fillTask('task1', {}, 'user1')).rejects.toThrow(BadRequestException);
   });
 });

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -1,0 +1,16 @@
+import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
+
+describe('change event default form rules', () => {
+  it('excludes product change application and product development review from generic changes', () => {
+    const allCodes = [
+      ...getDefaultFormCodesForChangeType('product'),
+      ...getDefaultFormCodesForChangeType('recipe'),
+      ...getDefaultFormCodesForChangeType('process'),
+      ...getDefaultFormCodesForChangeType('document'),
+      ...getDefaultFormCodesForChangeType('record_form'),
+    ];
+
+    expect(allCodes).not.toContain('GRSS-KF-JL-03');
+    expect(allCodes).not.toContain('GRSS-KF-JL-01');
+  });
+});

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -90,4 +90,27 @@ describe('ChangeEventFormTaskService', () => {
 
     await expect(service.fillTask('task1', {}, 'user1')).rejects.toThrow(BadRequestException);
   });
+
+  it('links existing record to task without creating a new one', async () => {
+    prisma.changeEventFormTask.findUnique.mockResolvedValue({
+      id: 'task1',
+      recordId: null,
+      status: 'pending',
+      changeEventId: 'change1',
+      templateId: 'tpl1',
+    });
+    prisma.changeEventFormTask.update.mockResolvedValue({
+      id: 'task1',
+      recordId: 'existing-record-1',
+      status: 'filled',
+    });
+
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+    await service.fillTask('task1', {}, 'user1', 'existing-record-1');
+
+    expect(recordService.create).not.toHaveBeenCalled();
+    expect(prisma.changeEventFormTask.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ recordId: 'existing-record-1', status: 'filled' }),
+    }));
+  });
 });

--- a/server/src/modules/change-event/change-event-form-task.service.spec.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.spec.ts
@@ -1,4 +1,5 @@
 import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
+import { ChangeEventFormTaskService } from './change-event-form-task.service';
 
 describe('change event default form rules', () => {
   it('excludes product change application and product development review from generic changes', () => {
@@ -27,5 +28,43 @@ describe('change event default form rules', () => {
   it('returns empty array for document and record_form change types', () => {
     expect(getDefaultFormCodesForChangeType('document')).toEqual([]);
     expect(getDefaultFormCodesForChangeType('record_form')).toEqual([]);
+  });
+});
+
+describe('ChangeEventFormTaskService', () => {
+  const prisma = {
+    recordTemplate: { findMany: jest.fn() },
+    changeEventFormTask: { createMany: jest.fn(), findMany: jest.fn(), findUnique: jest.fn(), update: jest.fn() },
+    record: { create: jest.fn() },
+  };
+  const recordService = { create: jest.fn() };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('generates pending tasks from default form codes', async () => {
+    prisma.recordTemplate.findMany.mockResolvedValue([
+      { id: 'tpl1', code: 'GRSS-KF-JL-07', name: '产品验证记录表' },
+    ]);
+    prisma.changeEventFormTask.createMany.mockResolvedValue({ count: 1 });
+    prisma.changeEventFormTask.findMany.mockResolvedValue([
+      { id: 'task1', templateId: 'tpl1', sourceFormCode: 'GRSS-KF-JL-07', status: 'pending' },
+    ]);
+
+    const service = new ChangeEventFormTaskService(prisma as any, recordService as any);
+    const result = await service.generateDefaultTasks('change1', 'recipe');
+
+    expect(prisma.changeEventFormTask.createMany).toHaveBeenCalledWith({
+      data: [{
+        changeEventId: 'change1',
+        templateId: 'tpl1',
+        sourceFormCode: 'GRSS-KF-JL-07',
+        title: '产品验证记录表',
+        status: 'pending',
+        required: true,
+        sortOrder: 0,
+      }],
+      skipDuplicates: true,
+    });
+    expect(result).toHaveLength(1);
   });
 });

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -1,0 +1,76 @@
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { RecordService } from '../record/record.service';
+import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
+
+@Injectable()
+export class ChangeEventFormTaskService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly recordService: RecordService,
+  ) {}
+
+  async generateDefaultTasks(changeEventId: string, changeType: string) {
+    const codes = getDefaultFormCodesForChangeType(changeType);
+    if (codes.length === 0) return [];
+
+    const templates = await this.prisma.recordTemplate.findMany({
+      where: { code: { in: codes }, deletedAt: null, status: { not: 'retired' } },
+      select: { id: true, code: true, name: true },
+    });
+    const byCode = new Map(templates.map((t: { id: string; code: string; name: string }) => [t.code, t]));
+    const data = codes
+      .map((code, index) => ({ code, template: byCode.get(code), index }))
+      .filter((item): item is { code: string; template: { id: string; code: string; name: string }; index: number } => Boolean(item.template))
+      .map((item) => ({
+        changeEventId,
+        templateId: item.template.id,
+        sourceFormCode: item.code,
+        title: item.template.name,
+        status: 'pending',
+        required: true,
+        sortOrder: item.index,
+      }));
+
+    if (data.length === 0) return [];
+
+    await this.prisma.changeEventFormTask.createMany({ data, skipDuplicates: true });
+    return this.listForChange(changeEventId);
+  }
+
+  async listForChange(changeEventId: string) {
+    return this.prisma.changeEventFormTask.findMany({
+      where: { changeEventId },
+      include: {
+        template: { select: { id: true, code: true, name: true, status: true } },
+        record: { select: { id: true, number: true, status: true, createdAt: true } },
+      },
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+    });
+  }
+
+  async fillTask(taskId: string, dataJson: object, userId: string) {
+    const task = await this.prisma.changeEventFormTask.findUnique({ where: { id: taskId } });
+    if (!task) throw new NotFoundException('变更表单任务不存在');
+    if (task.recordId) throw new ConflictException('变更表单任务已填写');
+    if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
+
+    const record = await this.recordService.create({
+      templateId: task.templateId,
+      dataJson,
+      usageType: 'change',
+      sourceType: 'change_event',
+      sourceId: task.changeEventId,
+      changeEventId: task.changeEventId,
+    } as any, userId);
+
+    return this.prisma.changeEventFormTask.update({
+      where: { id: task.id },
+      data: { recordId: record.id, status: 'filled' },
+      include: {
+        template: { select: { id: true, code: true, name: true, status: true } },
+        record: { select: { id: true, number: true, status: true, createdAt: true } },
+      },
+    });
+  }
+}

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -51,24 +51,30 @@ export class ChangeEventFormTaskService {
     });
   }
 
-  async fillTask(taskId: string, dataJson: object, userId: string) {
+  async fillTask(taskId: string, dataJson: object, userId: string, existingRecordId?: string) {
     const task = await this.prisma.changeEventFormTask.findUnique({ where: { id: taskId } });
     if (!task) throw new NotFoundException('变更表单任务不存在');
     if (task.recordId) throw new ConflictException('变更表单任务已填写');
     if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
 
-    const record = await this.recordService.create({
-      templateId: task.templateId,
-      dataJson,
-      usageType: 'change' as const,
-      sourceType: 'change_event',
-      sourceId: task.changeEventId,
-      changeEventId: task.changeEventId,
-    }, userId);
+    let recordId: string;
+    if (existingRecordId) {
+      recordId = existingRecordId;
+    } else {
+      const record = await this.recordService.create({
+        templateId: task.templateId,
+        dataJson,
+        usageType: 'change' as const,
+        sourceType: 'change_event',
+        sourceId: task.changeEventId,
+        changeEventId: task.changeEventId,
+      }, userId);
+      recordId = record.id;
+    }
 
     return this.prisma.changeEventFormTask.update({
       where: { id: task.id },
-      data: { recordId: record.id, status: 'filled' },
+      data: { recordId, status: 'filled' },
       include: {
         template: { select: { id: true, code: true, name: true, status: true } },
         record: { select: { id: true, number: true, status: true, createdAt: true } },

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -1,8 +1,6 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RecordService } from '../record/record.service';
-import { CreateRecordDto } from '../record/dto/create-record.dto';
 import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
 
 @Injectable()
@@ -52,30 +50,27 @@ export class ChangeEventFormTaskService {
   }
 
   async fillTask(taskId: string, dataJson: object, userId: string) {
-    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-      const task = await tx.changeEventFormTask.findUnique({ where: { id: taskId } });
-      if (!task) throw new NotFoundException('变更表单任务不存在');
-      if (task.recordId) throw new ConflictException('变更表单任务已填写');
-      if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
+    const task = await this.prisma.changeEventFormTask.findUnique({ where: { id: taskId } });
+    if (!task) throw new NotFoundException('变更表单任务不存在');
+    if (task.recordId) throw new ConflictException('变更表单任务已填写');
+    if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
 
-      const dto: CreateRecordDto = {
-        templateId: task.templateId,
-        dataJson,
-        usageType: 'change',
-        sourceType: 'change_event',
-        sourceId: task.changeEventId,
-        changeEventId: task.changeEventId,
-      };
-      const record = await this.recordService.create(dto, userId);
+    const record = await this.recordService.create({
+      templateId: task.templateId,
+      dataJson,
+      usageType: 'change' as const,
+      sourceType: 'change_event',
+      sourceId: task.changeEventId,
+      changeEventId: task.changeEventId,
+    }, userId);
 
-      return tx.changeEventFormTask.update({
-        where: { id: task.id },
-        data: { recordId: record.id, status: 'filled' },
-        include: {
-          template: { select: { id: true, code: true, name: true, status: true } },
-          record: { select: { id: true, number: true, status: true, createdAt: true } },
-        },
-      });
+    return this.prisma.changeEventFormTask.update({
+      where: { id: task.id },
+      data: { recordId: record.id, status: 'filled' },
+      include: {
+        template: { select: { id: true, code: true, name: true, status: true } },
+        record: { select: { id: true, number: true, status: true, createdAt: true } },
+      },
     });
   }
 }

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -52,33 +52,45 @@ export class ChangeEventFormTaskService {
   }
 
   async fillTask(taskId: string, dataJson: object, userId: string, existingRecordId?: string) {
-    const task = await this.prisma.changeEventFormTask.findUnique({ where: { id: taskId } });
-    if (!task) throw new NotFoundException('变更表单任务不存在');
-    if (task.recordId) throw new ConflictException('变更表单任务已填写');
-    if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      const task = await tx.changeEventFormTask.findUnique({ where: { id: taskId } });
+      if (!task) throw new NotFoundException('变更表单任务不存在');
+      if (task.recordId) throw new ConflictException('变更表单任务已填写');
+      if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
 
-    let recordId: string;
-    if (existingRecordId) {
-      recordId = existingRecordId;
-    } else {
-      const record = await this.recordService.create({
-        templateId: task.templateId,
-        dataJson,
-        usageType: 'change' as const,
-        sourceType: 'change_event',
-        sourceId: task.changeEventId,
-        changeEventId: task.changeEventId,
-      }, userId);
-      recordId = record.id;
-    }
+      let recordId: string;
+      if (existingRecordId) {
+        const record = await tx.record.findUnique({ where: { id: existingRecordId } });
+        if (!record || record.deletedAt) {
+          throw new NotFoundException(`记录不存在: ${existingRecordId}`);
+        }
+        if (record.templateId !== task.templateId) {
+          throw new BadRequestException('记录模板与任务要求的模板不一致');
+        }
+        if (record.changeEventId !== task.changeEventId) {
+          throw new BadRequestException('记录关联的变更事件与任务不一致');
+        }
+        recordId = record.id;
+      } else {
+        const record = await this.recordService.create({
+          templateId: task.templateId,
+          dataJson,
+          usageType: 'change' as const,
+          sourceType: 'change_event',
+          sourceId: task.changeEventId,
+          changeEventId: task.changeEventId,
+        }, userId);
+        recordId = record.id;
+      }
 
-    return this.prisma.changeEventFormTask.update({
-      where: { id: task.id },
-      data: { recordId, status: 'filled' },
-      include: {
-        template: { select: { id: true, code: true, name: true, status: true } },
-        record: { select: { id: true, number: true, status: true, createdAt: true } },
-      },
+      return tx.changeEventFormTask.update({
+        where: { id: task.id },
+        data: { recordId, status: 'filled' },
+        include: {
+          template: { select: { id: true, code: true, name: true, status: true } },
+          record: { select: { id: true, number: true, status: true, createdAt: true } },
+        },
+      });
     });
   }
 }

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -1,6 +1,8 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RecordService } from '../record/record.service';
+import { CreateRecordDto } from '../record/dto/create-record.dto';
 import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
 
 @Injectable()
@@ -50,27 +52,30 @@ export class ChangeEventFormTaskService {
   }
 
   async fillTask(taskId: string, dataJson: object, userId: string) {
-    const task = await this.prisma.changeEventFormTask.findUnique({ where: { id: taskId } });
-    if (!task) throw new NotFoundException('变更表单任务不存在');
-    if (task.recordId) throw new ConflictException('变更表单任务已填写');
-    if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      const task = await tx.changeEventFormTask.findUnique({ where: { id: taskId } });
+      if (!task) throw new NotFoundException('变更表单任务不存在');
+      if (task.recordId) throw new ConflictException('变更表单任务已填写');
+      if (task.status !== 'pending') throw new BadRequestException('只有待填写任务可以填写');
 
-    const record = await this.recordService.create({
-      templateId: task.templateId,
-      dataJson,
-      usageType: 'change',
-      sourceType: 'change_event',
-      sourceId: task.changeEventId,
-      changeEventId: task.changeEventId,
-    } as any, userId);
+      const dto: CreateRecordDto = {
+        templateId: task.templateId,
+        dataJson,
+        usageType: 'change',
+        sourceType: 'change_event',
+        sourceId: task.changeEventId,
+        changeEventId: task.changeEventId,
+      };
+      const record = await this.recordService.create(dto, userId);
 
-    return this.prisma.changeEventFormTask.update({
-      where: { id: task.id },
-      data: { recordId: record.id, status: 'filled' },
-      include: {
-        template: { select: { id: true, code: true, name: true, status: true } },
-        record: { select: { id: true, number: true, status: true, createdAt: true } },
-      },
+      return tx.changeEventFormTask.update({
+        where: { id: task.id },
+        data: { recordId: record.id, status: 'filled' },
+        include: {
+          template: { select: { id: true, code: true, name: true, status: true } },
+          record: { select: { id: true, number: true, status: true, createdAt: true } },
+        },
+      });
     });
   }
 }

--- a/server/src/modules/change-event/change-event-form-task.service.ts
+++ b/server/src/modules/change-event/change-event-form-task.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RecordService } from '../record/record.service';
 import { getDefaultFormCodesForChangeType } from './change-event-default-form-rules';
@@ -10,11 +11,12 @@ export class ChangeEventFormTaskService {
     private readonly recordService: RecordService,
   ) {}
 
-  async generateDefaultTasks(changeEventId: string, changeType: string) {
+  async generateDefaultTasks(changeEventId: string, changeType: string, tx?: Prisma.TransactionClient) {
     const codes = getDefaultFormCodesForChangeType(changeType);
     if (codes.length === 0) return [];
 
-    const templates = await this.prisma.recordTemplate.findMany({
+    const db = tx ?? this.prisma;
+    const templates = await db.recordTemplate.findMany({
       where: { code: { in: codes }, deletedAt: null, status: { not: 'retired' } },
       select: { id: true, code: true, name: true },
     });
@@ -34,7 +36,7 @@ export class ChangeEventFormTaskService {
 
     if (data.length === 0) return [];
 
-    await this.prisma.changeEventFormTask.createMany({ data, skipDuplicates: true });
+    await db.changeEventFormTask.createMany({ data, skipDuplicates: true });
     return this.listForChange(changeEventId);
   }
 

--- a/server/src/modules/change-event/change-event-relation.service.spec.ts
+++ b/server/src/modules/change-event/change-event-relation.service.spec.ts
@@ -19,7 +19,7 @@ describe('ChangeEventRelationService', () => {
     prisma.document.findUnique.mockResolvedValue(null);
     const service = new ChangeEventRelationService(prisma as any);
 
-    await expect(service.createRelations('change1', [{
+    await expect(service.validateRelations([{
       targetType: 'document',
       targetId: 'missing-doc',
       targetLabel: '质量手册',
@@ -27,7 +27,6 @@ describe('ChangeEventRelationService', () => {
   });
 
   it('creates validated relation rows', async () => {
-    prisma.document.findUnique.mockResolvedValue({ id: 'doc1' });
     prisma.changeEventRelation.createMany.mockResolvedValue({ count: 1 });
     const service = new ChangeEventRelationService(prisma as any);
 

--- a/server/src/modules/change-event/change-event-relation.service.spec.ts
+++ b/server/src/modules/change-event/change-event-relation.service.spec.ts
@@ -1,0 +1,55 @@
+import { NotFoundException } from '@nestjs/common';
+import { ChangeEventRelationService } from './change-event-relation.service';
+
+describe('ChangeEventRelationService', () => {
+  const prisma = {
+    document: { findUnique: jest.fn() },
+    recordTemplate: { findUnique: jest.fn() },
+    product: { findUnique: jest.fn() },
+    recipe: { findUnique: jest.fn() },
+    processStep: { findUnique: jest.fn() },
+    material: { findUnique: jest.fn() },
+    supplier: { findUnique: jest.fn() },
+    changeEventRelation: { createMany: jest.fn() },
+  };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('rejects missing known relation targets', async () => {
+    prisma.document.findUnique.mockResolvedValue(null);
+    const service = new ChangeEventRelationService(prisma as any);
+
+    await expect(service.createRelations('change1', [{
+      targetType: 'document',
+      targetId: 'missing-doc',
+      targetLabel: '质量手册',
+    }])).rejects.toThrow(NotFoundException);
+  });
+
+  it('creates validated relation rows', async () => {
+    prisma.document.findUnique.mockResolvedValue({ id: 'doc1' });
+    prisma.changeEventRelation.createMany.mockResolvedValue({ count: 1 });
+    const service = new ChangeEventRelationService(prisma as any);
+
+    await service.createRelations('change1', [{
+      targetType: 'document',
+      targetId: 'doc1',
+      targetLabel: '质量手册',
+      relationType: 'affected',
+    }]);
+
+    expect(prisma.changeEventRelation.createMany).toHaveBeenCalledWith({
+      data: [{
+        changeEventId: 'change1',
+        targetType: 'document',
+        targetId: 'doc1',
+        targetRoute: null,
+        targetLabel: '质量手册',
+        relationType: 'affected',
+        impactLevel: 'medium',
+        requiredAction: null,
+        status: 'open',
+      }],
+    });
+  });
+});

--- a/server/src/modules/change-event/change-event-relation.service.ts
+++ b/server/src/modules/change-event/change-event-relation.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ChangeEventRelationDto } from './dto/create-change-event.dto';
 
@@ -6,14 +7,20 @@ import { ChangeEventRelationDto } from './dto/create-change-event.dto';
 export class ChangeEventRelationService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async createRelations(changeEventId: string, relations: ChangeEventRelationDto[] = []) {
-    if (relations.length === 0) return { count: 0 };
-
+  async validateRelations(relations: ChangeEventRelationDto[]) {
     for (const relation of relations) {
       await this.assertTargetExists(relation);
     }
+  }
 
-    return this.prisma.changeEventRelation.createMany({
+  async createRelations(
+    changeEventId: string,
+    relations: ChangeEventRelationDto[] = [],
+    tx?: Prisma.TransactionClient,
+  ) {
+    if (relations.length === 0) return { count: 0 };
+    const db = tx ?? this.prisma;
+    return db.changeEventRelation.createMany({
       data: relations.map((relation) => ({
         changeEventId,
         targetType: relation.targetType,

--- a/server/src/modules/change-event/change-event-relation.service.ts
+++ b/server/src/modules/change-event/change-event-relation.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ChangeEventRelationDto } from './dto/create-change-event.dto';
+
+@Injectable()
+export class ChangeEventRelationService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async createRelations(changeEventId: string, relations: ChangeEventRelationDto[] = []) {
+    if (relations.length === 0) return { count: 0 };
+
+    for (const relation of relations) {
+      await this.assertTargetExists(relation);
+    }
+
+    return this.prisma.changeEventRelation.createMany({
+      data: relations.map((relation) => ({
+        changeEventId,
+        targetType: relation.targetType,
+        targetId: relation.targetId ?? null,
+        targetRoute: relation.targetRoute ?? null,
+        targetLabel: relation.targetLabel,
+        relationType: relation.relationType ?? null,
+        impactLevel: relation.impactLevel ?? 'medium',
+        requiredAction: relation.requiredAction ?? null,
+        status: 'open',
+      })),
+    });
+  }
+
+  private async assertTargetExists(relation: ChangeEventRelationDto) {
+    if (!relation.targetId) return;
+
+    const modelByType: Record<string, any> = {
+      document: this.prisma.document,
+      record_template: this.prisma.recordTemplate,
+      product: this.prisma.product,
+      recipe: this.prisma.recipe,
+      process_step: this.prisma.processStep,
+      material: this.prisma.material,
+      supplier: this.prisma.supplier,
+    };
+    const model = modelByType[relation.targetType];
+    if (!model) return;
+
+    const target = await model.findUnique({ where: { id: relation.targetId } });
+    if (!target || target.deletedAt) {
+      throw new NotFoundException(`变更关联目标不存在: ${relation.targetType}/${relation.targetId}`);
+    }
+  }
+}

--- a/server/src/modules/change-event/change-event.controller.ts
+++ b/server/src/modules/change-event/change-event.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Delete, Body, Param, Query, UseGuards, Request, BadRequestException } from '@nestjs/common';
 import { ChangeEventService } from './change-event.service';
 import { ChangeEventFormTaskService } from './change-event-form-task.service';
 import { CreateChangeEventDto } from './dto/create-change-event.dto';
@@ -37,7 +37,9 @@ export class ChangeEventController {
     @Body('dataJson') dataJson: object,
     @Request() req: { user: { id?: string; userId?: string } },
   ) {
-    return this.formTaskService.fillTask(taskId, dataJson ?? {}, req.user.id ?? req.user.userId!);
+    const userId = req.user.id ?? req.user.userId;
+    if (!userId) throw new BadRequestException('Unable to resolve userId from token');
+    return this.formTaskService.fillTask(taskId, dataJson ?? {}, userId);
   }
 
   @Get(':id')

--- a/server/src/modules/change-event/change-event.controller.ts
+++ b/server/src/modules/change-event/change-event.controller.ts
@@ -34,12 +34,12 @@ export class ChangeEventController {
   @Post('form-tasks/:taskId/fill')
   fillFormTask(
     @Param('taskId') taskId: string,
-    @Body('dataJson') dataJson: object,
+    @Body() body: { dataJson?: object; existingRecordId?: string },
     @Request() req: { user: { id?: string; userId?: string } },
   ) {
     const userId = req.user.id ?? req.user.userId;
     if (!userId) throw new BadRequestException('Unable to resolve userId from token');
-    return this.formTaskService.fillTask(taskId, dataJson ?? {}, userId);
+    return this.formTaskService.fillTask(taskId, body.dataJson ?? {}, userId, body.existingRecordId);
   }
 
   @Get(':id')

--- a/server/src/modules/change-event/change-event.controller.ts
+++ b/server/src/modules/change-event/change-event.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Patch, Delete, Body, Param, Query, UseGuards, Request } from '@nestjs/common';
 import { ChangeEventService } from './change-event.service';
+import { ChangeEventFormTaskService } from './change-event-form-task.service';
 import { CreateChangeEventDto } from './dto/create-change-event.dto';
 import { CreateVerificationDto } from './dto/create-verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -7,7 +8,10 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 @Controller('change-events')
 @UseGuards(JwtAuthGuard)
 export class ChangeEventController {
-  constructor(private service: ChangeEventService) {}
+  constructor(
+    private service: ChangeEventService,
+    private formTaskService: ChangeEventFormTaskService,
+  ) {}
 
   @Post()
   create(
@@ -20,6 +24,20 @@ export class ChangeEventController {
   @Get()
   findAll() {
     return this.service.findAll();
+  }
+
+  @Get(':id/form-tasks')
+  findFormTasks(@Param('id') id: string) {
+    return this.formTaskService.listForChange(id);
+  }
+
+  @Post('form-tasks/:taskId/fill')
+  fillFormTask(
+    @Param('taskId') taskId: string,
+    @Body('dataJson') dataJson: object,
+    @Request() req: { user: { id?: string; userId?: string } },
+  ) {
+    return this.formTaskService.fillTask(taskId, dataJson ?? {}, req.user.id ?? req.user.userId!);
   }
 
   @Get(':id')

--- a/server/src/modules/change-event/change-event.module.ts
+++ b/server/src/modules/change-event/change-event.module.ts
@@ -1,14 +1,16 @@
 import { Module, OnModuleInit } from '@nestjs/common';
 import { ChangeEventController } from './change-event.controller';
 import { ChangeEventService } from './change-event.service';
+import { ChangeEventFormTaskService } from './change-event-form-task.service';
 import { UnifiedApprovalModule } from '../unified-approval/unified-approval.module';
 import { ApprovalCallbackRegistry } from '../unified-approval/approval-callback.registry';
+import { RecordModule } from '../record/record.module';
 
 @Module({
-  imports: [UnifiedApprovalModule],
+  imports: [UnifiedApprovalModule, RecordModule],
   controllers: [ChangeEventController],
-  providers: [ChangeEventService],
-  exports: [ChangeEventService],
+  providers: [ChangeEventService, ChangeEventFormTaskService],
+  exports: [ChangeEventService, ChangeEventFormTaskService],
 })
 export class ChangeEventModule implements OnModuleInit {
   constructor(private readonly callbacks: ApprovalCallbackRegistry) {}

--- a/server/src/modules/change-event/change-event.module.ts
+++ b/server/src/modules/change-event/change-event.module.ts
@@ -2,6 +2,7 @@ import { Module, OnModuleInit } from '@nestjs/common';
 import { ChangeEventController } from './change-event.controller';
 import { ChangeEventService } from './change-event.service';
 import { ChangeEventFormTaskService } from './change-event-form-task.service';
+import { ChangeEventRelationService } from './change-event-relation.service';
 import { UnifiedApprovalModule } from '../unified-approval/unified-approval.module';
 import { ApprovalCallbackRegistry } from '../unified-approval/approval-callback.registry';
 import { RecordModule } from '../record/record.module';
@@ -9,8 +10,8 @@ import { RecordModule } from '../record/record.module';
 @Module({
   imports: [UnifiedApprovalModule, RecordModule],
   controllers: [ChangeEventController],
-  providers: [ChangeEventService, ChangeEventFormTaskService],
-  exports: [ChangeEventService, ChangeEventFormTaskService],
+  providers: [ChangeEventService, ChangeEventFormTaskService, ChangeEventRelationService],
+  exports: [ChangeEventService, ChangeEventFormTaskService, ChangeEventRelationService],
 })
 export class ChangeEventModule implements OnModuleInit {
   constructor(private readonly callbacks: ApprovalCallbackRegistry) {}

--- a/server/src/modules/change-event/change-event.service.spec.ts
+++ b/server/src/modules/change-event/change-event.service.spec.ts
@@ -1,0 +1,62 @@
+import { ChangeEventService } from './change-event.service';
+
+describe('ChangeEventService', () => {
+  const prisma = {
+    changeEvent: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    $transaction: jest.fn(),
+  };
+  const eventEmitter = { emit: jest.fn() };
+  const approvalEngine = { startApproval: jest.fn() };
+  const formTasks = { generateDefaultTasks: jest.fn() };
+  const relations = { createRelations: jest.fn() };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.$transaction.mockImplementation(async (callback) => callback(prisma));
+  });
+
+  it('creates change event with relations and default form tasks', async () => {
+    prisma.changeEvent.count.mockResolvedValue(0);
+    prisma.changeEvent.create.mockResolvedValue({
+      id: 'change1',
+      change_no: 'CE-2026-0001',
+      change_type: 'recipe',
+    });
+    prisma.changeEvent.findUnique.mockResolvedValue({
+      id: 'change1',
+      change_no: 'CE-2026-0001',
+      change_type: 'recipe',
+      verifications: [],
+      relations: [],
+      formTasks: [],
+    });
+    formTasks.generateDefaultTasks.mockResolvedValue([{ id: 'task1' }]);
+    relations.createRelations.mockResolvedValue({ count: 1 });
+
+    const service = new ChangeEventService(
+      prisma as any,
+      eventEmitter as any,
+      formTasks as any,
+      relations as any,
+      approvalEngine as any,
+    );
+
+    const result = await service.create({
+      change_type: 'recipe',
+      title: '配方调整',
+      description: '调整配方参数',
+      relations: [{ targetType: 'recipe', targetId: 'recipe1', targetLabel: '蛋液配方' }],
+    } as any, 'user1');
+
+    expect(result.id).toBe('change1');
+    expect(relations.createRelations).toHaveBeenCalledWith('change1', [
+      { targetType: 'recipe', targetId: 'recipe1', targetLabel: '蛋液配方' },
+    ]);
+    expect(formTasks.generateDefaultTasks).toHaveBeenCalledWith('change1', 'recipe');
+  });
+});

--- a/server/src/modules/change-event/change-event.service.spec.ts
+++ b/server/src/modules/change-event/change-event.service.spec.ts
@@ -13,7 +13,7 @@ describe('ChangeEventService', () => {
   const eventEmitter = { emit: jest.fn() };
   const approvalEngine = { startApproval: jest.fn() };
   const formTasks = { generateDefaultTasks: jest.fn() };
-  const relations = { createRelations: jest.fn() };
+  const relations = { validateRelations: jest.fn(), createRelations: jest.fn() };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -21,6 +21,7 @@ describe('ChangeEventService', () => {
   });
 
   it('creates change event with relations and default form tasks', async () => {
+    relations.validateRelations.mockResolvedValue(undefined);
     prisma.changeEvent.count.mockResolvedValue(0);
     prisma.changeEvent.create.mockResolvedValue({
       id: 'change1',
@@ -54,9 +55,12 @@ describe('ChangeEventService', () => {
     } as any, 'user1');
 
     expect(result.id).toBe('change1');
-    expect(relations.createRelations).toHaveBeenCalledWith('change1', [
+    expect(relations.validateRelations).toHaveBeenCalledWith([
       { targetType: 'recipe', targetId: 'recipe1', targetLabel: '蛋液配方' },
     ]);
-    expect(formTasks.generateDefaultTasks).toHaveBeenCalledWith('change1', 'recipe');
+    expect(relations.createRelations).toHaveBeenCalledWith('change1', [
+      { targetType: 'recipe', targetId: 'recipe1', targetLabel: '蛋液配方' },
+    ], prisma);
+    expect(formTasks.generateDefaultTasks).toHaveBeenCalledWith('change1', 'recipe', prisma);
   });
 });

--- a/server/src/modules/change-event/change-event.service.ts
+++ b/server/src/modules/change-event/change-event.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Optional } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
@@ -9,6 +9,8 @@ import { CreateVerificationDto } from './dto/create-verification.dto';
 
 @Injectable()
 export class ChangeEventService {
+  private readonly logger = new Logger(ChangeEventService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly eventEmitter: EventEmitter2,
@@ -19,10 +21,12 @@ export class ChangeEventService {
 
   async create(dto: CreateChangeEventDto, userId: string) {
     const year = new Date().getFullYear();
+
+    // Atomic: count + create ChangeEvent to ensure unique change_no
     const changeEvent = await this.prisma.$transaction(async (tx: any) => {
       const count = await tx.changeEvent.count();
       const change_no = `CE-${year}-${String(count + 1).padStart(4, '0')}`;
-      const created = await tx.changeEvent.create({
+      return tx.changeEvent.create({
         data: {
           company_id: '1',
           change_no,
@@ -34,11 +38,11 @@ export class ChangeEventService {
           status: dto.status ?? 'pending',
         },
       });
-
-      await this.relationService.createRelations(created.id, dto.relations ?? []);
-      await this.formTaskService.generateDefaultTasks(created.id, dto.change_type);
-      return created;
     });
+
+    // These run after the ChangeEvent is committed — they reference changeEvent.id
+    await this.relationService.createRelations(changeEvent.id, dto.relations ?? []);
+    await this.formTaskService.generateDefaultTasks(changeEvent.id, dto.change_type);
 
     try {
       await this.approvalEngine?.startApproval({
@@ -49,8 +53,8 @@ export class ChangeEventService {
         title: `变更事件审批：${changeEvent.change_no}`,
         createdById: userId,
       });
-    } catch {
-      // no approval definition = skip
+    } catch (error) {
+      this.logger.warn('Approval engine skipped (no definition or error)', error instanceof Error ? error.message : String(error));
     }
 
     return this.findOne(changeEvent.id);

--- a/server/src/modules/change-event/change-event.service.ts
+++ b/server/src/modules/change-event/change-event.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
@@ -20,13 +21,16 @@ export class ChangeEventService {
   ) {}
 
   async create(dto: CreateChangeEventDto, userId: string) {
+    // Validate relations BEFORE the transaction (read-only checks)
+    await this.relationService.validateRelations(dto.relations ?? []);
+
     const year = new Date().getFullYear();
 
-    // Atomic: count + create ChangeEvent to ensure unique change_no
-    const changeEvent = await this.prisma.$transaction(async (tx: any) => {
+    // Atomic: ChangeEvent + relations + form tasks all in one transaction
+    const changeEvent = await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const count = await tx.changeEvent.count();
       const change_no = `CE-${year}-${String(count + 1).padStart(4, '0')}`;
-      return tx.changeEvent.create({
+      const created = await tx.changeEvent.create({
         data: {
           company_id: '1',
           change_no,
@@ -38,11 +42,12 @@ export class ChangeEventService {
           status: dto.status ?? 'pending',
         },
       });
-    });
 
-    // These run after the ChangeEvent is committed — they reference changeEvent.id
-    await this.relationService.createRelations(changeEvent.id, dto.relations ?? []);
-    await this.formTaskService.generateDefaultTasks(changeEvent.id, dto.change_type);
+      await this.relationService.createRelations(created.id, dto.relations ?? [], tx);
+      await this.formTaskService.generateDefaultTasks(created.id, dto.change_type, tx);
+
+      return created;
+    });
 
     try {
       await this.approvalEngine?.startApproval({

--- a/server/src/modules/change-event/change-event.service.ts
+++ b/server/src/modules/change-event/change-event.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Optional } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
+import { ChangeEventFormTaskService } from './change-event-form-task.service';
+import { ChangeEventRelationService } from './change-event-relation.service';
 import { CreateChangeEventDto } from './dto/create-change-event.dto';
 import { CreateVerificationDto } from './dto/create-verification.dto';
 
@@ -10,24 +12,32 @@ export class ChangeEventService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly formTaskService: ChangeEventFormTaskService,
+    private readonly relationService: ChangeEventRelationService,
     @Optional() private readonly approvalEngine?: ApprovalEngineService,
   ) {}
 
   async create(dto: CreateChangeEventDto, userId: string) {
-    const count = await this.prisma.changeEvent.count();
     const year = new Date().getFullYear();
-    const change_no = `CE-${year}-${String(count + 1).padStart(4, '0')}`;
-    const changeEvent = await this.prisma.changeEvent.create({
-      data: {
-        company_id: '1',
-        change_no,
-        change_type: dto.change_type,
-        description: dto.description,
-        reason: dto.title,
-        applied_by: userId,
-        applied_at: new Date(),
-        status: dto.status ?? 'pending',
-      },
+    const changeEvent = await this.prisma.$transaction(async (tx: any) => {
+      const count = await tx.changeEvent.count();
+      const change_no = `CE-${year}-${String(count + 1).padStart(4, '0')}`;
+      const created = await tx.changeEvent.create({
+        data: {
+          company_id: '1',
+          change_no,
+          change_type: dto.change_type,
+          description: dto.description,
+          reason: dto.title,
+          applied_by: userId,
+          applied_at: new Date(),
+          status: dto.status ?? 'pending',
+        },
+      });
+
+      await this.relationService.createRelations(created.id, dto.relations ?? []);
+      await this.formTaskService.generateDefaultTasks(created.id, dto.change_type);
+      return created;
     });
 
     try {
@@ -36,17 +46,29 @@ export class ChangeEventService {
         resourceId: changeEvent.id,
         resourceStep: 'submit',
         triggerKey: 'submit',
-        title: `变更事件审批：${change_no}`,
+        title: `变更事件审批：${changeEvent.change_no}`,
         createdById: userId,
       });
-    } catch { /* no definition = skip */ }
+    } catch {
+      // no approval definition = skip
+    }
 
-    return changeEvent;
+    return this.findOne(changeEvent.id);
   }
 
   async findAll() {
     return this.prisma.changeEvent.findMany({
-      include: { verifications: true },
+      include: {
+        verifications: true,
+        relations: true,
+        formTasks: {
+          include: {
+            template: { select: { id: true, code: true, name: true, status: true } },
+            record: { select: { id: true, number: true, status: true, createdAt: true } },
+          },
+          orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
       orderBy: { created_at: 'desc' },
     });
   }
@@ -54,7 +76,17 @@ export class ChangeEventService {
   async findOne(id: string) {
     return this.prisma.changeEvent.findUnique({
       where: { id },
-      include: { verifications: true },
+      include: {
+        verifications: true,
+        relations: true,
+        formTasks: {
+          include: {
+            template: { select: { id: true, code: true, name: true, status: true } },
+            record: { select: { id: true, number: true, status: true, createdAt: true } },
+          },
+          orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+        },
+      },
     });
   }
 

--- a/server/src/modules/change-event/dto/create-change-event.dto.ts
+++ b/server/src/modules/change-event/dto/create-change-event.dto.ts
@@ -1,9 +1,55 @@
-import { IsString, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsArray, IsIn, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+export class ChangeEventRelationDto {
+  @IsString()
+  targetType: string;
+
+  @IsOptional()
+  @IsString()
+  targetId?: string;
+
+  @IsOptional()
+  @IsString()
+  targetRoute?: string;
+
+  @IsString()
+  targetLabel: string;
+
+  @IsOptional()
+  @IsString()
+  relationType?: string;
+
+  @IsOptional()
+  @IsString()
+  impactLevel?: string;
+
+  @IsOptional()
+  @IsString()
+  requiredAction?: string;
+}
 
 export class CreateChangeEventDto {
-  @IsString() change_type: string; // 'recipe'|'process'|'equipment'|'supplier'|'other'
-  @IsString() title: string;
-  @IsString() description: string;
-  @IsOptional() @IsString() initiator_id?: string;
-  @IsOptional() @IsString() status?: string;
+  @IsIn(['document', 'record_form', 'product', 'recipe', 'process', 'equipment', 'supplier', 'haccp', 'other'])
+  change_type: string;
+
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  initiator_id?: string;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ChangeEventRelationDto)
+  relations?: ChangeEventRelationDto[];
 }

--- a/server/src/modules/document/dto/document-operations.dto.ts
+++ b/server/src/modules/document/dto/document-operations.dto.ts
@@ -39,6 +39,10 @@ export class ImpactReviewCreateDto {
 
   @IsString()
   title!: string;
+
+  @IsOptional()
+  @IsString()
+  changeEventId?: string;
 }
 
 export class ImpactItemUpdateDto {

--- a/server/src/modules/document/services/document-impact.service.spec.ts
+++ b/server/src/modules/document/services/document-impact.service.spec.ts
@@ -35,4 +35,29 @@ describe('DocumentImpactService', () => {
       }),
     }));
   });
+
+  it('links impact review to change event when provided', async () => {
+    const prisma = {
+      documentReference: { findMany: jest.fn().mockResolvedValue([]) },
+      recordFormLandingEntry: { findMany: jest.fn().mockResolvedValue([]) },
+      documentImpactReview: { create: jest.fn().mockResolvedValue({ id: 'review1', changeEventId: 'change1', items: [] }) },
+      documentImpactItem: { findUnique: jest.fn(), update: jest.fn() },
+    };
+    const service = new DocumentImpactService(prisma as any);
+
+    await service.createReview({
+      sourceType: 'change_event',
+      sourceId: 'change1',
+      changeEventId: 'change1',
+      title: '变更影响评审',
+    } as any);
+
+    expect(prisma.documentImpactReview.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        sourceType: 'change_event',
+        sourceId: 'change1',
+        changeEventId: 'change1',
+      }),
+    }));
+  });
 });

--- a/server/src/modules/document/services/document-impact.service.ts
+++ b/server/src/modules/document/services/document-impact.service.ts
@@ -19,6 +19,7 @@ export class DocumentImpactService {
         sourceType: dto.sourceType,
         sourceId: dto.sourceId,
         title: dto.title,
+        changeEventId: dto.changeEventId ?? (dto.sourceType === 'change_event' ? dto.sourceId : null),
         items: {
           create: [
             ...references.map((ref: any) => ({

--- a/server/src/modules/equipment/stats.service.ts
+++ b/server/src/modules/equipment/stats.service.ts
@@ -55,7 +55,7 @@ export class StatsService {
       });
 
       const results = await Promise.all(
-        equipment.map(async (eq) => {
+        equipment.map(async (eq: { id: string; code: string; name: string }) => {
           const faultCount = await this.prisma.equipmentFault.count({
             where: { equipmentId: eq.id, deletedAt: null },
           });

--- a/server/src/modules/record/dto/create-record.dto.ts
+++ b/server/src/modules/record/dto/create-record.dto.ts
@@ -16,4 +16,24 @@ export class CreateRecordDto {
   @IsOptional()
   @IsBoolean()
   offlineFilled?: boolean;
+
+  @ApiPropertyOptional({ description: '填写用途', enum: ['initial', 'change', 'periodic'] })
+  @IsOptional()
+  @IsString()
+  usageType?: string;
+
+  @ApiPropertyOptional({ description: '来源对象类型', example: 'change_event' })
+  @IsOptional()
+  @IsString()
+  sourceType?: string;
+
+  @ApiPropertyOptional({ description: '来源对象ID', example: 'clxxxxxxxxxxxxx' })
+  @IsOptional()
+  @IsString()
+  sourceId?: string;
+
+  @ApiPropertyOptional({ description: '关联变更事件ID', example: 'clxxxxxxxxxxxxx' })
+  @IsOptional()
+  @IsString()
+  changeEventId?: string;
 }

--- a/server/src/modules/record/dto/create-record.dto.ts
+++ b/server/src/modules/record/dto/create-record.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsNotEmpty, IsObject, IsOptional, IsBoolean, IsDateString } from 'class-validator';
+import { IsString, IsNotEmpty, IsObject, IsOptional, IsBoolean, IsDateString, IsIn } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateRecordDto {
@@ -19,6 +19,7 @@ export class CreateRecordDto {
 
   @ApiPropertyOptional({ description: '填写用途', enum: ['initial', 'change', 'periodic'] })
   @IsOptional()
+  @IsIn(['initial', 'change', 'periodic'])
   @IsString()
   usageType?: string;
 

--- a/server/src/modules/record/dto/query-record.dto.ts
+++ b/server/src/modules/record/dto/query-record.dto.ts
@@ -32,4 +32,12 @@ export class QueryRecordDto {
   @IsOptional()
   @IsString()
   keyword?: string;
+
+  @IsOptional()
+  @IsString()
+  usageType?: string;
+
+  @IsOptional()
+  @IsString()
+  changeEventId?: string;
 }

--- a/server/src/modules/record/record.service.spec.ts
+++ b/server/src/modules/record/record.service.spec.ts
@@ -168,6 +168,42 @@ describe('RecordService', () => {
         }),
       );
     });
+
+    it('creates a change record with usage and source fields', async () => {
+      prisma.recordTemplate.findUnique.mockResolvedValue({
+        id: 'tpl1',
+        code: 'GRSS-PZ-JL-07',
+        fieldsJson: { fields: [] },
+        retentionYears: 5,
+        batchLinkEnabled: false,
+      });
+      prisma.record.create.mockResolvedValue({
+        id: 'record1',
+        templateId: 'tpl1',
+        usageType: 'change',
+        sourceType: 'change_event',
+        sourceId: 'change1',
+        changeEventId: 'change1',
+      });
+
+      await service.create({
+        templateId: 'tpl1',
+        dataJson: {},
+        usageType: 'change',
+        sourceType: 'change_event',
+        sourceId: 'change1',
+        changeEventId: 'change1',
+      } as any, 'user1');
+
+      expect(prisma.record.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          usageType: 'change',
+          sourceType: 'change_event',
+          sourceId: 'change1',
+          changeEventId: 'change1',
+        }),
+      });
+    });
   });
 
   describe('findAll', () => {

--- a/server/src/modules/record/record.service.spec.ts
+++ b/server/src/modules/record/record.service.spec.ts
@@ -170,14 +170,15 @@ describe('RecordService', () => {
     });
 
     it('creates a change record with usage and source fields', async () => {
-      prisma.recordTemplate.findUnique.mockResolvedValue({
+      mockPrismaService.record.findFirst.mockResolvedValue(null);
+      mockPrismaService.recordTemplate.findUnique.mockResolvedValue({
         id: 'tpl1',
         code: 'GRSS-PZ-JL-07',
         fieldsJson: { fields: [] },
         retentionYears: 5,
         batchLinkEnabled: false,
       });
-      prisma.record.create.mockResolvedValue({
+      mockPrismaService.record.create.mockResolvedValue({
         id: 'record1',
         templateId: 'tpl1',
         usageType: 'change',
@@ -195,7 +196,7 @@ describe('RecordService', () => {
         changeEventId: 'change1',
       } as any, 'user1');
 
-      expect(prisma.record.create).toHaveBeenCalledWith({
+      expect(mockPrismaService.record.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           usageType: 'change',
           sourceType: 'change_event',

--- a/server/src/modules/record/record.service.ts
+++ b/server/src/modules/record/record.service.ts
@@ -65,6 +65,10 @@ export class RecordService {
         createdBy: userId,
         retentionUntil,
         offlineFilled: createDto.offlineFilled ?? false,
+        usageType: createDto.usageType ?? null,
+        sourceType: createDto.sourceType ?? null,
+        sourceId: createDto.sourceId ?? null,
+        changeEventId: createDto.changeEventId ?? null,
         ...batchAssociation,
       },
     });
@@ -118,6 +122,14 @@ export class RecordService {
 
     if (keyword) {
       where.number = { contains: keyword };
+    }
+
+    if (query.usageType) {
+      where.usageType = query.usageType;
+    }
+
+    if (query.changeEventId) {
+      where.changeEventId = query.changeEventId;
     }
 
     const [data, total] = await Promise.all([

--- a/server/src/modules/unified-approval/approval-assignment.resolver.ts
+++ b/server/src/modules/unified-approval/approval-assignment.resolver.ts
@@ -34,7 +34,7 @@ export class ApprovalAssignmentResolver {
       });
       return {
         assignment,
-        assigneeUserIds: users.map((u) => u.id),
+        assigneeUserIds: users.map((u: { id: string }) => u.id),
         assigneeRoleCode: assignment.roleCode,
         claimMode: 'CLAIMABLE',
       };
@@ -55,7 +55,7 @@ export class ApprovalAssignmentResolver {
       });
       return {
         assignment,
-        assigneeUserIds: users.map((u) => u.id),
+        assigneeUserIds: users.map((u: { id: string }) => u.id),
         assigneeDepartmentId: department.id,
         claimMode: 'CLAIMABLE',
       };
@@ -76,7 +76,7 @@ export class ApprovalAssignmentResolver {
       });
       return {
         assignment,
-        assigneeUserIds: users.map((u) => u.id),
+        assigneeUserIds: users.map((u: { id: string }) => u.id),
         assigneePermissionCode: assignment.permissionCode,
         claimMode: 'CLAIMABLE',
       };

--- a/server/src/modules/unified-approval/approval-engine.service.ts
+++ b/server/src/modules/unified-approval/approval-engine.service.ts
@@ -96,7 +96,7 @@ export class ApprovalEngineService {
   }
 
   private async completeTask(taskId: string, actorId: string, status: 'APPROVED' | 'REJECTED', comment: string) {
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: any) => {
       const task = await tx.approvalTask.findUnique({
         where: { id: taskId },
         include: { instance: { include: { definition: true } } },

--- a/server/src/modules/workflow/workflow-instance.service.ts
+++ b/server/src/modules/workflow/workflow-instance.service.ts
@@ -19,7 +19,7 @@ export class WorkflowInstanceService {
   async create(createDto: CreateWorkflowInstanceDto, initiatorId: string) {
     const template = await this.validateTemplate(createDto.templateId);
 
-    return await this.prisma.$transaction(async (prisma) => {
+    return await this.prisma.$transaction(async (prisma: any) => {
       const instance = await this.createInstance(prisma, createDto, template.id, initiatorId);
       await this.createFirstTask(prisma, instance, template, initiatorId);
       return instance;
@@ -149,7 +149,7 @@ export class WorkflowInstanceService {
 
     let avgProcessingTimeHours = 0;
     if (completedInstances.length > 0) {
-      const totalMs = completedInstances.reduce((sum, inst) => {
+      const totalMs = completedInstances.reduce((sum: number, inst: { createdAt: Date; updatedAt: Date }) => {
         return sum + (inst.updatedAt.getTime() - inst.createdAt.getTime());
       }, 0);
       avgProcessingTimeHours = Math.round(totalMs / completedInstances.length / 3600000 * 10) / 10;

--- a/server/src/prisma/migrations/20260427000002_change_mainline_form_tasks/migration.sql
+++ b/server/src/prisma/migrations/20260427000002_change_mainline_form_tasks/migration.sql
@@ -1,0 +1,122 @@
+-- Phase 2: unified change mainline, form tasks, and record usage linkage.
+
+ALTER TABLE "records"
+  ADD COLUMN IF NOT EXISTS "usageType" TEXT,
+  ADD COLUMN IF NOT EXISTS "sourceType" TEXT,
+  ADD COLUMN IF NOT EXISTS "sourceId" TEXT,
+  ADD COLUMN IF NOT EXISTS "changeEventId" TEXT;
+
+ALTER TABLE "document_impact_reviews"
+  ADD COLUMN IF NOT EXISTS "changeEventId" TEXT;
+
+CREATE TABLE IF NOT EXISTS "change_event_relations" (
+  "id" TEXT NOT NULL,
+  "changeEventId" TEXT NOT NULL,
+  "targetType" TEXT NOT NULL,
+  "targetId" TEXT,
+  "targetRoute" TEXT,
+  "targetLabel" TEXT NOT NULL,
+  "relationType" TEXT,
+  "impactLevel" TEXT NOT NULL DEFAULT 'medium',
+  "requiredAction" TEXT,
+  "status" TEXT NOT NULL DEFAULT 'open',
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "change_event_relations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE IF NOT EXISTS "change_event_form_tasks" (
+  "id" TEXT NOT NULL,
+  "changeEventId" TEXT NOT NULL,
+  "templateId" TEXT NOT NULL,
+  "recordId" TEXT,
+  "sourceFormCode" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "required" BOOLEAN NOT NULL DEFAULT true,
+  "sortOrder" INTEGER NOT NULL DEFAULT 0,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "change_event_form_tasks_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "records_usageType_idx" ON "records"("usageType");
+CREATE INDEX IF NOT EXISTS "records_sourceType_sourceId_idx" ON "records"("sourceType", "sourceId");
+CREATE INDEX IF NOT EXISTS "records_changeEventId_idx" ON "records"("changeEventId");
+CREATE INDEX IF NOT EXISTS "document_impact_reviews_changeEventId_idx" ON "document_impact_reviews"("changeEventId");
+CREATE INDEX IF NOT EXISTS "change_event_relations_changeEventId_idx" ON "change_event_relations"("changeEventId");
+CREATE INDEX IF NOT EXISTS "change_event_relations_targetType_targetId_idx" ON "change_event_relations"("targetType", "targetId");
+CREATE INDEX IF NOT EXISTS "change_event_relations_status_idx" ON "change_event_relations"("status");
+CREATE INDEX IF NOT EXISTS "change_event_form_tasks_changeEventId_idx" ON "change_event_form_tasks"("changeEventId");
+CREATE INDEX IF NOT EXISTS "change_event_form_tasks_templateId_idx" ON "change_event_form_tasks"("templateId");
+CREATE INDEX IF NOT EXISTS "change_event_form_tasks_recordId_idx" ON "change_event_form_tasks"("recordId");
+CREATE INDEX IF NOT EXISTS "change_event_form_tasks_status_idx" ON "change_event_form_tasks"("status");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'change_event_form_tasks_changeEventId_templateId_key') THEN
+    ALTER TABLE "change_event_form_tasks"
+      ADD CONSTRAINT "change_event_form_tasks_changeEventId_templateId_key"
+      UNIQUE ("changeEventId", "templateId");
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'records_changeEventId_fkey') THEN
+    ALTER TABLE "records"
+      ADD CONSTRAINT "records_changeEventId_fkey"
+      FOREIGN KEY ("changeEventId") REFERENCES "ChangeEvent"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'document_impact_reviews_changeEventId_fkey') THEN
+    ALTER TABLE "document_impact_reviews"
+      ADD CONSTRAINT "document_impact_reviews_changeEventId_fkey"
+      FOREIGN KEY ("changeEventId") REFERENCES "ChangeEvent"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'change_event_relations_changeEventId_fkey') THEN
+    ALTER TABLE "change_event_relations"
+      ADD CONSTRAINT "change_event_relations_changeEventId_fkey"
+      FOREIGN KEY ("changeEventId") REFERENCES "ChangeEvent"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'change_event_form_tasks_changeEventId_fkey') THEN
+    ALTER TABLE "change_event_form_tasks"
+      ADD CONSTRAINT "change_event_form_tasks_changeEventId_fkey"
+      FOREIGN KEY ("changeEventId") REFERENCES "ChangeEvent"("id")
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'change_event_form_tasks_templateId_fkey') THEN
+    ALTER TABLE "change_event_form_tasks"
+      ADD CONSTRAINT "change_event_form_tasks_templateId_fkey"
+      FOREIGN KEY ("templateId") REFERENCES "record_templates"("id")
+      ON DELETE RESTRICT ON UPDATE CASCADE;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'change_event_form_tasks_recordId_fkey') THEN
+    ALTER TABLE "change_event_form_tasks"
+      ADD CONSTRAINT "change_event_form_tasks_recordId_fkey"
+      FOREIGN KEY ("recordId") REFERENCES "records"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END$$;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -3031,7 +3031,7 @@ model ChangeEvent {
   id            String                     @id @default(cuid())
   company_id    String
   change_no     String
-  change_type   String                     // 'recipe'|'process'|'equipment'|'supplier'|'other'
+  change_type   String                     // 'recipe'|'process'|'equipment'|'supplier'|'document'|'record_form'|'other'
   description   String
   reason        String
   applied_by    String?
@@ -3442,10 +3442,9 @@ model DocumentImpactReview {
   reviewedAt    DateTime?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
-  items         DocumentImpactItem[]
-
   changeEventId String?
   changeEvent   ChangeEvent? @relation(fields: [changeEventId], references: [id], onDelete: SetNull)
+  items         DocumentImpactItem[]
 
   @@index([sourceType, sourceId])
   @@index([status])

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -750,6 +750,7 @@ model RecordTemplate {
   taskAssignments      RecordTaskAssignment[]
   tasks                Task[]
   landingEntries       RecordFormLandingEntry[]
+  changeFormTasks      ChangeEventFormTask[]
 
   @@index([code])
   @@index([status])
@@ -807,6 +808,13 @@ model Record {
   changeLogs      RecordChangeLog[]
   deviationReports DeviationReport[]
 
+  usageType      String?
+  sourceType     String?
+  sourceId       String?
+  changeEventId  String?
+  changeEvent    ChangeEvent? @relation("ChangeEventRecords", fields: [changeEventId], references: [id], onDelete: SetNull)
+  changeFormTasks ChangeEventFormTask[]
+
   @@index([templateId])
   @@index([number])
   @@index([status])
@@ -819,6 +827,9 @@ model Record {
   @@index([shift_instance_id])
   @@index([production_run_id])
   @@index([approvalInstanceId])
+  @@index([usageType])
+  @@index([sourceType, sourceId])
+  @@index([changeEventId])
   @@map("records")
 }
 
@@ -3031,6 +3042,11 @@ model ChangeEvent {
   created_at    DateTime                   @default(now())
   updated_at    DateTime                   @updatedAt
 
+  records       Record[]                   @relation("ChangeEventRecords")
+  relations     ChangeEventRelation[]
+  formTasks     ChangeEventFormTask[]
+  impactReviews DocumentImpactReview[]
+
   @@unique([company_id, change_no])
 }
 
@@ -3046,6 +3062,51 @@ model ChangeVerificationRecord {
   approved_by         String?
   verified_at         DateTime    @db.Date
   created_at          DateTime    @default(now())
+}
+
+model ChangeEventRelation {
+  id             String      @id @default(cuid())
+  changeEventId  String
+  changeEvent    ChangeEvent @relation(fields: [changeEventId], references: [id], onDelete: Cascade)
+  targetType     String
+  targetId       String?
+  targetRoute    String?
+  targetLabel    String
+  relationType   String?
+  impactLevel    String      @default("medium")
+  requiredAction String?
+  status         String      @default("open")
+  createdAt      DateTime    @default(now())
+  updatedAt      DateTime    @updatedAt
+
+  @@index([changeEventId])
+  @@index([targetType, targetId])
+  @@index([status])
+  @@map("change_event_relations")
+}
+
+model ChangeEventFormTask {
+  id            String         @id @default(cuid())
+  changeEventId String
+  changeEvent   ChangeEvent    @relation(fields: [changeEventId], references: [id], onDelete: Cascade)
+  templateId    String
+  template      RecordTemplate @relation(fields: [templateId], references: [id], onDelete: Restrict)
+  recordId      String?
+  record        Record?        @relation(fields: [recordId], references: [id], onDelete: SetNull)
+  sourceFormCode String
+  title         String
+  status        String         @default("pending")
+  required      Boolean        @default(true)
+  sortOrder     Int            @default(0)
+  createdAt     DateTime       @default(now())
+  updatedAt     DateTime       @updatedAt
+
+  @@unique([changeEventId, templateId])
+  @@index([changeEventId])
+  @@index([templateId])
+  @@index([recordId])
+  @@index([status])
+  @@map("change_event_form_tasks")
 }
 
 model WasteDisposalRecord {
@@ -3371,20 +3432,24 @@ model DocumentTrainingNeed {
 }
 
 model DocumentImpactReview {
-  id         String   @id @default(cuid())
-  sourceType String
-  sourceId   String
-  title      String
-  status     String   @default("draft")
-  summary    String?
-  reviewedBy String?
-  reviewedAt DateTime?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  items      DocumentImpactItem[]
+  id            String   @id @default(cuid())
+  sourceType    String
+  sourceId      String
+  title         String
+  status        String   @default("draft")
+  summary       String?
+  reviewedBy    String?
+  reviewedAt    DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  items         DocumentImpactItem[]
+
+  changeEventId String?
+  changeEvent   ChangeEvent? @relation(fields: [changeEventId], references: [id], onDelete: SetNull)
 
   @@index([sourceType, sourceId])
   @@index([status])
+  @@index([changeEventId])
   @@map("document_impact_reviews")
 }
 


### PR DESCRIPTION
## Summary

- **Schema**: Added `ChangeEventRelation` and `ChangeEventFormTask` models; added `usageType/sourceType/sourceId/changeEventId` fields to `Record`; linked `DocumentImpactReview` to `ChangeEvent`. Additive migration with idempotent IF NOT EXISTS guards.
- **Server**: Creating a `ChangeEvent` now automatically generates default form tasks from `RecordTemplate` rows (based on `change_type`), validates and persists affected-object relations, and links impact reviews back to the change event. Explicitly excludes `GRSS-KF-JL-03` (产品更改申请表) and `GRSS-KF-JL-01` (产品开发评审记录) from auto-generated tasks.
- **Client**: Added `ChangeEventRelation`/`ChangeEventFormTask` types and API methods; the change event detail dialog now shows the generated form tasks with status tags and links to filled records.

## Test Plan

- [x] 48 server unit tests pass (`change-event.service`, `change-event-relation.service`, `change-event-form-task.service`, `record.service`, `document-impact.service`)
- [x] 1 client Vitest test passes (`ChangeEventList.spec.ts`)
- [x] `prisma validate` confirms schema is valid
- [x] GRSS-KF-JL-03 and GRSS-KF-JL-01 are confirmed excluded from all generic change types
- [x] No `.env` files committed; no build outputs tracked
- [ ] Run `prisma migrate deploy` against staging DB before merging to production