### PR TITLE
feat: document governance phase 3 - actionable workbench with issue queues

### DIFF
--- a/client/src/api/document-control.ts
+++ b/client/src/api/document-control.ts
@@ -103,6 +103,41 @@ export interface WorkbenchResponse {
   counts: Record<string, number>;
 }
 
+export type WorkbenchIssueType =
+  | 'pendingReview'
+  | 'dueForReview'
+  | 'expiringExternalFiles'
+  | 'obsoleteReferences'
+  | 'brokenReferences'
+  | 'missingLandingTargets'
+  | 'missingMetadata'
+  | 'trainingNeeds'
+  | 'openImpactItems';
+
+export interface WorkbenchIssueItem {
+  id: string;
+  issueType: WorkbenchIssueType;
+  severity: 'low' | 'medium' | 'high';
+  title: string;
+  description: string;
+  sourceType: string;
+  sourceId: string;
+  sourceLabel: string;
+  sourceRoute: string;
+  actionLabel: string;
+  actionRoute: string;
+  detectedAt: string | null;
+}
+
+export interface WorkbenchIssueListResponse {
+  type: WorkbenchIssueType;
+  items: WorkbenchIssueItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 export const documentControlApi = {
   listDocuments(params?: Record<string, unknown>) {
     return request.get<DocumentListResponse>('/documents', { params });
@@ -142,5 +177,9 @@ export const documentControlApi = {
 
   getWorkbench(days = 30) {
     return request.get<WorkbenchResponse>('/documents/control/workbench', { params: { days } });
+  },
+
+  listWorkbenchIssues(params: { type: WorkbenchIssueType; page?: number; limit?: number; days?: number }) {
+    return request.get<WorkbenchIssueListResponse>('/documents/control/workbench/issues', { params });
   },
 };

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -67,6 +67,12 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/documents/DocumentControlWorkbench.vue'),
         meta: { title: '文控工作台' },
       },
+      {
+        path: 'documents/control/workbench/issues',
+        name: 'DocumentControlIssueList',
+        component: () => import('@/views/documents/DocumentControlIssueList.vue'),
+        meta: { title: '文控问题明细' },
+      },
       // 文控运营中心
       {
         path: 'documents/operations/read-confirmations',

--- a/client/src/views/documents/DocumentControlIssueList.vue
+++ b/client/src/views/documents/DocumentControlIssueList.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="document-control-issue-list">
+    <el-card>
+      <template #header>
+        <div class="header">
+          <div>
+            <strong>{{ issueTitle }}</strong>
+            <span class="total">共 {{ total }} 条</span>
+          </div>
+          <el-button size="small" @click="fetchIssues">刷新</el-button>
+        </div>
+      </template>
+
+      <el-empty v-if="!loading && items.length === 0" description="暂无问题" />
+
+      <el-table v-else :data="items" v-loading="loading" stripe>
+        <el-table-column label="严重度" width="100">
+          <template #default="{ row }">
+            <el-tag :type="severityType(row.severity)">{{ severityText(row.severity) }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column prop="title" label="问题" min-width="180" />
+        <el-table-column prop="description" label="说明" min-width="260" show-overflow-tooltip />
+        <el-table-column prop="sourceLabel" label="来源" min-width="160" />
+        <el-table-column label="发现时间" width="140">
+          <template #default="{ row }">{{ formatDate(row.detectedAt) }}</template>
+        </el-table-column>
+        <el-table-column label="操作" width="140" fixed="right">
+          <template #default="{ row }">
+            <el-button :data-test="`issue-action-${row.id}`" type="primary" size="small" @click="openAction(row.actionRoute)">
+              {{ row.actionLabel }}
+            </el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+
+      <el-pagination
+        v-if="total > 0"
+        class="pagination"
+        :current-page="page"
+        :page-size="limit"
+        :total="total"
+        layout="prev, pager, next, total"
+        @current-change="handlePageChange"
+      />
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import {
+  documentControlApi,
+  type WorkbenchIssueItem,
+  type WorkbenchIssueType,
+} from '@/api/document-control';
+
+const route = useRoute();
+const router = useRouter();
+
+const issueTitles: Record<WorkbenchIssueType, string> = {
+  pendingReview: '待审核',
+  dueForReview: '即将复审',
+  expiringExternalFiles: '外来文件到期',
+  obsoleteReferences: '作废仍被引用',
+  brokenReferences: '入口失效',
+  missingLandingTargets: '表单入口缺失',
+  missingMetadata: '元数据缺失',
+  trainingNeeds: '培训需求未处理',
+  openImpactItems: '影响项未关闭',
+};
+
+const validTypes = Object.keys(issueTitles) as WorkbenchIssueType[];
+const loading = ref(false);
+const items = ref<WorkbenchIssueItem[]>([]);
+const total = ref(0);
+const page = ref(1);
+const limit = ref(20);
+
+const issueType = computed<WorkbenchIssueType>(() => {
+  const value = route.query.type as WorkbenchIssueType | undefined;
+  return value && validTypes.includes(value) ? value : 'missingMetadata';
+});
+
+const issueTitle = computed(() => issueTitles[issueType.value]);
+
+async function fetchIssues() {
+  loading.value = true;
+  try {
+    const result = await documentControlApi.listWorkbenchIssues({
+      type: issueType.value,
+      page: page.value,
+      limit: limit.value,
+      days: 30,
+    });
+    items.value = result.items;
+    total.value = result.total;
+    page.value = result.page;
+    limit.value = result.limit;
+  } catch {
+    ElMessage.error('加载问题列表失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function severityType(severity: string) {
+  if (severity === 'high') return 'danger';
+  if (severity === 'medium') return 'warning';
+  return 'info';
+}
+
+function severityText(severity: string) {
+  if (severity === 'high') return '高';
+  if (severity === 'medium') return '中';
+  return '低';
+}
+
+function formatDate(value: string | null) {
+  if (!value) return '-';
+  return new Date(value).toLocaleDateString('zh-CN');
+}
+
+function openAction(actionRoute: string) {
+  router.push(actionRoute);
+}
+
+function handlePageChange(nextPage: number) {
+  page.value = nextPage;
+  fetchIssues();
+}
+
+watch(issueType, () => {
+  page.value = 1;
+  fetchIssues();
+});
+
+onMounted(fetchIssues);
+</script>
+
+<style scoped>
+.document-control-issue-list {
+  padding: 16px;
+}
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.total {
+  margin-left: 8px;
+  color: #909399;
+  font-size: 13px;
+}
+.pagination {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/client/src/views/documents/DocumentControlWorkbench.vue
+++ b/client/src/views/documents/DocumentControlWorkbench.vue
@@ -16,6 +16,9 @@
           <span>{{ card.title }}</span>
         </template>
         <strong class="count">{{ workbench?.counts?.[card.key] ?? 0 }}</strong>
+        <span class="severity" :class="`severity-${card.severity}`">
+          {{ card.severity === 'high' ? '需优先处理' : '待处理' }}
+        </span>
       </el-card>
     </div>
 
@@ -41,16 +44,21 @@ const loading = ref(false);
 const workbench = ref<WorkbenchResponse | null>(null);
 
 const cards = computed(() => [
-  { key: 'pendingReview', title: '待审核', route: { path: '/documents', query: { status: 'pending' } } },
-  { key: 'dueForReview', title: '即将复审', route: { path: '/documents/control/library', query: { issue: 'dueForReview' } } },
-  { key: 'expiringExternalFiles', title: '外来文件到期', route: { path: '/documents/control/library', query: { issue: 'expiringExternalFiles' } } },
-  { key: 'obsoleteReferences', title: '作废仍被引用', route: { path: '/documents/operations/impact', query: { issue: 'obsoleteReferences' } } },
-  { key: 'brokenReferences', title: '入口失效', route: { path: '/documents/control/record-form-index', query: { issue: 'brokenReferences' } } },
-  { key: 'missingLandingTargets', title: '表单入口缺失', route: { path: '/documents/control/record-form-index', query: { issue: 'missingLandingTargets' } } },
-  { key: 'missingMetadata', title: '元数据缺失', route: { path: '/documents/control/library', query: { issue: 'missingMetadata' } } },
+  { key: 'pendingReview', title: '待审核', severity: 'medium' },
+  { key: 'dueForReview', title: '即将复审', severity: 'medium' },
+  { key: 'expiringExternalFiles', title: '外来文件到期', severity: 'high' },
+  { key: 'obsoleteReferences', title: '作废仍被引用', severity: 'high' },
+  { key: 'brokenReferences', title: '入口失效', severity: 'medium' },
+  { key: 'missingLandingTargets', title: '表单入口缺失', severity: 'high' },
+  { key: 'missingMetadata', title: '元数据缺失', severity: 'medium' },
+  { key: 'trainingNeeds', title: '培训需求未处理', severity: 'medium' },
+  { key: 'openImpactItems', title: '影响项未关闭', severity: 'medium' },
 ]);
 
-const openCard = (card: { route: any }) => router.push(card.route);
+const openCard = (card: { key: string }) => router.push({
+  path: '/documents/control/workbench/issues',
+  query: { type: card.key },
+});
 
 const fetchWorkbench = async () => {
   loading.value = true;
@@ -81,5 +89,16 @@ onMounted(fetchWorkbench);
 }
 .queue-card {
   margin-top: 12px;
+}
+.severity {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+}
+.severity-high {
+  color: #c45656;
+}
+.severity-medium {
+  color: #e6a23c;
 }
 </style>

--- a/client/src/views/documents/__tests__/DocumentControlIssueList.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentControlIssueList.spec.ts
@@ -1,7 +1,111 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { computed, inject, provide, type Ref } from 'vue';
+
+const mockListIssues = vi.fn();
+const mockPush = vi.fn();
+let mockRoute = { query: { type: 'missingMetadata' } as Record<string, string> };
+
+vi.mock('@/api/document-control', () => ({
+  documentControlApi: {
+    listWorkbenchIssues: (...args: unknown[]) => mockListIssues(...args),
+  },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('element-plus', () => ({
+  ElMessage: { error: vi.fn() },
+}));
+
+const stubs = {
+  'el-card': { template: '<div><slot name="header" /><slot /></div>' },
+  'el-button': { template: '<button @click="$emit(\'click\')"><slot /></button>', props: ['type', 'size'] },
+  'el-tag': { template: '<span><slot /></span>', props: ['type'] },
+  'el-empty': { template: '<div class="empty">empty</div>' },
+  'el-pagination': { template: '<div class="pagination" />', props: ['currentPage', 'pageSize', 'total'] },
+  'el-table': {
+    props: ['data'],
+    setup(props: { data: unknown[] }) {
+      provide('tableRows', computed(() => props.data));
+    },
+    template: '<div><slot /></div>',
+  },
+  'el-table-column': {
+    props: ['label', 'prop'],
+    setup(props: { label: string; prop?: string }, { slots }) {
+      const rows = inject<Ref<Record<string, unknown>[]>>('tableRows');
+      return { rows, slots, prop: props.prop };
+    },
+    template: `<div><template v-for="row in rows" :key="row.id"><slot :row="row">{{ prop ? row[prop] : '' }}</slot></template></div>`,
+  },
+};
+
+import DocumentControlIssueList from '../DocumentControlIssueList.vue';
+
+const mountOptions = { global: { stubs, directives: { loading: {} } } };
 
 describe('DocumentControlIssueList', () => {
-  it('has a test file ready for the issue list component', () => {
-    expect(true).toBe(true);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute = { query: { type: 'missingMetadata' } };
+    mockListIssues.mockResolvedValue({
+      type: 'missingMetadata',
+      items: [
+        {
+          id: 'issue-1',
+          issueType: 'missingMetadata',
+          severity: 'medium',
+          title: 'QM-001 质量手册',
+          description: '文件缺少文控元数据。',
+          sourceType: 'document',
+          sourceId: 'doc-1',
+          sourceLabel: 'QM-001 质量手册',
+          sourceRoute: '/documents/doc-1',
+          actionLabel: '补齐元数据',
+          actionRoute: '/documents/doc-1?section=metadata&issue=missingMetadata',
+          detectedAt: '2026-04-28T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+    });
+  });
+
+  it('loads issue rows from route query type', async () => {
+    const wrapper = mount(DocumentControlIssueList, mountOptions);
+    await flushPromises();
+
+    expect(mockListIssues).toHaveBeenCalledWith({ type: 'missingMetadata', page: 1, limit: 20, days: 30 });
+    expect(wrapper.text()).toContain('QM-001 质量手册');
+  });
+
+  it('routes action button to the issue action route', async () => {
+    const wrapper = mount(DocumentControlIssueList, mountOptions);
+    await flushPromises();
+
+    await wrapper.find('[data-test="issue-action-issue-1"]').trigger('click');
+    expect(mockPush).toHaveBeenCalledWith('/documents/doc-1?section=metadata&issue=missingMetadata');
+  });
+
+  it('shows empty state when there are no rows', async () => {
+    mockListIssues.mockResolvedValue({ type: 'missingMetadata', items: [], total: 0, page: 1, limit: 20, totalPages: 0 });
+    const wrapper = mount(DocumentControlIssueList, mountOptions);
+    await flushPromises();
+
+    expect(wrapper.find('.empty').exists()).toBe(true);
+  });
+
+  it('falls back to missingMetadata when route type is absent', async () => {
+    mockRoute = { query: {} };
+    mount(DocumentControlIssueList, mountOptions);
+    await flushPromises();
+
+    expect(mockListIssues).toHaveBeenCalledWith({ type: 'missingMetadata', page: 1, limit: 20, days: 30 });
   });
 });

--- a/client/src/views/documents/__tests__/DocumentControlIssueList.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentControlIssueList.spec.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('DocumentControlIssueList', () => {
+  it('has a test file ready for the issue list component', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/client/src/views/documents/__tests__/DocumentControlWorkbench.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentControlWorkbench.spec.ts
@@ -49,7 +49,17 @@ describe('DocumentControlWorkbench', () => {
   it('renders queue cards with correct titles', async () => {
     const wrapper = mount(DocumentControlWorkbench, mountOptions);
     await flushPromises();
-    const titles = ['待审核', '即将复审', '外来文件到期', '作废仍被引用', '入口失效', '表单入口缺失', '元数据缺失'];
+    const titles = [
+      '待审核',
+      '即将复审',
+      '外来文件到期',
+      '作废仍被引用',
+      '入口失效',
+      '表单入口缺失',
+      '元数据缺失',
+      '培训需求未处理',
+      '影响项未关闭',
+    ];
     expect((wrapper.vm as any).cards.map((card: any) => card.title)).toEqual(titles);
   });
 
@@ -68,8 +78,8 @@ describe('DocumentControlWorkbench', () => {
     await wrapper.find('[data-test="workbench-card-missingMetadata"]').trigger('click');
 
     expect(routerPush).toHaveBeenCalledWith({
-      path: '/documents/control/library',
-      query: { issue: 'missingMetadata' },
+      path: '/documents/control/workbench/issues',
+      query: { type: 'missingMetadata' },
     });
   });
 
@@ -88,12 +98,12 @@ describe('DocumentControlWorkbench', () => {
 
     expect(routerPush).toHaveBeenCalledTimes(2);
     expect(routerPush).toHaveBeenNthCalledWith(1, {
-      path: '/documents/control/library',
-      query: { issue: 'missingMetadata' },
+      path: '/documents/control/workbench/issues',
+      query: { type: 'missingMetadata' },
     });
     expect(routerPush).toHaveBeenNthCalledWith(2, {
-      path: '/documents/control/library',
-      query: { issue: 'missingMetadata' },
+      path: '/documents/control/workbench/issues',
+      query: { type: 'missingMetadata' },
     });
   });
 });

--- a/server/src/modules/document/document.controller.ts
+++ b/server/src/modules/document/document.controller.ts
@@ -34,7 +34,7 @@ import { DocumentImpactService } from './services/document-impact.service';
 import { DocumentHealthService } from './services/document-health.service';
 import { DocumentAuditChainService } from './services/document-audit-chain.service';
 import { DocumentReferenceHealthService } from './services/document-reference-health.service';
-import { CreateDocumentDto, UpdateDocumentDto, DocumentQueryDto, ArchiveDocumentDto, ObsoleteDocumentDto, ApproveDocumentDto, CreateGenericDocumentReferenceDto, WorkbenchQueryDto, CreateReadRequirementDto, TrainingNeedActionDto, ImpactReviewCreateDto, ImpactItemUpdateDto, CoverageQueryDto, AuditChainQueryDto, UpdateMarkdownDto } from './dto';
+import { CreateDocumentDto, UpdateDocumentDto, DocumentQueryDto, ArchiveDocumentDto, ObsoleteDocumentDto, ApproveDocumentDto, CreateGenericDocumentReferenceDto, WorkbenchQueryDto, WorkbenchIssueQueryDto, CreateReadRequirementDto, TrainingNeedActionDto, ImpactReviewCreateDto, ImpactItemUpdateDto, CoverageQueryDto, AuditChainQueryDto, UpdateMarkdownDto } from './dto';
 import { UpdateRecordFormLandingEntryDto } from './dto/document-control.dto';
 import { PublishDocumentDto, RollbackDocumentVersionDto } from './dto/document-lifecycle.dto';
 import { RestoreDocumentDto } from './dto/archive-document.dto';
@@ -140,6 +140,12 @@ export class DocumentController {
   @ApiOperation({ summary: '查询即将到期复审的文件' })
   getDueSoon(@Query('days') days?: string) {
     return this.lifecycleSvc.getDueSoon(days ? parseInt(days, 10) : 30);
+  }
+
+  @Get('control/workbench/issues')
+  @ApiOperation({ summary: '文控工作台问题明细' })
+  getControlWorkbenchIssues(@Query() query: WorkbenchIssueQueryDto) {
+    return this.workbenchService.listIssues(query);
   }
 
   @Get('control/workbench')

--- a/server/src/modules/document/dto/document-control.dto.ts
+++ b/server/src/modules/document/dto/document-control.dto.ts
@@ -1,4 +1,4 @@
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   ArrayMaxSize,
@@ -188,7 +188,7 @@ export const WORKBENCH_ISSUE_TYPES = [
 export type WorkbenchIssueType = typeof WORKBENCH_ISSUE_TYPES[number];
 
 export class WorkbenchIssueQueryDto {
-  @ApiPropertyOptional({ enum: WORKBENCH_ISSUE_TYPES })
+  @ApiProperty({ enum: WORKBENCH_ISSUE_TYPES })
   @IsIn(WORKBENCH_ISSUE_TYPES)
   type!: WorkbenchIssueType;
 

--- a/server/src/modules/document/dto/document-control.dto.ts
+++ b/server/src/modules/document/dto/document-control.dto.ts
@@ -172,3 +172,62 @@ export class WorkbenchQueryDto {
   @Type(() => Number)
   days?: number = 30;
 }
+
+export const WORKBENCH_ISSUE_TYPES = [
+  'pendingReview',
+  'dueForReview',
+  'expiringExternalFiles',
+  'obsoleteReferences',
+  'brokenReferences',
+  'missingLandingTargets',
+  'missingMetadata',
+  'trainingNeeds',
+  'openImpactItems',
+] as const;
+
+export type WorkbenchIssueType = typeof WORKBENCH_ISSUE_TYPES[number];
+
+export class WorkbenchIssueQueryDto {
+  @ApiPropertyOptional({ enum: WORKBENCH_ISSUE_TYPES })
+  @IsIn(WORKBENCH_ISSUE_TYPES)
+  type!: WorkbenchIssueType;
+
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ default: 30 })
+  @IsOptional()
+  @Type(() => Number)
+  days?: number = 30;
+}
+
+export interface WorkbenchIssueItem {
+  id: string;
+  issueType: WorkbenchIssueType;
+  severity: 'low' | 'medium' | 'high';
+  title: string;
+  description: string;
+  sourceType: string;
+  sourceId: string;
+  sourceLabel: string;
+  sourceRoute: string;
+  actionLabel: string;
+  actionRoute: string;
+  detectedAt: Date | string | null;
+}
+
+export interface WorkbenchIssueListResponse {
+  type: WorkbenchIssueType;
+  items: WorkbenchIssueItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/server/src/modules/document/services/document-control-workbench.service.spec.ts
+++ b/server/src/modules/document/services/document-control-workbench.service.spec.ts
@@ -60,4 +60,19 @@ describe('DocumentControlWorkbenchService', () => {
     expect(result.counts.missingLandingTargets).toBe(0);
     expect(result.counts.missingMetadata).toBe(0);
   });
+
+  it('exposes stable issue type contract values', async () => {
+    const dto = await import('../dto/document-control.dto');
+    expect(dto.WORKBENCH_ISSUE_TYPES).toEqual([
+      'pendingReview',
+      'dueForReview',
+      'expiringExternalFiles',
+      'obsoleteReferences',
+      'brokenReferences',
+      'missingLandingTargets',
+      'missingMetadata',
+      'trainingNeeds',
+      'openImpactItems',
+    ]);
+  });
 });

--- a/server/src/modules/document/services/document-control-workbench.service.spec.ts
+++ b/server/src/modules/document/services/document-control-workbench.service.spec.ts
@@ -25,26 +25,30 @@ describe('DocumentControlWorkbenchService', () => {
   });
 
   it('returns queue counts for all workbench sections', async () => {
-    prisma.document.findMany
-      .mockResolvedValueOnce([{ id: 'pending' }])
-      .mockResolvedValueOnce([{ id: 'due' }])
-      .mockResolvedValueOnce([{ id: 'external' }])
-      .mockResolvedValueOnce([{ id: 'missing' }]);
-    prisma.documentReference.findMany
-      .mockResolvedValueOnce([{ id: 'obsolete-ref' }])
-      .mockResolvedValueOnce([{ id: 'broken-ref' }]);
-    prisma.recordFormLandingEntry.findMany.mockResolvedValueOnce([{ id: 'landing-gap' }]);
+    prisma.document.count
+      .mockResolvedValueOnce(1)  // pendingReview
+      .mockResolvedValueOnce(2)  // dueForReview
+      .mockResolvedValueOnce(3)  // expiringExternalFiles
+      .mockResolvedValueOnce(4)  // missingMetadata
+    prisma.documentReference.count
+      .mockResolvedValueOnce(5)  // obsoleteReferences
+      .mockResolvedValueOnce(6); // brokenReferences
+    prisma.recordFormLandingEntry.count.mockResolvedValueOnce(7);
+    prisma.documentTrainingNeed.count.mockResolvedValueOnce(8);
+    prisma.documentImpactItem.count.mockResolvedValueOnce(9);
 
     const service = new DocumentControlWorkbenchService(prisma as any);
     const result = await service.getWorkbench(30);
 
     expect(result.counts.pendingReview).toBe(1);
-    expect(result.counts.dueForReview).toBe(1);
-    expect(result.counts.expiringExternalFiles).toBe(1);
-    expect(result.counts.obsoleteReferences).toBe(1);
-    expect(result.counts.brokenReferences).toBe(1);
-    expect(result.counts.missingLandingTargets).toBe(1);
-    expect(result.counts.missingMetadata).toBe(1);
+    expect(result.counts.dueForReview).toBe(2);
+    expect(result.counts.expiringExternalFiles).toBe(3);
+    expect(result.counts.missingMetadata).toBe(4);
+    expect(result.counts.obsoleteReferences).toBe(5);
+    expect(result.counts.brokenReferences).toBe(6);
+    expect(result.counts.missingLandingTargets).toBe(7);
+    expect(result.counts.trainingNeeds).toBe(8);
+    expect(result.counts.openImpactItems).toBe(9);
     expect(prisma.document.findMany).toHaveBeenNthCalledWith(2, expect.objectContaining({
       where: expect.objectContaining({
         status: { in: EFFECTIVE_COMPAT_STATUSES },

--- a/server/src/modules/document/services/document-control-workbench.service.spec.ts
+++ b/server/src/modules/document/services/document-control-workbench.service.spec.ts
@@ -3,16 +3,25 @@ import { EFFECTIVE_COMPAT_STATUSES } from '../constants/document-control.constan
 
 describe('DocumentControlWorkbenchService', () => {
   const prisma = {
-    document: { findMany: jest.fn() },
-    documentReference: { findMany: jest.fn() },
-    recordFormLandingEntry: { findMany: jest.fn() },
+    document: { findMany: jest.fn(), count: jest.fn() },
+    documentReference: { findMany: jest.fn(), count: jest.fn() },
+    recordFormLandingEntry: { findMany: jest.fn(), count: jest.fn() },
+    documentTrainingNeed: { findMany: jest.fn(), count: jest.fn() },
+    documentImpactItem: { findMany: jest.fn(), count: jest.fn() },
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     prisma.document.findMany.mockResolvedValue([]);
+    prisma.document.count.mockResolvedValue(0);
     prisma.documentReference.findMany.mockResolvedValue([]);
+    prisma.documentReference.count.mockResolvedValue(0);
     prisma.recordFormLandingEntry.findMany.mockResolvedValue([]);
+    prisma.recordFormLandingEntry.count.mockResolvedValue(0);
+    prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+    prisma.documentTrainingNeed.count.mockResolvedValue(0);
+    prisma.documentImpactItem.findMany.mockResolvedValue([]);
+    prisma.documentImpactItem.count.mockResolvedValue(0);
   });
 
   it('returns queue counts for all workbench sections', async () => {
@@ -74,5 +83,72 @@ describe('DocumentControlWorkbenchService', () => {
       'trainingNeeds',
       'openImpactItems',
     ]);
+  });
+
+  it('returns paginated due-for-review issue rows with action routes', async () => {
+    prisma.document.count.mockResolvedValueOnce(1);
+    prisma.document.findMany.mockResolvedValueOnce([
+      {
+        id: 'doc-1',
+        number: 'QM-001',
+        title: '质量手册',
+        review_due_date: new Date('2026-05-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-04-01T00:00:00.000Z'),
+      },
+    ]);
+
+    const service = new DocumentControlWorkbenchService(prisma as any);
+    const result = await service.listIssues({ type: 'dueForReview', page: 1, limit: 20, days: 30 });
+
+    expect(result.total).toBe(1);
+    expect(result.items[0]).toEqual(expect.objectContaining({
+      id: 'doc-1',
+      issueType: 'dueForReview',
+      severity: 'medium',
+      title: 'QM-001 质量手册',
+      sourceType: 'document',
+      sourceId: 'doc-1',
+      actionLabel: '查看复审文件',
+      actionRoute: '/documents/control/library?issue=dueForReview&documentId=doc-1',
+    }));
+  });
+
+  it('returns missing landing target issue rows with record form action routes', async () => {
+    prisma.recordFormLandingEntry.count.mockResolvedValueOnce(1);
+    prisma.recordFormLandingEntry.findMany.mockResolvedValueOnce([
+      {
+        id: 'landing-1',
+        sourceCode: 'GRSS-PZ-JL-01',
+        targetRoute: null,
+        targetModule: null,
+        updatedAt: new Date('2026-04-02T00:00:00.000Z'),
+      },
+    ]);
+
+    const service = new DocumentControlWorkbenchService(prisma as any);
+    const result = await service.listIssues({ type: 'missingLandingTargets', page: 1, limit: 20, days: 30 });
+
+    expect(result.items[0]).toEqual(expect.objectContaining({
+      id: 'landing-1',
+      issueType: 'missingLandingTargets',
+      severity: 'high',
+      title: 'GRSS-PZ-JL-01 缺少落地入口',
+      sourceType: 'record_form_landing',
+      sourceId: 'GRSS-PZ-JL-01',
+      actionRoute: '/documents/control/record-form-index?issue=missingLandingTargets&code=GRSS-PZ-JL-01',
+    }));
+  });
+
+  it('clamps issue pagination to a safe range', async () => {
+    prisma.document.count.mockResolvedValueOnce(0);
+    prisma.document.findMany.mockResolvedValueOnce([]);
+
+    const service = new DocumentControlWorkbenchService(prisma as any);
+    await service.listIssues({ type: 'pendingReview', page: -10, limit: 999, days: 30 });
+
+    expect(prisma.document.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      skip: 0,
+      take: 100,
+    }));
   });
 });

--- a/server/src/modules/document/services/document-control-workbench.service.ts
+++ b/server/src/modules/document/services/document-control-workbench.service.ts
@@ -1,15 +1,39 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { EFFECTIVE_COMPAT_STATUSES } from '../constants/document-control.constants';
+import {
+  WORKBENCH_ISSUE_TYPES,
+  WorkbenchIssueItem,
+  WorkbenchIssueListResponse,
+  WorkbenchIssueQueryDto,
+  WorkbenchIssueType,
+} from '../dto/document-control.dto';
 
 @Injectable()
 export class DocumentControlWorkbenchService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async getWorkbench(days = 30) {
-    const safeDays = Math.min(Math.max(days, 1), 365);
+  private getDeadline(days = 30) {
+    const safeDays = Math.min(Math.max(Number(days) || 30, 1), 365);
     const deadline = new Date();
     deadline.setDate(deadline.getDate() + safeDays);
+    return deadline;
+  }
+
+  private getPage(query: WorkbenchIssueQueryDto) {
+    const page = Math.max(Number(query.page) || 1, 1);
+    const limit = Math.min(Math.max(Number(query.limit) || 20, 1), 100);
+    return { page, limit, skip: (page - 1) * limit };
+  }
+
+  private assertIssueType(type: string): asserts type is WorkbenchIssueType {
+    if (!WORKBENCH_ISSUE_TYPES.includes(type as WorkbenchIssueType)) {
+      throw new BadRequestException(`Unsupported workbench issue type: ${type}`);
+    }
+  }
+
+  async getWorkbench(days = 30) {
+    const deadline = this.getDeadline(days);
 
     const [
       pendingReview,
@@ -19,6 +43,8 @@ export class DocumentControlWorkbenchService {
       brokenReferences,
       missingLandingTargets,
       missingMetadata,
+      trainingNeeds,
+      openImpactItems,
     ] = await Promise.all([
       this.prisma.document.findMany({
         where: { deletedAt: null, status: { in: ['pending_review', 'pending'] } },
@@ -73,6 +99,16 @@ export class DocumentControlWorkbenchService {
         orderBy: { updatedAt: 'desc' },
         take: 100,
       }),
+      this.prisma.documentTrainingNeed.findMany({
+        where: { status: { in: ['suggested', 'open', 'pending'] } },
+        orderBy: { updatedAt: 'desc' },
+        take: 100,
+      }),
+      this.prisma.documentImpactItem.findMany({
+        where: { status: { in: ['open', 'pending'] } },
+        orderBy: { updatedAt: 'desc' },
+        take: 100,
+      }),
     ]);
 
     return {
@@ -83,6 +119,8 @@ export class DocumentControlWorkbenchService {
       brokenReferences,
       missingLandingTargets,
       missingMetadata,
+      trainingNeeds,
+      openImpactItems,
       counts: {
         pendingReview: pendingReview.length,
         dueForReview: dueForReview.length,
@@ -91,7 +129,245 @@ export class DocumentControlWorkbenchService {
         brokenReferences: brokenReferences.length,
         missingLandingTargets: missingLandingTargets.length,
         missingMetadata: missingMetadata.length,
+        trainingNeeds: trainingNeeds.length,
+        openImpactItems: openImpactItems.length,
       },
     };
+  }
+
+  async listIssues(query: WorkbenchIssueQueryDto): Promise<WorkbenchIssueListResponse> {
+    this.assertIssueType(query.type);
+    const { page, limit, skip } = this.getPage(query);
+    const deadline = this.getDeadline(query.days);
+    const { total, rows } = await this.queryIssueRows(query.type, deadline, skip, limit);
+    const items = rows.map((row: any) => this.toIssueItem(query.type, row));
+    return {
+      type: query.type,
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  private async queryIssueRows(type: WorkbenchIssueType, deadline: Date, skip: number, take: number) {
+    if (type === 'pendingReview') {
+      const where = { deletedAt: null, status: { in: ['pending_review', 'pending'] } };
+      const [total, rows] = await Promise.all([
+        this.prisma.document.count({ where }),
+        this.prisma.document.findMany({ where, orderBy: { updatedAt: 'desc' }, skip, take }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'dueForReview') {
+      const where = { deletedAt: null, status: { in: [...EFFECTIVE_COMPAT_STATUSES] }, review_due_date: { lte: deadline } };
+      const [total, rows] = await Promise.all([
+        this.prisma.document.count({ where }),
+        this.prisma.document.findMany({ where, orderBy: { review_due_date: 'asc' }, skip, take }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'expiringExternalFiles') {
+      const where = {
+        deletedAt: null,
+        document_type: 'EXTERNAL_FILE',
+        external_expires_at: { lte: deadline },
+        status: { in: [...EFFECTIVE_COMPAT_STATUSES] },
+      };
+      const [total, rows] = await Promise.all([
+        this.prisma.document.count({ where }),
+        this.prisma.document.findMany({ where, orderBy: { external_expires_at: 'asc' }, skip, take }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'obsoleteReferences') {
+      const where = { targetDoc: { status: { in: ['obsolete', 'archived', 'superseded'] } } };
+      const [total, rows] = await Promise.all([
+        this.prisma.documentReference.count({ where }),
+        this.prisma.documentReference.findMany({
+          where,
+          include: {
+            sourceDoc: { select: { id: true, title: true, status: true } },
+            targetDoc: { select: { id: true, title: true, status: true } },
+          },
+          skip,
+          take,
+        }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'brokenReferences') {
+      const where = {
+        targetType: { in: ['record_template', 'record_list', 'business_module', 'business_object'] },
+        targetRoute: null,
+      };
+      const [total, rows] = await Promise.all([
+        this.prisma.documentReference.count({ where }),
+        this.prisma.documentReference.findMany({
+          where,
+          include: { sourceDoc: { select: { id: true, title: true, status: true } } },
+          skip,
+          take,
+        }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'missingLandingTargets') {
+      const where = { OR: [{ targetRoute: null }, { targetModule: null }] };
+      const [total, rows] = await Promise.all([
+        this.prisma.recordFormLandingEntry.count({ where }),
+        this.prisma.recordFormLandingEntry.findMany({ where, orderBy: { updatedAt: 'desc' }, skip, take }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'missingMetadata') {
+      const where = {
+        deletedAt: null,
+        OR: [
+          { document_type: null },
+          { source_folder: null },
+          { review_due_date: null },
+        ],
+      };
+      const [total, rows] = await Promise.all([
+        this.prisma.document.count({ where }),
+        this.prisma.document.findMany({ where, orderBy: { updatedAt: 'desc' }, skip, take }),
+      ]);
+      return { total, rows };
+    }
+
+    if (type === 'trainingNeeds') {
+      const where = { status: { in: ['suggested', 'open', 'pending'] } };
+      const [total, rows] = await Promise.all([
+        this.prisma.documentTrainingNeed.count({ where }),
+        this.prisma.documentTrainingNeed.findMany({
+          where,
+          include: { document: { select: { id: true, title: true, number: true } } },
+          orderBy: { updatedAt: 'desc' },
+          skip,
+          take,
+        }),
+      ]);
+      return { total, rows };
+    }
+
+    const where = { status: { in: ['open', 'pending'] } };
+    const [total, rows] = await Promise.all([
+      this.prisma.documentImpactItem.count({ where }),
+      this.prisma.documentImpactItem.findMany({
+        where,
+        include: { review: { select: { id: true, title: true, sourceType: true, sourceId: true } } },
+        orderBy: { updatedAt: 'desc' },
+        skip,
+        take,
+      }),
+    ]);
+    return { total, rows };
+  }
+
+  private toIssueItem(type: WorkbenchIssueType, row: any): WorkbenchIssueItem {
+    if (type === 'missingLandingTargets') {
+      const code = row.sourceCode;
+      return {
+        id: row.id,
+        issueType: type,
+        severity: 'high',
+        title: `${code} 缺少落地入口`,
+        description: '记录表单索引缺少目标模块或目标路由，无法从文控中心导航到实际填报入口。',
+        sourceType: 'record_form_landing',
+        sourceId: code,
+        sourceLabel: code,
+        sourceRoute: `/documents/control/record-form-index?code=${encodeURIComponent(code)}`,
+        actionLabel: '维护表单入口',
+        actionRoute: `/documents/control/record-form-index?issue=missingLandingTargets&code=${encodeURIComponent(code)}`,
+        detectedAt: row.updatedAt ?? row.createdAt ?? null,
+      };
+    }
+
+    if (type === 'obsoleteReferences' || type === 'brokenReferences') {
+      const sourceDocId = row.sourceDocId ?? row.sourceDoc?.id;
+      const label = row.targetLabel ?? row.targetDoc?.title ?? row.targetId ?? '未命名引用';
+      return {
+        id: row.id,
+        issueType: type,
+        severity: type === 'obsoleteReferences' ? 'high' : 'medium',
+        title: `${row.sourceDoc?.title ?? '来源文件'} 引用异常`,
+        description: type === 'obsoleteReferences'
+          ? `引用目标 ${label} 已作废、归档或被替代。`
+          : `引用目标 ${label} 缺少可用入口。`,
+        sourceType: 'document_reference',
+        sourceId: sourceDocId,
+        sourceLabel: row.sourceDoc?.title ?? sourceDocId,
+        sourceRoute: `/documents/${sourceDocId}`,
+        actionLabel: '查看引用',
+        actionRoute: `/documents/${sourceDocId}?section=references&issue=${type}`,
+        detectedAt: row.updatedAt ?? row.createdAt ?? null,
+      };
+    }
+
+    if (type === 'trainingNeeds') {
+      return {
+        id: row.id,
+        issueType: type,
+        severity: 'medium',
+        title: row.document?.title ? `${row.document.title} 培训需求未处理` : '培训需求未处理',
+        description: row.reason ?? '文档变更或阅读要求产生了培训需求，尚未接受、驳回或关联培训项目。',
+        sourceType: 'document_training_need',
+        sourceId: row.id,
+        sourceLabel: row.document?.number ?? row.document?.title ?? row.id,
+        sourceRoute: '/documents/operations/training-needs?status=suggested',
+        actionLabel: '处理培训需求',
+        actionRoute: '/documents/operations/training-needs?status=suggested',
+        detectedAt: row.updatedAt ?? row.createdAt ?? null,
+      };
+    }
+
+    if (type === 'openImpactItems') {
+      return {
+        id: row.id,
+        issueType: type,
+        severity: row.impactLevel === 'high' ? 'high' : 'medium',
+        title: row.targetLabel ?? row.review?.title ?? '影响项未关闭',
+        description: row.suggestedAction ?? '影响评审项仍处于打开状态，需要确认处理动作。',
+        sourceType: 'document_impact_item',
+        sourceId: row.id,
+        sourceLabel: row.review?.title ?? row.id,
+        sourceRoute: '/documents/operations/impact?status=open',
+        actionLabel: '处理影响项',
+        actionRoute: '/documents/operations/impact?status=open',
+        detectedAt: row.updatedAt ?? row.createdAt ?? null,
+      };
+    }
+
+    const documentId = row.id;
+    const title = `${row.number ?? ''} ${row.title ?? '未命名文件'}`.trim();
+    const base = {
+      id: documentId,
+      issueType: type,
+      title,
+      sourceType: 'document',
+      sourceId: documentId,
+      sourceLabel: title,
+      sourceRoute: `/documents/${documentId}`,
+      detectedAt: row.updatedAt ?? row.review_due_date ?? row.external_expires_at ?? row.createdAt ?? null,
+    };
+
+    if (type === 'pendingReview') {
+      return { ...base, severity: 'medium', description: '文件处于待审核状态。', actionLabel: '查看审批文件', actionRoute: `/documents/${documentId}` };
+    }
+    if (type === 'dueForReview') {
+      return { ...base, severity: 'medium', description: '文件已到或即将到达复审日期。', actionLabel: '查看复审文件', actionRoute: `/documents/control/library?issue=dueForReview&documentId=${documentId}` };
+    }
+    if (type === 'expiringExternalFiles') {
+      return { ...base, severity: 'high', description: '外来文件已到或即将到达有效期。', actionLabel: '查看外来文件', actionRoute: `/documents/control/library?issue=expiringExternalFiles&documentId=${documentId}` };
+    }
+    return { ...base, severity: 'medium', description: '文件缺少文控元数据。', actionLabel: '补齐元数据', actionRoute: `/documents/${documentId}?section=metadata&issue=missingMetadata` };
   }
 }

--- a/server/src/modules/document/services/document-control-workbench.service.ts
+++ b/server/src/modules/document/services/document-control-workbench.service.ts
@@ -35,6 +35,16 @@ export class DocumentControlWorkbenchService {
   async getWorkbench(days = 30) {
     const deadline = this.getDeadline(days);
 
+    const pendingReviewWhere = { deletedAt: null, status: { in: ['pending_review', 'pending'] } };
+    const dueForReviewWhere = { deletedAt: null, status: { in: [...EFFECTIVE_COMPAT_STATUSES] }, review_due_date: { lte: deadline } };
+    const expiringWhere = { deletedAt: null, document_type: 'EXTERNAL_FILE', external_expires_at: { lte: deadline }, status: { in: [...EFFECTIVE_COMPAT_STATUSES] } };
+    const obsoleteRefWhere = { targetDoc: { status: { in: ['obsolete', 'archived', 'superseded'] } } };
+    const brokenRefWhere = { targetType: { in: ['record_template', 'record_list', 'business_module', 'business_object'] }, targetRoute: null };
+    const missingLandingWhere = { OR: [{ targetRoute: null }, { targetModule: null }] };
+    const missingMetaWhere = { deletedAt: null, OR: [{ document_type: null }, { source_folder: null }, { review_due_date: null }] };
+    const trainingWhere = { status: { in: ['suggested', 'open', 'pending'] } };
+    const impactWhere = { status: { in: ['open', 'pending'] } };
+
     const [
       pendingReview,
       dueForReview,
@@ -45,29 +55,21 @@ export class DocumentControlWorkbenchService {
       missingMetadata,
       trainingNeeds,
       openImpactItems,
+      pendingReviewCount,
+      dueForReviewCount,
+      expiringCount,
+      obsoleteRefCount,
+      brokenRefCount,
+      missingLandingCount,
+      missingMetaCount,
+      trainingCount,
+      impactCount,
     ] = await Promise.all([
-      this.prisma.document.findMany({
-        where: { deletedAt: null, status: { in: ['pending_review', 'pending'] } },
-        orderBy: { updatedAt: 'desc' },
-        take: 100,
-      }),
-      this.prisma.document.findMany({
-        where: { deletedAt: null, status: { in: [...EFFECTIVE_COMPAT_STATUSES] }, review_due_date: { lte: deadline } },
-        orderBy: { review_due_date: 'asc' },
-        take: 100,
-      }),
-      this.prisma.document.findMany({
-        where: {
-          deletedAt: null,
-          document_type: 'EXTERNAL_FILE',
-          external_expires_at: { lte: deadline },
-          status: { in: [...EFFECTIVE_COMPAT_STATUSES] },
-        },
-        orderBy: { external_expires_at: 'asc' },
-        take: 100,
-      }),
+      this.prisma.document.findMany({ where: pendingReviewWhere, orderBy: { updatedAt: 'desc' }, take: 100 }),
+      this.prisma.document.findMany({ where: dueForReviewWhere, orderBy: { review_due_date: 'asc' }, take: 100 }),
+      this.prisma.document.findMany({ where: expiringWhere, orderBy: { external_expires_at: 'asc' }, take: 100 }),
       this.prisma.documentReference.findMany({
-        where: { targetDoc: { status: { in: ['obsolete', 'archived', 'superseded'] } } },
+        where: obsoleteRefWhere,
         include: {
           sourceDoc: { select: { id: true, title: true, status: true } },
           targetDoc: { select: { id: true, title: true, status: true } },
@@ -75,40 +77,23 @@ export class DocumentControlWorkbenchService {
         take: 100,
       }),
       this.prisma.documentReference.findMany({
-        where: {
-          targetType: { in: ['record_template', 'record_list', 'business_module', 'business_object'] },
-          targetRoute: null,
-        },
+        where: brokenRefWhere,
         include: { sourceDoc: { select: { id: true, title: true, status: true } } },
         take: 100,
       }),
-      this.prisma.recordFormLandingEntry.findMany({
-        where: { OR: [{ targetRoute: null }, { targetModule: null }] },
-        orderBy: { updatedAt: 'desc' },
-        take: 100,
-      }),
-      this.prisma.document.findMany({
-        where: {
-          deletedAt: null,
-          OR: [
-            { document_type: null },
-            { source_folder: null },
-            { review_due_date: null },
-          ],
-        },
-        orderBy: { updatedAt: 'desc' },
-        take: 100,
-      }),
-      this.prisma.documentTrainingNeed.findMany({
-        where: { status: { in: ['suggested', 'open', 'pending'] } },
-        orderBy: { updatedAt: 'desc' },
-        take: 100,
-      }),
-      this.prisma.documentImpactItem.findMany({
-        where: { status: { in: ['open', 'pending'] } },
-        orderBy: { updatedAt: 'desc' },
-        take: 100,
-      }),
+      this.prisma.recordFormLandingEntry.findMany({ where: missingLandingWhere, orderBy: { updatedAt: 'desc' }, take: 100 }),
+      this.prisma.document.findMany({ where: missingMetaWhere, orderBy: { updatedAt: 'desc' }, take: 100 }),
+      this.prisma.documentTrainingNeed.findMany({ where: trainingWhere, orderBy: { updatedAt: 'desc' }, take: 100 }),
+      this.prisma.documentImpactItem.findMany({ where: impactWhere, orderBy: { updatedAt: 'desc' }, take: 100 }),
+      this.prisma.document.count({ where: pendingReviewWhere }),
+      this.prisma.document.count({ where: dueForReviewWhere }),
+      this.prisma.document.count({ where: expiringWhere }),
+      this.prisma.documentReference.count({ where: obsoleteRefWhere }),
+      this.prisma.documentReference.count({ where: brokenRefWhere }),
+      this.prisma.recordFormLandingEntry.count({ where: missingLandingWhere }),
+      this.prisma.document.count({ where: missingMetaWhere }),
+      this.prisma.documentTrainingNeed.count({ where: trainingWhere }),
+      this.prisma.documentImpactItem.count({ where: impactWhere }),
     ]);
 
     return {
@@ -122,15 +107,15 @@ export class DocumentControlWorkbenchService {
       trainingNeeds,
       openImpactItems,
       counts: {
-        pendingReview: pendingReview.length,
-        dueForReview: dueForReview.length,
-        expiringExternalFiles: expiringExternalFiles.length,
-        obsoleteReferences: obsoleteReferences.length,
-        brokenReferences: brokenReferences.length,
-        missingLandingTargets: missingLandingTargets.length,
-        missingMetadata: missingMetadata.length,
-        trainingNeeds: trainingNeeds.length,
-        openImpactItems: openImpactItems.length,
+        pendingReview: pendingReviewCount,
+        dueForReview: dueForReviewCount,
+        expiringExternalFiles: expiringCount,
+        obsoleteReferences: obsoleteRefCount,
+        brokenReferences: brokenRefCount,
+        missingLandingTargets: missingLandingCount,
+        missingMetadata: missingMetaCount,
+        trainingNeeds: trainingCount,
+        openImpactItems: impactCount,
       },
     };
   }


### PR DESCRIPTION
## Summary

- 新增后端 `GET /documents/control/workbench/issues` 端点，支持 9 种问题类型的分页查询
- 更新 `DocumentControlWorkbench.vue` 卡片，统一路由到 `/documents/control/workbench/issues?type=<key>`
- 新建 `DocumentControlIssueList.vue` 问题明细页面，展示问题行、严重度标签、来源、修复入口

## Changes

- `server/src/modules/document/dto/document-control.dto.ts` — 新增 `WORKBENCH_ISSUE_TYPES`、`WorkbenchIssueType`、`WorkbenchIssueQueryDto`、`WorkbenchIssueItem`、`WorkbenchIssueListResponse`
- `server/src/modules/document/services/document-control-workbench.service.ts` — 新增 `listIssues()` 及 `queryIssueRows()`、`toIssueItem()` 私有方法；`getWorkbench()` 扩展支持 `trainingNeeds` 和 `openImpactItems` 计数
- `server/src/modules/document/document.controller.ts` — 新增路由 `GET control/workbench/issues`，置于 `GET control/workbench` 之前
- `client/src/api/document-control.ts` — 新增前端类型合约及 `listWorkbenchIssues` 方法
- `client/src/views/documents/DocumentControlWorkbench.vue` — 卡片路由统一、新增严重度标签、扩展为 9 张卡片
- `client/src/views/documents/DocumentControlIssueList.vue` — 新建问题明细页面
- `client/src/router/index.ts` — 注册 `documents/control/workbench/issues` 路由

## Test plan

- [ ] 后端测试：`npm test -- document-control-workbench.service.spec.ts --runInBand`（6 个测试全部通过）
- [ ] 前端测试：`npm test -- DocumentControlWorkbench.spec.ts DocumentControlIssueList.spec.ts --run`（9 个测试全部通过）
- [ ] 手动确认工作台各卡片可点击并跳转到 `/documents/control/workbench/issues?type=<key>`
- [ ] 手动确认问题明细页显示问题行、空状态、分页、刷新功能
- [ ] 手动确认问题操作按钮跳转到对应修复页面