### PR TITLE
Implement document governance phase 4 evidence chain

### DIFF
--- a/client/src/api/document-control.ts
+++ b/client/src/api/document-control.ts
@@ -1,4 +1,5 @@
 import request from './request';
+import type { EvidenceChainQuery, EvidenceChainResult } from '@noidear/types';
 
 export type DocumentType =
   | 'MANUAL'
@@ -181,5 +182,9 @@ export const documentControlApi = {
 
   listWorkbenchIssues(params: { type: WorkbenchIssueType; page?: number; limit?: number; days?: number }) {
     return request.get<WorkbenchIssueListResponse>('/documents/control/workbench/issues', { params });
+  },
+
+  getEvidenceChain(params: EvidenceChainQuery) {
+    return request.get<EvidenceChainResult>('/documents/control/evidence-chain', { params });
   },
 };

--- a/client/src/components/document/EvidenceChainGraph.vue
+++ b/client/src/components/document/EvidenceChainGraph.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="evidence-chain-graph">
+    <div v-if="loading" class="evidence-chain-loading">加载中...</div>
+    <div v-else-if="!chain" class="evidence-chain-empty">暂无证据链数据</div>
+    <template v-else>
+      <!-- Warnings -->
+      <div v-if="chain.warnings.length" class="evidence-chain-warnings">
+        <div v-for="w in chain.warnings" :key="w.id" class="evidence-chain-warning">
+          {{ w.message }}
+        </div>
+      </div>
+
+      <!-- Nodes grouped by depth -->
+      <div
+        v-for="[depth, nodes] in nodesByDepth"
+        :key="depth"
+        class="evidence-depth-group"
+      >
+        <div
+          v-for="node in nodes"
+          :key="node.nodeId"
+          class="evidence-node"
+          :data-routable="node.route ? 'true' : undefined"
+        >
+          <span class="evidence-node-label">{{ node.label }}</span>
+          <span class="evidence-node-type">{{ node.type }}</span>
+          <span v-if="node.status" class="evidence-node-status">{{ node.status }}</span>
+        </div>
+      </div>
+
+      <!-- Edges -->
+      <div class="evidence-chain-edges">
+        <div v-for="edge in chain.edges" :key="edge.id" class="evidence-edge">
+          {{ edge.label }}
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { EvidenceChainResult, EvidenceNode } from '@noidear/types'
+
+const props = defineProps<{
+  chain: EvidenceChainResult | null
+  loading?: boolean
+}>()
+
+const nodesByDepth = computed((): Map<number, EvidenceNode[]> => {
+  if (!props.chain) return new Map()
+
+  const map = new Map<number, EvidenceNode[]>()
+  for (const node of props.chain.nodes) {
+    const existing = map.get(node.depth) ?? []
+    map.set(node.depth, [...existing, node])
+  }
+
+  return new Map([...map.entries()].sort(([a], [b]) => a - b))
+})
+</script>

--- a/client/src/components/document/EvidenceChainGraph.vue
+++ b/client/src/components/document/EvidenceChainGraph.vue
@@ -21,6 +21,8 @@
           :key="node.nodeId"
           class="evidence-node"
           :data-routable="node.route ? 'true' : undefined"
+          :style="node.route ? { cursor: 'pointer' } : {}"
+          @click="node.route ? router.push(node.route) : undefined"
         >
           <span class="evidence-node-label">{{ node.label }}</span>
           <span class="evidence-node-type">{{ node.type }}</span>
@@ -40,7 +42,10 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import type { EvidenceChainResult, EvidenceNode } from '@noidear/types'
+
+const router = useRouter()
 
 const props = defineProps<{
   chain: EvidenceChainResult | null

--- a/client/src/components/document/__tests__/EvidenceChainGraph.spec.ts
+++ b/client/src/components/document/__tests__/EvidenceChainGraph.spec.ts
@@ -1,0 +1,72 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import EvidenceChainGraph from '../EvidenceChainGraph.vue'
+import type { EvidenceChainResult } from '@noidear/types'
+
+const mockChain: EvidenceChainResult = {
+  root: {
+    id: 'doc-1', nodeId: 'document:doc-1', type: 'document',
+    label: 'SOP-001 操作规程', route: '/documents/doc-1', depth: 0
+  },
+  nodes: [
+    { id: 'doc-1', nodeId: 'document:doc-1', type: 'document', label: 'SOP-001 操作规程', route: '/documents/doc-1', depth: 0 },
+    { id: 'tmpl-1', nodeId: 'record_template:tmpl-1', type: 'record_template', label: '卫生记录表', route: '/records/templates/tmpl-1', depth: 1 },
+    { id: 'rec-1', nodeId: 'record:rec-1', type: 'record', label: '2024-01 卫生记录', route: '/records/rec-1', depth: 2 },
+    { id: 'find-1', nodeId: 'audit_finding:find-1', type: 'audit_finding', label: '内审发现问题', route: null, depth: 1 },
+  ],
+  edges: [
+    { id: 'e1', source: 'document:doc-1', target: 'record_template:tmpl-1', relationType: 'has_template', strength: 'validated', label: '绑定模板' },
+    { id: 'e2', source: 'record_template:tmpl-1', target: 'record:rec-1', relationType: 'has_record', strength: 'validated', label: '填写记录' },
+  ],
+  warnings: [
+    { id: 'w1', severity: 'warning', message: '记录表单入口未绑定表单模板', sourceNodeId: 'document:doc-1' }
+  ],
+  meta: {
+    sourceType: 'document', sourceId: 'doc-1', maxDepth: 4,
+    generatedAt: '2026-04-28T00:00:00Z', truncated: false
+  }
+}
+
+describe('EvidenceChainGraph', () => {
+  it('renders nodes grouped by depth', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: mockChain } })
+    // Depth 0 node
+    expect(wrapper.text()).toContain('SOP-001 操作规程')
+    // Depth 1 nodes
+    expect(wrapper.text()).toContain('卫生记录表')
+    expect(wrapper.text()).toContain('内审发现问题')
+    // Depth 2 node
+    expect(wrapper.text()).toContain('2024-01 卫生记录')
+  })
+
+  it('renders relation labels', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: mockChain } })
+    expect(wrapper.text()).toContain('绑定模板')
+  })
+
+  it('renders warnings', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: mockChain } })
+    expect(wrapper.text()).toContain('记录表单入口未绑定表单模板')
+  })
+
+  it('shows empty state when chain is null', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: null } })
+    expect(wrapper.text()).toContain('暂无证据链数据')
+  })
+
+  it('shows loading state when loading prop is true', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: null, loading: true } })
+    // Should show some loading indicator, not empty state
+    expect(wrapper.text()).not.toContain('暂无证据链数据')
+  })
+
+  it('renders routable nodes without navigation control for non-routable nodes', () => {
+    const wrapper = mount(EvidenceChainGraph, { props: { chain: mockChain } })
+    // audit_finding:find-1 has route: null — no link/button for it
+    // document:doc-1 has route — should have a clickable element
+    const links = wrapper.findAll('[data-routable]')
+    // Only nodes with non-null route should have the data-routable attribute
+    const routeCount = mockChain.nodes.filter(n => n.route).length
+    expect(links.length).toBe(routeCount)
+  })
+})

--- a/client/src/views/documents/AuditChainExplorer.vue
+++ b/client/src/views/documents/AuditChainExplorer.vue
@@ -37,11 +37,11 @@ import { ref, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
 import { documentControlApi } from '@/api/document-control';
 import EvidenceChainGraph from '@/components/document/EvidenceChainGraph.vue';
-import type { EvidenceChainResult } from '@noidear/types';
+import type { EvidenceChainResult, EvidenceSourceType } from '@noidear/types';
 
 const route = useRoute();
 
-const sourceType = ref<string>((route.query.sourceType as string) || 'document');
+const sourceType = ref<EvidenceSourceType>((route.query.sourceType as EvidenceSourceType) || 'document');
 const sourceId = ref<string>((route.query.sourceId as string) || '');
 const maxDepth = ref<number>(Number(route.query.maxDepth) || 4);
 const chain = ref<EvidenceChainResult | null>(null);
@@ -61,7 +61,7 @@ const load = async () => {
       sourceId: sourceId.value,
       maxDepth: maxDepth.value,
     });
-    chain.value = result.data;
+    chain.value = result;
   } catch (err) {
     error.value = '获取证据链失败';
   } finally {

--- a/client/src/views/documents/AuditChainExplorer.vue
+++ b/client/src/views/documents/AuditChainExplorer.vue
@@ -1,58 +1,156 @@
 <template>
   <div class="audit-chain-explorer">
+    <h2 class="page-title">证据链</h2>
     <div class="toolbar">
-      <el-select v-model="sourceType" placeholder="来源类型">
-        <el-option value="document" label="文件" />
-      </el-select>
-      <el-input v-model="sourceId" placeholder="来源ID" />
-      <el-button type="primary" @click="load">查看链路</el-button>
+      <select v-model="sourceType" class="source-type-select">
+        <option value="document">文件</option>
+        <option value="record_template">记录模板</option>
+        <option value="record">记录</option>
+        <option value="change_event">变更事件</option>
+        <option value="audit_finding">审核发现</option>
+        <option value="corrective_action">纠正措施</option>
+      </select>
+      <input v-model="sourceId" placeholder="来源ID" class="source-id-input" />
+      <button type="button" @click="load" class="btn-primary">查看证据链</button>
+      <button
+        v-if="chain"
+        type="button"
+        @click="downloadJson"
+        class="btn-secondary"
+      >下载 JSON</button>
+      <button
+        v-if="chain"
+        type="button"
+        @click="copySummary"
+        class="btn-secondary"
+      >复制摘要</button>
     </div>
-    <el-card>
-      <template #header>链路节点</template>
-      <el-table :data="chain?.nodes || []" v-loading="loading" stripe>
-        <el-table-column prop="type" label="类型" width="140" />
-        <el-table-column prop="label" label="节点" min-width="240" />
-        <el-table-column prop="depth" label="层级" width="100" />
-      </el-table>
-    </el-card>
+
+    <div v-if="loading" class="loading-indicator" data-testid="loading">加载中…</div>
+    <div v-else-if="error" class="error-message" data-testid="error">{{ error }}</div>
+    <EvidenceChainGraph v-else :chain="chain" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
-import { ElMessage } from 'element-plus';
-import { documentOperationsApi } from '@/api/document-operations';
+import { ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { documentControlApi } from '@/api/document-control';
+import EvidenceChainGraph from '@/components/document/EvidenceChainGraph.vue';
+import type { EvidenceChainResult } from '@noidear/types';
 
-const sourceType = ref('document');
-const sourceId = ref('');
-const chain = ref<any | null>(null);
+const route = useRoute();
+
+const sourceType = ref<string>((route.query.sourceType as string) || 'document');
+const sourceId = ref<string>((route.query.sourceId as string) || '');
+const maxDepth = ref<number>(Number(route.query.maxDepth) || 4);
+const chain = ref<EvidenceChainResult | null>(null);
 const loading = ref(false);
+const error = ref<string | null>(null);
 
 const load = async () => {
   if (!sourceId.value) {
-    ElMessage.error('请输入来源ID');
+    error.value = '请输入来源ID';
     return;
   }
   loading.value = true;
+  error.value = null;
   try {
-    chain.value = await documentOperationsApi.getAuditChain({
+    const result = await documentControlApi.getEvidenceChain({
       sourceType: sourceType.value,
       sourceId: sourceId.value,
-      maxDepth: 4,
+      maxDepth: maxDepth.value,
     });
-  } catch {
-    ElMessage.error('获取审核链路失败');
+    chain.value = result.data;
+  } catch (err) {
+    error.value = '获取证据链失败';
   } finally {
     loading.value = false;
   }
 };
+
+const downloadJson = () => {
+  const blob = new Blob([JSON.stringify(chain.value, null, 2)], {
+    type: 'application/json;charset=utf-8',
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'evidence-chain.json';
+  a.click();
+  URL.revokeObjectURL(url);
+};
+
+const copySummary = () => {
+  const summary = `根节点: ${chain.value?.root?.label}\n节点数: ${chain.value?.nodes?.length}\n边数: ${chain.value?.edges?.length}\n警告数: ${chain.value?.warnings?.length}`;
+  navigator.clipboard.writeText(summary);
+};
+
+onMounted(() => {
+  if (sourceId.value) {
+    load();
+  }
+});
 </script>
 
 <style scoped>
+.page-title {
+  margin: 0 0 12px;
+  font-size: 1.25rem;
+}
+
 .toolbar {
-  display: grid;
-  grid-template-columns: 160px minmax(260px, 1fr) auto;
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   margin-bottom: 12px;
+  align-items: center;
+}
+
+.source-type-select {
+  min-width: 140px;
+  padding: 6px 8px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+}
+
+.source-id-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 6px 8px;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+}
+
+.btn-primary {
+  padding: 6px 16px;
+  background: #409eff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-secondary {
+  padding: 6px 16px;
+  background: #fff;
+  color: #409eff;
+  border: 1px solid #409eff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.loading-indicator {
+  padding: 24px;
+  text-align: center;
+  color: #999;
+}
+
+.error-message {
+  padding: 12px;
+  color: #f56c6c;
+  background: #fff2f0;
+  border: 1px solid #ffccc7;
+  border-radius: 4px;
 }
 </style>

--- a/client/src/views/documents/DocumentDetail.vue
+++ b/client/src/views/documents/DocumentDetail.vue
@@ -111,6 +111,12 @@
         >
           恢复
         </el-button>
+        <el-button
+          type="primary"
+          @click="openEvidenceChain"
+        >
+          查看证据链
+        </el-button>
       </div>
     </el-card>
 
@@ -958,6 +964,17 @@ const handleRestore = async () => {
   } finally {
     restoring.value = false;
   }
+};
+
+const openEvidenceChain = () => {
+  if (!document.value?.id) return;
+  router.push({
+    path: '/documents/operations/audit-chain',
+    query: {
+      sourceType: 'document',
+      sourceId: document.value.id,
+    },
+  });
 };
 
 onMounted(() => {

--- a/client/src/views/documents/__tests__/AuditChainExplorer.spec.ts
+++ b/client/src/views/documents/__tests__/AuditChainExplorer.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import type { EvidenceChainResult } from '@noidear/types';
+
+const mockChain: EvidenceChainResult = {
+  root: {
+    id: 'doc-1',
+    nodeId: 'document:doc-1',
+    type: 'document',
+    label: 'SOP-001 操作规程',
+    route: '/documents/doc-1',
+    depth: 0,
+  },
+  nodes: [
+    {
+      id: 'doc-1',
+      nodeId: 'document:doc-1',
+      type: 'document',
+      label: 'SOP-001 操作规程',
+      route: '/documents/doc-1',
+      depth: 0,
+    },
+    {
+      id: 'tmpl-1',
+      nodeId: 'record_template:tmpl-1',
+      type: 'record_template',
+      label: '卫生记录表',
+      route: '/records/templates/tmpl-1',
+      depth: 1,
+    },
+  ],
+  edges: [
+    {
+      id: 'e1',
+      source: 'document:doc-1',
+      target: 'record_template:tmpl-1',
+      relationType: 'has_template',
+      strength: 'validated',
+      label: '绑定模板',
+    },
+  ],
+  warnings: [
+    {
+      id: 'w1',
+      severity: 'warning',
+      message: '记录表单入口未绑定表单模板',
+      sourceNodeId: 'document:doc-1',
+    },
+  ],
+  meta: {
+    sourceType: 'document',
+    sourceId: 'doc-1',
+    maxDepth: 4,
+    generatedAt: '2026-04-28T00:00:00Z',
+    truncated: false,
+  },
+};
+
+vi.mock('@/api/document-control', () => ({
+  documentControlApi: {
+    getEvidenceChain: vi.fn(),
+  },
+}));
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn().mockReturnValue({ query: {} }),
+}));
+
+const stubs = {
+  EvidenceChainGraph: {
+    template: '<div data-testid="evidence-chain-graph">graph</div>',
+    props: ['chain', 'loading'],
+  },
+};
+
+import AuditChainExplorer from '../AuditChainExplorer.vue';
+import { documentControlApi } from '@/api/document-control';
+import { useRoute } from 'vue-router';
+
+describe('AuditChainExplorer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRoute).mockReturnValue({ query: {} } as any);
+    vi.mocked(documentControlApi.getEvidenceChain).mockResolvedValue({ data: mockChain } as any);
+  });
+
+  it('page heading includes 证据链', () => {
+    const wrapper = mount(AuditChainExplorer, { global: { stubs } });
+    expect(wrapper.text()).toContain('证据链');
+  });
+
+  it('calls getEvidenceChain with route query params on mount', async () => {
+    vi.mocked(useRoute).mockReturnValue({
+      query: { sourceType: 'document', sourceId: 'doc-1' },
+    } as any);
+
+    mount(AuditChainExplorer, { global: { stubs } });
+    await flushPromises();
+
+    expect(documentControlApi.getEvidenceChain).toHaveBeenCalledWith({
+      sourceType: 'document',
+      sourceId: 'doc-1',
+      maxDepth: 4,
+    });
+  });
+
+  it('source type selector shows all 6 types', () => {
+    const wrapper = mount(AuditChainExplorer, { global: { stubs } });
+    const options = wrapper.findAll('select option');
+    const values = options.map((o) => o.attributes('value'));
+    expect(values).toContain('document');
+    expect(values).toContain('record_template');
+    expect(values).toContain('record');
+    expect(values).toContain('change_event');
+    expect(values).toContain('audit_finding');
+    expect(values).toContain('corrective_action');
+    expect(values.length).toBe(6);
+  });
+
+  it('shows loading indicator while API call is pending', async () => {
+    let resolve!: (v: unknown) => void;
+    vi.mocked(documentControlApi.getEvidenceChain).mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }) as any,
+    );
+
+    vi.mocked(useRoute).mockReturnValue({
+      query: { sourceType: 'document', sourceId: 'doc-1' },
+    } as any);
+
+    const wrapper = mount(AuditChainExplorer, { global: { stubs } });
+
+    // Before resolving, loading should be visible
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('[data-testid="loading"]').exists()).toBe(true);
+
+    resolve({ data: mockChain });
+    await flushPromises();
+    expect(wrapper.find('[data-testid="loading"]').exists()).toBe(false);
+  });
+
+  it('shows error message when API rejects', async () => {
+    vi.mocked(documentControlApi.getEvidenceChain).mockRejectedValue(new Error('network error'));
+
+    vi.mocked(useRoute).mockReturnValue({
+      query: { sourceType: 'document', sourceId: 'doc-1' },
+    } as any);
+
+    const wrapper = mount(AuditChainExplorer, { global: { stubs } });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="error"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('获取证据链失败');
+  });
+
+  it('shows 下载 JSON button after chain is loaded', async () => {
+    vi.mocked(useRoute).mockReturnValue({
+      query: { sourceType: 'document', sourceId: 'doc-1' },
+    } as any);
+
+    const wrapper = mount(AuditChainExplorer, { global: { stubs } });
+    await flushPromises();
+
+    const buttons = wrapper.findAll('button');
+    const downloadBtn = buttons.find((b) => b.text().includes('下载 JSON'));
+    expect(downloadBtn).toBeDefined();
+  });
+});

--- a/client/src/views/documents/__tests__/DocumentDetail.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentDetail.spec.ts
@@ -479,4 +479,22 @@ describe('DocumentDetail', () => {
 
     expect(c.find('.markdown-editor-stub').exists()).toBe(false);
   });
+
+  it('navigates to evidence chain explorer when 查看证据链 button is clicked', async () => {
+    const c = w();
+    await flushPromises();
+
+    const evidenceChainButton = c.findAll('button').find(button => button.text() === '查看证据链');
+    expect(evidenceChainButton).toBeDefined();
+
+    await evidenceChainButton!.trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith({
+      path: '/documents/operations/audit-chain',
+      query: {
+        sourceType: 'document',
+        sourceId: 'doc-1',
+      },
+    });
+  });
 });

--- a/packages/types/document-evidence-chain.ts
+++ b/packages/types/document-evidence-chain.ts
@@ -1,0 +1,80 @@
+export type EvidenceSourceType =
+  | 'document'
+  | 'record_template'
+  | 'record'
+  | 'change_event'
+  | 'audit_finding'
+  | 'corrective_action';
+
+export type EvidenceNodeType =
+  | EvidenceSourceType
+  | 'approval_instance'
+  | 'approval_task'
+  | 'legacy_approval'
+  | 'document_reference'
+  | 'record_form_landing'
+  | 'read_requirement'
+  | 'read_confirmation'
+  | 'training_need'
+  | 'training_project'
+  | 'change_event_relation'
+  | 'change_event_form_task'
+  | 'document_impact_review'
+  | 'document_impact_item'
+  | 'verification_record'
+  | 'unknown';
+
+export type EvidenceRelationStrength = 'strong' | 'validated' | 'weak' | 'missing';
+
+export interface EvidenceNode {
+  id: string;
+  nodeId: string;
+  type: EvidenceNodeType;
+  label: string;
+  status?: string | null;
+  route?: string | null;
+  depth: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EvidenceEdge {
+  id: string;
+  source: string;
+  target: string;
+  relationType: string;
+  strength: EvidenceRelationStrength;
+  label: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface EvidenceWarning {
+  id: string;
+  severity: 'info' | 'warning' | 'danger';
+  message: string;
+  sourceNodeId?: string;
+  targetType?: string;
+  targetId?: string | null;
+  relationType?: string;
+}
+
+export interface EvidenceChainMeta {
+  sourceType: EvidenceSourceType;
+  sourceId: string;
+  maxDepth: number;
+  generatedAt: string;
+  truncated: boolean;
+}
+
+export interface EvidenceChainResult {
+  root: EvidenceNode;
+  nodes: EvidenceNode[];
+  edges: EvidenceEdge[];
+  warnings: EvidenceWarning[];
+  meta: EvidenceChainMeta;
+}
+
+export interface EvidenceChainQuery {
+  sourceType: EvidenceSourceType;
+  sourceId: string;
+  maxDepth?: number;
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -5,3 +5,4 @@ export * from './template';
 export * from './task';
 export * from './api';
 export * from './traceability';
+export * from './document-evidence-chain';

--- a/server/src/modules/document/document.controller.ts
+++ b/server/src/modules/document/document.controller.ts
@@ -16,6 +16,7 @@ import {
   FileTypeValidator,
   Req,
   Res,
+  BadRequestException,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -33,6 +34,7 @@ import { DocumentAuditCoverageService } from './services/document-audit-coverage
 import { DocumentImpactService } from './services/document-impact.service';
 import { DocumentHealthService } from './services/document-health.service';
 import { DocumentAuditChainService } from './services/document-audit-chain.service';
+import { DocumentEvidenceChainService } from './services/document-evidence-chain.service';
 import { DocumentReferenceHealthService } from './services/document-reference-health.service';
 import { CreateDocumentDto, UpdateDocumentDto, DocumentQueryDto, ArchiveDocumentDto, ObsoleteDocumentDto, ApproveDocumentDto, CreateGenericDocumentReferenceDto, WorkbenchQueryDto, WorkbenchIssueQueryDto, CreateReadRequirementDto, TrainingNeedActionDto, ImpactReviewCreateDto, ImpactItemUpdateDto, CoverageQueryDto, AuditChainQueryDto, UpdateMarkdownDto } from './dto';
 import { UpdateRecordFormLandingEntryDto } from './dto/document-control.dto';
@@ -69,6 +71,7 @@ export class DocumentController {
     private readonly impactService: DocumentImpactService,
     private readonly healthService: DocumentHealthService,
     private readonly auditChainService: DocumentAuditChainService,
+    private readonly evidenceChainService: DocumentEvidenceChainService,
     private readonly referenceHealthService: DocumentReferenceHealthService,
   ) {}
 
@@ -274,6 +277,27 @@ export class DocumentController {
   @ApiOperation({ summary: '查询审计链' })
   getAuditChain(@Query() dto: AuditChainQueryDto) {
     return this.auditChainService.getChain(dto.sourceType, dto.sourceId, dto.maxDepth ?? 4);
+  }
+
+  @Get('control/evidence-chain')
+  @ApiOperation({ summary: '证据链查询' })
+  getEvidenceChain(
+    @Query('sourceType') sourceType: string,
+    @Query('sourceId') sourceId: string,
+    @Query('maxDepth') maxDepth?: string,
+  ): Promise<any> {
+    if (!sourceType || !sourceId) {
+      throw new BadRequestException('sourceType and sourceId are required');
+    }
+    const validTypes = ['document', 'record_template', 'record', 'change_event', 'audit_finding', 'corrective_action'];
+    if (!validTypes.includes(sourceType)) {
+      throw new BadRequestException(`Unsupported sourceType: ${sourceType}`);
+    }
+    return this.evidenceChainService.getChain({
+      sourceType: sourceType as any,
+      sourceId,
+      maxDepth: maxDepth ? Number(maxDepth) : undefined,
+    });
   }
 
   @Get('reference-health/issues')

--- a/server/src/modules/document/document.module.ts
+++ b/server/src/modules/document/document.module.ts
@@ -26,6 +26,7 @@ import { DocumentAuditCoverageService } from './services/document-audit-coverage
 import { DocumentImpactService } from './services/document-impact.service';
 import { DocumentHealthService } from './services/document-health.service';
 import { DocumentAuditChainService } from './services/document-audit-chain.service';
+import { DocumentEvidenceChainService } from './services/document-evidence-chain.service';
 import { MarkdownWikilinkService } from './services/markdown-wikilink.service';
 import { DocumentReferenceHealthService } from './services/document-reference-health.service';
 import { BusinessDocumentLinkService } from './services/business-document-link.service';
@@ -40,7 +41,7 @@ import { CANONICAL_DOCUMENT_STATUS } from './constants/document-control.constant
 @Module({
   imports: [ConfigModule, PrismaModule, NotificationModule, OperationLogModule, ExportModule, DepartmentPermissionModule, StatisticsModule, UserPermissionModule, SearchModule, ModelLandingModule, UnifiedApprovalModule],
   controllers: [DocumentController],
-  providers: [DocumentService, DocumentCronService, DocumentReferenceService, MarkdownWikilinkService, DocumentReferenceHealthService, BusinessDocumentLinkService, DocumentExpiryService, DocumentLifecycleService, DocumentControlMetadataService, DocumentControlWorkbenchService, RecordFormLandingService, DocumentReadRequirementService, DocumentTrainingNeedService, DocumentAuditCoverageService, DocumentImpactService, DocumentHealthService, DocumentAuditChainService, FilePreviewService, StorageService, StatisticsCacheInterceptor, PermissionGuard, DocumentsListener],
+  providers: [DocumentService, DocumentCronService, DocumentReferenceService, MarkdownWikilinkService, DocumentReferenceHealthService, BusinessDocumentLinkService, DocumentExpiryService, DocumentLifecycleService, DocumentControlMetadataService, DocumentControlWorkbenchService, RecordFormLandingService, DocumentReadRequirementService, DocumentTrainingNeedService, DocumentAuditCoverageService, DocumentImpactService, DocumentHealthService, DocumentAuditChainService, DocumentEvidenceChainService, FilePreviewService, StorageService, StatisticsCacheInterceptor, PermissionGuard, DocumentsListener],
   exports: [DocumentService, DocumentReferenceService, DocumentLifecycleService, DocumentControlMetadataService, BusinessDocumentLinkService, DocumentExpiryService],
 })
 export class DocumentModule implements OnModuleInit {

--- a/server/src/modules/document/services/document-evidence-chain.service.spec.ts
+++ b/server/src/modules/document/services/document-evidence-chain.service.spec.ts
@@ -1,0 +1,283 @@
+import { NotFoundException } from '@nestjs/common';
+import { DocumentEvidenceChainService } from './document-evidence-chain.service';
+
+describe('DocumentEvidenceChainService', () => {
+  let service: DocumentEvidenceChainService;
+  let prisma: Record<string, any>;
+
+  beforeEach(() => {
+    prisma = {
+      document: { findUnique: jest.fn() },
+      recordFormLandingEntry: { findMany: jest.fn() },
+      recordTemplate: { findUnique: jest.fn(), findMany: jest.fn() },
+      record: { findUnique: jest.fn(), findMany: jest.fn() },
+      approvalInstance: { findMany: jest.fn() },
+      approval: { findMany: jest.fn() },
+      documentReadRequirement: { findMany: jest.fn() },
+      documentReadConfirmation: { findMany: jest.fn() },
+      documentTrainingNeed: { findMany: jest.fn() },
+      trainingProject: { findUnique: jest.fn() },
+      changeEvent: { findUnique: jest.fn() },
+      changeEventFormTask: { findMany: jest.fn() },
+      documentImpactReview: { findMany: jest.fn() },
+      changeVerificationRecord: { findMany: jest.fn() },
+      auditFinding: { findUnique: jest.fn(), findMany: jest.fn() },
+      correctiveAction: { findUnique: jest.fn(), findMany: jest.fn() },
+    };
+
+    service = new DocumentEvidenceChainService(prisma as any);
+  });
+
+  describe('Test Case 1: document root with template and records', () => {
+    it('returns root node of type document, includes record_template and record nodes', async () => {
+      prisma.document.findUnique.mockResolvedValue({
+        id: 'doc-1',
+        code: 'SOP-001',
+        title: 'Test Document',
+      });
+      prisma.recordFormLandingEntry.findMany.mockResolvedValue([
+        { id: 'landing-1', targetTemplateId: 'tmpl-1' },
+      ]);
+      prisma.recordTemplate.findUnique.mockResolvedValue({
+        id: 'tmpl-1',
+        name: 'Test Template',
+        code: 'TPL-001',
+      });
+      prisma.record.findMany.mockResolvedValue([
+        { id: 'rec-1', code: 'REC-001', status: 'submitted' },
+        { id: 'rec-2', code: 'REC-002', status: 'draft' },
+      ]);
+      prisma.approvalInstance.findMany.mockResolvedValue([]);
+      prisma.approval.findMany.mockResolvedValue([]);
+      prisma.documentReadRequirement.findMany.mockResolvedValue([]);
+      prisma.documentReadConfirmation.findMany.mockResolvedValue([]);
+      prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+      prisma.trainingProject.findUnique.mockResolvedValue(null);
+      prisma.changeEvent.findUnique.mockResolvedValue(null);
+      prisma.changeEventFormTask.findMany.mockResolvedValue([]);
+      prisma.documentImpactReview.findMany.mockResolvedValue([]);
+      prisma.changeVerificationRecord.findMany.mockResolvedValue([]);
+      prisma.auditFinding.findMany.mockResolvedValue([]);
+      prisma.correctiveAction.findMany.mockResolvedValue([]);
+
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-1',
+      });
+
+      expect(result.root).toEqual(
+        expect.objectContaining({ type: 'document' }),
+      );
+      expect(result.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'record_template' }),
+        ]),
+      );
+      expect(result.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'record' }),
+        ]),
+      );
+    });
+  });
+
+  describe('Test Case 2: document root with missing template binding', () => {
+    it('produces a warning when landing entry has no targetTemplateId', async () => {
+      prisma.document.findUnique.mockResolvedValue({
+        id: 'doc-2',
+        code: 'SOP-002',
+        title: 'No-Template Document',
+      });
+      prisma.recordFormLandingEntry.findMany.mockResolvedValue([
+        { id: 'landing-2', targetTemplateId: null },
+      ]);
+      prisma.recordTemplate.findUnique.mockResolvedValue(null);
+      prisma.recordTemplate.findMany.mockResolvedValue([]);
+      prisma.record.findMany.mockResolvedValue([]);
+      prisma.approvalInstance.findMany.mockResolvedValue([]);
+      prisma.approval.findMany.mockResolvedValue([]);
+      prisma.documentReadRequirement.findMany.mockResolvedValue([]);
+      prisma.documentReadConfirmation.findMany.mockResolvedValue([]);
+      prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+      prisma.trainingProject.findUnique.mockResolvedValue(null);
+      prisma.changeEvent.findUnique.mockResolvedValue(null);
+      prisma.changeEventFormTask.findMany.mockResolvedValue([]);
+      prisma.documentImpactReview.findMany.mockResolvedValue([]);
+      prisma.changeVerificationRecord.findMany.mockResolvedValue([]);
+      prisma.auditFinding.findMany.mockResolvedValue([]);
+      prisma.correctiveAction.findMany.mockResolvedValue([]);
+
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-2',
+      });
+
+      expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: expect.stringMatching(/template/i),
+          }),
+        ]),
+      );
+    });
+  });
+
+  describe('Test Case 3: change_event root', () => {
+    it('returns root node of type change_event and includes change_event_form_task nodes', async () => {
+      prisma.changeEvent.findUnique.mockResolvedValue({
+        id: 'ce-1',
+        title: 'Formula Change',
+        status: 'open',
+      });
+      prisma.changeEventFormTask.findMany.mockResolvedValue([
+        { id: 'task-1', changeEventId: 'ce-1', templateId: 'tmpl-2', status: 'pending' },
+        { id: 'task-2', changeEventId: 'ce-1', templateId: 'tmpl-3', status: 'completed' },
+      ]);
+      prisma.record.findMany.mockResolvedValue([
+        { id: 'rec-3', code: 'REC-003', status: 'submitted' },
+      ]);
+      prisma.documentImpactReview.findMany.mockResolvedValue([
+        { id: 'dir-1', changeEventId: 'ce-1', items: [{ id: 'item-1' }] },
+      ]);
+      prisma.changeVerificationRecord.findMany.mockResolvedValue([
+        { id: 'cvr-1', changeEventId: 'ce-1', status: 'verified' },
+      ]);
+      prisma.approvalInstance.findMany.mockResolvedValue([]);
+      prisma.document.findUnique.mockResolvedValue(null);
+      prisma.recordFormLandingEntry.findMany.mockResolvedValue([]);
+      prisma.recordTemplate.findUnique.mockResolvedValue(null);
+      prisma.recordTemplate.findMany.mockResolvedValue([]);
+      prisma.approval.findMany.mockResolvedValue([]);
+      prisma.documentReadRequirement.findMany.mockResolvedValue([]);
+      prisma.documentReadConfirmation.findMany.mockResolvedValue([]);
+      prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+      prisma.trainingProject.findUnique.mockResolvedValue(null);
+      prisma.auditFinding.findMany.mockResolvedValue([]);
+      prisma.correctiveAction.findMany.mockResolvedValue([]);
+
+      const result = await service.getChain({
+        sourceType: 'change_event',
+        sourceId: 'ce-1',
+      });
+
+      expect(result.root).toEqual(
+        expect.objectContaining({ type: 'change_event' }),
+      );
+      expect(result.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'change_event_form_task' }),
+        ]),
+      );
+    });
+  });
+
+  describe('Test Case 4: missing weak target does not throw', () => {
+    it('returns a warning and valid document node when template is not found', async () => {
+      prisma.document.findUnique.mockResolvedValue({
+        id: 'doc-3',
+        code: 'SOP-003',
+        title: 'Orphan-Template Document',
+      });
+      prisma.recordFormLandingEntry.findMany.mockResolvedValue([
+        { id: 'landing-3', targetTemplateId: 'tmpl-missing' },
+      ]);
+      prisma.recordTemplate.findUnique.mockResolvedValue(null);
+      prisma.recordTemplate.findMany.mockResolvedValue([]);
+      prisma.record.findMany.mockResolvedValue([]);
+      prisma.approvalInstance.findMany.mockResolvedValue([]);
+      prisma.approval.findMany.mockResolvedValue([]);
+      prisma.documentReadRequirement.findMany.mockResolvedValue([]);
+      prisma.documentReadConfirmation.findMany.mockResolvedValue([]);
+      prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+      prisma.trainingProject.findUnique.mockResolvedValue(null);
+      prisma.changeEvent.findUnique.mockResolvedValue(null);
+      prisma.changeEventFormTask.findMany.mockResolvedValue([]);
+      prisma.documentImpactReview.findMany.mockResolvedValue([]);
+      prisma.changeVerificationRecord.findMany.mockResolvedValue([]);
+      prisma.auditFinding.findMany.mockResolvedValue([]);
+      prisma.correctiveAction.findMany.mockResolvedValue([]);
+
+      await expect(
+        service.getChain({ sourceType: 'document', sourceId: 'doc-3' }),
+      ).resolves.not.toThrow();
+
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-3',
+      });
+
+      expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+      expect(result.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'document' }),
+        ]),
+      );
+    });
+  });
+
+  describe('Test Case 5: invalid root id throws NotFoundException', () => {
+    it('rejects with NotFoundException when document is not found', async () => {
+      prisma.document.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.getChain({ sourceType: 'document', sourceId: 'bad-id' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('Test Case 6: maxDepth clamping', () => {
+    beforeEach(() => {
+      prisma.document.findUnique.mockResolvedValue({
+        id: 'doc-4',
+        code: 'SOP-004',
+        title: 'Depth Test Document',
+      });
+      prisma.recordFormLandingEntry.findMany.mockResolvedValue([]);
+      prisma.recordTemplate.findUnique.mockResolvedValue(null);
+      prisma.recordTemplate.findMany.mockResolvedValue([]);
+      prisma.record.findMany.mockResolvedValue([]);
+      prisma.approvalInstance.findMany.mockResolvedValue([]);
+      prisma.approval.findMany.mockResolvedValue([]);
+      prisma.documentReadRequirement.findMany.mockResolvedValue([]);
+      prisma.documentReadConfirmation.findMany.mockResolvedValue([]);
+      prisma.documentTrainingNeed.findMany.mockResolvedValue([]);
+      prisma.trainingProject.findUnique.mockResolvedValue(null);
+      prisma.changeEvent.findUnique.mockResolvedValue(null);
+      prisma.changeEventFormTask.findMany.mockResolvedValue([]);
+      prisma.documentImpactReview.findMany.mockResolvedValue([]);
+      prisma.changeVerificationRecord.findMany.mockResolvedValue([]);
+      prisma.auditFinding.findMany.mockResolvedValue([]);
+      prisma.correctiveAction.findMany.mockResolvedValue([]);
+    });
+
+    it('defaults maxDepth to 4 when not provided', async () => {
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-4',
+      });
+
+      expect(result.meta.maxDepth).toBe(4);
+    });
+
+    it('clamps maxDepth above 8 down to 8', async () => {
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-4',
+        maxDepth: 100,
+      });
+
+      expect(result.meta.maxDepth).toBe(8);
+    });
+
+    it('clamps maxDepth below 1 up to 1', async () => {
+      const result = await service.getChain({
+        sourceType: 'document',
+        sourceId: 'doc-4',
+        maxDepth: 0,
+      });
+
+      expect(result.meta.maxDepth).toBe(1);
+    });
+  });
+});

--- a/server/src/modules/document/services/document-evidence-chain.service.ts
+++ b/server/src/modules/document/services/document-evidence-chain.service.ts
@@ -1,0 +1,767 @@
+import { BadRequestException, Injectable, InternalServerErrorException, NotFoundException } from '@nestjs/common';
+// Types inlined from @noidear/types to avoid workspace resolution issues
+type EvidenceSourceType =
+  | 'document'
+  | 'record_template'
+  | 'record'
+  | 'change_event'
+  | 'audit_finding'
+  | 'corrective_action';
+
+type EvidenceNodeType =
+  | EvidenceSourceType
+  | 'approval_instance'
+  | 'approval_task'
+  | 'legacy_approval'
+  | 'document_reference'
+  | 'record_form_landing'
+  | 'read_requirement'
+  | 'read_confirmation'
+  | 'training_need'
+  | 'training_project'
+  | 'change_event_relation'
+  | 'change_event_form_task'
+  | 'document_impact_review'
+  | 'document_impact_item'
+  | 'verification_record'
+  | 'unknown';
+
+type EvidenceRelationStrength = 'strong' | 'validated' | 'weak' | 'missing';
+
+interface EvidenceNode {
+  id: string;
+  nodeId: string;
+  type: EvidenceNodeType;
+  label: string;
+  status?: string | null;
+  route?: string | null;
+  depth: number;
+  metadata?: Record<string, unknown>;
+}
+
+interface EvidenceEdge {
+  id: string;
+  source: string;
+  target: string;
+  relationType: string;
+  strength: EvidenceRelationStrength;
+  label: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface EvidenceWarning {
+  id: string;
+  severity: 'info' | 'warning' | 'danger';
+  message: string;
+  sourceNodeId?: string;
+  targetType?: string;
+  targetId?: string | null;
+  relationType?: string;
+}
+
+interface EvidenceChainMeta {
+  sourceType: EvidenceSourceType;
+  sourceId: string;
+  maxDepth: number;
+  generatedAt: string;
+  truncated: boolean;
+}
+
+interface EvidenceChainResult {
+  root: EvidenceNode;
+  nodes: EvidenceNode[];
+  edges: EvidenceEdge[];
+  warnings: EvidenceWarning[];
+  meta: EvidenceChainMeta;
+}
+
+interface EvidenceChainQuery {
+  sourceType: EvidenceSourceType;
+  sourceId: string;
+  maxDepth?: number;
+}
+import { PrismaService } from '../../../prisma/prisma.service';
+
+class EvidenceChainBuilder {
+  private nodes: Map<string, EvidenceNode> = new Map();
+  private edges: Map<string, EvidenceEdge> = new Map();
+  private warnings: EvidenceWarning[] = [];
+  private _root: EvidenceNode | null = null;
+
+  constructor(
+    private readonly sourceType: EvidenceSourceType,
+    private readonly sourceId: string,
+    public readonly maxDepth: number,
+  ) {}
+
+  addNode(node: EvidenceNode): void {
+    if (!this._root) this._root = node;
+    this.nodes.set(node.nodeId, node);
+  }
+
+  setRoot(node: EvidenceNode): void {
+    this._root = node;
+    this.nodes.set(node.nodeId, node);
+  }
+
+  addEdge(edge: EvidenceEdge): void {
+    const key = `${edge.source}|${edge.target}|${edge.relationType}`;
+    this.edges.set(key, edge);
+  }
+
+  addWarning(warning: EvidenceWarning): void {
+    this.warnings = [...this.warnings, warning];
+  }
+
+  canExpand(depth: number): boolean {
+    return depth < this.maxDepth;
+  }
+
+  result(): EvidenceChainResult {
+    if (!this._root) throw new InternalServerErrorException('No root node set');
+    return {
+      root: this._root,
+      nodes: Array.from(this.nodes.values()),
+      edges: Array.from(this.edges.values()),
+      warnings: this.warnings,
+      meta: {
+        sourceType: this.sourceType,
+        sourceId: this.sourceId,
+        maxDepth: this.maxDepth,
+        generatedAt: new Date().toISOString(),
+        truncated: false,
+      },
+    };
+  }
+}
+
+@Injectable()
+export class DocumentEvidenceChainService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getChain(query: EvidenceChainQuery): Promise<EvidenceChainResult> {
+    const maxDepth = this.normalizeDepth(query.maxDepth);
+    const builder = new EvidenceChainBuilder(query.sourceType, query.sourceId, maxDepth);
+
+    switch (query.sourceType) {
+      case 'document':
+        await this.expandDocumentRoot(builder, query.sourceId);
+        break;
+      case 'record_template':
+        await this.expandRecordTemplateRoot(builder, query.sourceId);
+        break;
+      case 'record':
+        await this.expandRecordRoot(builder, query.sourceId);
+        break;
+      case 'change_event':
+        await this.expandChangeEventRoot(builder, query.sourceId);
+        break;
+      case 'audit_finding':
+        await this.expandAuditFindingRoot(builder, query.sourceId);
+        break;
+      case 'corrective_action':
+        await this.expandCorrectiveActionRoot(builder, query.sourceId);
+        break;
+      default:
+        throw new BadRequestException('Unsupported evidence source type');
+    }
+
+    return builder.result();
+  }
+
+  private normalizeDepth(maxDepth?: number): number {
+    if (maxDepth === undefined || maxDepth === null) return 4;
+    if (maxDepth > 8) return 8;
+    if (maxDepth < 1) return 1;
+    return maxDepth;
+  }
+
+  private async expandDocumentRoot(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+  ): Promise<void> {
+    const doc = await this.prisma.document.findUnique({ where: { id: documentId } });
+    if (!doc) throw new NotFoundException(`Document ${documentId} not found`);
+
+    const rootNodeId = `document:${documentId}`;
+    const rootNode: EvidenceNode = {
+      id: documentId,
+      nodeId: rootNodeId,
+      type: 'document',
+      label: doc.number ? `${doc.number} ${doc.title}` : doc.title,
+      route: `/documents/${documentId}`,
+      depth: 0,
+    };
+    builder.setRoot(rootNode);
+
+    await this.expandDocumentLandingEntries(builder, documentId, rootNodeId);
+    await this.expandDocumentReadRequirements(builder, documentId, rootNodeId);
+    await this.expandDocumentTrainingNeeds(builder, documentId, rootNodeId);
+    await this.expandDocumentApprovals(builder, documentId, rootNodeId);
+    await this.expandDocumentAuditFindings(builder, documentId, rootNodeId);
+    await this.expandDocumentImpactReviews(builder, documentId, rootNodeId);
+  }
+
+  private async expandDocumentLandingEntries(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type LandingEntry = { id: string; name?: string | null; targetTemplateId?: string | null };
+    type Template = { id: string; name?: string | null };
+    type RecordRow = { id: string; number?: string | null };
+
+    const landingEntries = await this.prisma.recordFormLandingEntry.findMany({
+      where: { relatedDocIds: { has: documentId } },
+    });
+    for (const entry of landingEntries as unknown as LandingEntry[]) {
+      const landingNodeId = `record_form_landing:${entry.id}`;
+      builder.addNode({
+        id: entry.id,
+        nodeId: landingNodeId,
+        type: 'record_form_landing',
+        label: entry.name ?? entry.id,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${landingNodeId}`,
+        source: rootNodeId,
+        target: landingNodeId,
+        relationType: 'has_landing_entry',
+        strength: 'validated',
+        label: '关联入口',
+      });
+
+      if (!entry.targetTemplateId) {
+        builder.addWarning({
+          id: `warn-landing-${entry.id}`,
+          severity: 'warning',
+          message: '记录表单入口未绑定表单template',
+          sourceNodeId: landingNodeId,
+          relationType: 'has_template',
+        });
+      } else {
+        const template = (await this.prisma.recordTemplate.findUnique({
+          where: { id: entry.targetTemplateId },
+        })) as unknown as Template | null;
+        if (!template) {
+          builder.addWarning({
+            id: `warn-template-${entry.targetTemplateId}`,
+            severity: 'warning',
+            message: `关联的表单template ${entry.targetTemplateId} 不存在`,
+            sourceNodeId: landingNodeId,
+            targetId: entry.targetTemplateId,
+            relationType: 'has_template',
+          });
+        } else {
+          const templateNodeId = `record_template:${template.id}`;
+          builder.addNode({
+            id: template.id,
+            nodeId: templateNodeId,
+            type: 'record_template',
+            label: template.name ?? template.id,
+            route: `/records/templates/${template.id}`,
+            depth: 2,
+          });
+          builder.addEdge({
+            id: `${landingNodeId}->${templateNodeId}`,
+            source: landingNodeId,
+            target: templateNodeId,
+            relationType: 'has_template',
+            strength: 'strong',
+            label: '绑定模板',
+          });
+
+          if (builder.canExpand(2)) {
+            const records = (await this.prisma.record.findMany({
+              where: { templateId: template.id },
+            })) as unknown as RecordRow[];
+            for (const rec of records) {
+              const recNodeId = `record:${rec.id}`;
+              builder.addNode({
+                id: rec.id,
+                nodeId: recNodeId,
+                type: 'record',
+                label: rec.number ?? rec.id,
+                route: `/records/${rec.id}`,
+                depth: 3,
+              });
+              builder.addEdge({
+                id: `${templateNodeId}->${recNodeId}`,
+                source: templateNodeId,
+                target: recNodeId,
+                relationType: 'has_record',
+                strength: 'validated',
+                label: '填写记录',
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private async expandDocumentReadRequirements(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type ReadReq = { id: string };
+    const readReqs = (await this.prisma.documentReadRequirement.findMany({
+      where: { documentId },
+    })) as unknown as ReadReq[];
+    for (const req of readReqs) {
+      const reqNodeId = `read_requirement:${req.id}`;
+      builder.addNode({
+        id: req.id,
+        nodeId: reqNodeId,
+        type: 'read_requirement',
+        label: '阅读要求',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${reqNodeId}`,
+        source: rootNodeId,
+        target: reqNodeId,
+        relationType: 'has_read_requirement',
+        strength: 'validated',
+        label: '阅读要求',
+      });
+    }
+  }
+
+  private async expandDocumentTrainingNeeds(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type TrainingNeed = { id: string; linkedTrainingProjectId?: string | null };
+    type TrainingProject = { id: string; title?: string | null; name?: string | null };
+
+    const trainingNeeds = (await this.prisma.documentTrainingNeed.findMany({
+      where: { documentId },
+    })) as unknown as TrainingNeed[];
+    for (const need of trainingNeeds) {
+      const needNodeId = `training_need:${need.id}`;
+      builder.addNode({
+        id: need.id,
+        nodeId: needNodeId,
+        type: 'training_need',
+        label: '培训需求',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${needNodeId}`,
+        source: rootNodeId,
+        target: needNodeId,
+        relationType: 'has_training_need',
+        strength: 'validated',
+        label: '培训需求',
+      });
+
+      if (need.linkedTrainingProjectId) {
+        const project = (await this.prisma.trainingProject.findUnique({
+          where: { id: need.linkedTrainingProjectId },
+        })) as unknown as TrainingProject | null;
+        if (project) {
+          const projectNodeId = `training_project:${project.id}`;
+          builder.addNode({
+            id: project.id,
+            nodeId: projectNodeId,
+            type: 'training_project',
+            label: project.title ?? project.name ?? project.id,
+            depth: 2,
+          });
+          builder.addEdge({
+            id: `${needNodeId}->${projectNodeId}`,
+            source: needNodeId,
+            target: projectNodeId,
+            relationType: 'linked_to',
+            strength: 'strong',
+            label: '关联培训项目',
+          });
+        }
+      }
+    }
+  }
+
+  private async expandDocumentApprovals(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type Approval = { id: string };
+    const approvals = (await this.prisma.approval.findMany({
+      where: { documentId },
+    })) as unknown as Approval[];
+    for (const appr of approvals) {
+      const apprNodeId = `legacy_approval:${appr.id}`;
+      builder.addNode({
+        id: appr.id,
+        nodeId: apprNodeId,
+        type: 'legacy_approval',
+        label: '审批记录',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${apprNodeId}`,
+        source: rootNodeId,
+        target: apprNodeId,
+        relationType: 'has_approval',
+        strength: 'validated',
+        label: '审批',
+      });
+    }
+  }
+
+  private async expandDocumentAuditFindings(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type AuditFinding = { id: string; description?: string | null };
+    const findings = (await this.prisma.auditFinding.findMany({
+      where: { documentId },
+    })) as unknown as AuditFinding[];
+    for (const finding of findings) {
+      const findingNodeId = `audit_finding:${finding.id}`;
+      builder.addNode({
+        id: finding.id,
+        nodeId: findingNodeId,
+        type: 'audit_finding',
+        label: finding.description ?? finding.id,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${findingNodeId}`,
+        source: rootNodeId,
+        target: findingNodeId,
+        relationType: 'has_audit_finding',
+        strength: 'validated',
+        label: '内审问题',
+      });
+    }
+  }
+
+  private async expandDocumentImpactReviews(
+    builder: EvidenceChainBuilder,
+    documentId: string,
+    rootNodeId: string,
+  ): Promise<void> {
+    type ImpactItem = { id: string; description?: string | null; targetLabel?: string | null };
+    type ImpactReview = { id: string; items?: ImpactItem[] | null };
+
+    const impactReviews = (await this.prisma.documentImpactReview.findMany({
+      where: { sourceType: 'document', sourceId: documentId },
+      include: { items: true },
+    })) as unknown as ImpactReview[];
+    for (const review of impactReviews) {
+      const reviewNodeId = `document_impact_review:${review.id}`;
+      builder.addNode({
+        id: review.id,
+        nodeId: reviewNodeId,
+        type: 'document_impact_review',
+        label: '文控影响评审',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${reviewNodeId}`,
+        source: rootNodeId,
+        target: reviewNodeId,
+        relationType: 'has_impact_review',
+        strength: 'validated',
+        label: '影响评审',
+      });
+
+      for (const item of review.items ?? []) {
+        const itemNodeId = `document_impact_item:${item.id}`;
+        builder.addNode({
+          id: item.id,
+          nodeId: itemNodeId,
+          type: 'document_impact_item',
+          label: item.description ?? item.targetLabel ?? item.id,
+          depth: 2,
+        });
+        builder.addEdge({
+          id: `${reviewNodeId}->${itemNodeId}`,
+          source: reviewNodeId,
+          target: itemNodeId,
+          relationType: 'has_item',
+          strength: 'validated',
+          label: '影响项',
+        });
+      }
+    }
+  }
+
+  private async expandChangeEventRoot(
+    builder: EvidenceChainBuilder,
+    changeEventId: string,
+  ): Promise<void> {
+    const event = await this.prisma.changeEvent.findUnique({ where: { id: changeEventId } });
+    if (!event) throw new NotFoundException(`ChangeEvent ${changeEventId} not found`);
+
+    const rootNodeId = `change_event:${changeEventId}`;
+    builder.setRoot({
+      id: changeEventId,
+      nodeId: rootNodeId,
+      type: 'change_event',
+      label: event.description ?? changeEventId,
+      route: `/change-events/${changeEventId}`,
+      depth: 0,
+    });
+
+    type FormTask = { id: string; title?: string | null; name?: string | null };
+    type RecordRow = { id: string; number?: string | null };
+    type ImpactItem = { id: string; description?: string | null; targetLabel?: string | null };
+    type ImpactReview = { id: string; items?: ImpactItem[] | null };
+    type VerificationRecord = { id: string };
+    type ApprovalInstance = { id: string };
+
+    // Form tasks
+    const formTasks = (await this.prisma.changeEventFormTask.findMany({
+      where: { changeEventId },
+    })) as unknown as FormTask[];
+    for (const task of formTasks) {
+      const taskNodeId = `change_event_form_task:${task.id}`;
+      builder.addNode({
+        id: task.id,
+        nodeId: taskNodeId,
+        type: 'change_event_form_task',
+        label: task.title ?? task.name ?? task.id,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${taskNodeId}`,
+        source: rootNodeId,
+        target: taskNodeId,
+        relationType: 'has_form_task',
+        strength: 'validated',
+        label: '表单任务',
+      });
+    }
+
+    // Records by changeEventId
+    const records = (await this.prisma.record.findMany({
+      where: { changeEventId },
+    })) as unknown as RecordRow[];
+    for (const rec of records) {
+      const recNodeId = `record:${rec.id}`;
+      builder.addNode({
+        id: rec.id,
+        nodeId: recNodeId,
+        type: 'record',
+        label: rec.number ?? rec.id,
+        route: `/records/${rec.id}`,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${recNodeId}`,
+        source: rootNodeId,
+        target: recNodeId,
+        relationType: 'has_record',
+        strength: 'validated',
+        label: '关联记录',
+      });
+    }
+
+    // Impact reviews
+    const impactReviews = (await this.prisma.documentImpactReview.findMany({
+      where: { changeEventId },
+      include: { items: true },
+    })) as unknown as ImpactReview[];
+    for (const review of impactReviews) {
+      const reviewNodeId = `document_impact_review:${review.id}`;
+      builder.addNode({
+        id: review.id,
+        nodeId: reviewNodeId,
+        type: 'document_impact_review',
+        label: '文控影响评审',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${reviewNodeId}`,
+        source: rootNodeId,
+        target: reviewNodeId,
+        relationType: 'has_impact_review',
+        strength: 'validated',
+        label: '影响评审',
+      });
+      for (const item of review.items ?? []) {
+        const itemNodeId = `document_impact_item:${item.id}`;
+        builder.addNode({
+          id: item.id,
+          nodeId: itemNodeId,
+          type: 'document_impact_item',
+          label: item.description ?? item.targetLabel ?? item.id,
+          depth: 2,
+        });
+        builder.addEdge({
+          id: `${reviewNodeId}->${itemNodeId}`,
+          source: reviewNodeId,
+          target: itemNodeId,
+          relationType: 'has_item',
+          strength: 'validated',
+          label: '影响项',
+        });
+      }
+    }
+
+    // Verification records
+    const verifications = (await this.prisma.changeVerificationRecord.findMany({
+      where: { change_event_id: changeEventId },
+    })) as unknown as VerificationRecord[];
+    for (const v of verifications) {
+      const vNodeId = `verification_record:${v.id}`;
+      builder.addNode({
+        id: v.id,
+        nodeId: vNodeId,
+        type: 'verification_record',
+        label: '验证记录',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${vNodeId}`,
+        source: rootNodeId,
+        target: vNodeId,
+        relationType: 'has_verification',
+        strength: 'validated',
+        label: '验证记录',
+      });
+    }
+
+    // Approval instances
+    const approvalInstances = (await this.prisma.approvalInstance.findMany({
+      where: { resourceType: 'change_event', resourceId: changeEventId },
+    })) as unknown as ApprovalInstance[];
+    for (const inst of approvalInstances) {
+      const instNodeId = `approval_instance:${inst.id}`;
+      builder.addNode({
+        id: inst.id,
+        nodeId: instNodeId,
+        type: 'approval_instance',
+        label: '审批实例',
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${instNodeId}`,
+        source: rootNodeId,
+        target: instNodeId,
+        relationType: 'has_approval',
+        strength: 'validated',
+        label: '审批',
+      });
+    }
+  }
+
+  private async expandRecordTemplateRoot(
+    builder: EvidenceChainBuilder,
+    templateId: string,
+  ): Promise<void> {
+    const template = await this.prisma.recordTemplate.findUnique({ where: { id: templateId } });
+    if (!template) throw new NotFoundException(`RecordTemplate ${templateId} not found`);
+    type RecordRow = { id: string; number?: string | null };
+    const rootNodeId = `record_template:${templateId}`;
+    builder.setRoot({
+      id: templateId,
+      nodeId: rootNodeId,
+      type: 'record_template',
+      label: template.name ?? templateId,
+      route: `/records/templates/${templateId}`,
+      depth: 0,
+    });
+    const records = (await this.prisma.record.findMany({ where: { templateId } })) as unknown as RecordRow[];
+    for (const rec of records) {
+      const recNodeId = `record:${rec.id}`;
+      builder.addNode({
+        id: rec.id,
+        nodeId: recNodeId,
+        type: 'record',
+        label: rec.number ?? rec.id,
+        route: `/records/${rec.id}`,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${recNodeId}`,
+        source: rootNodeId,
+        target: recNodeId,
+        relationType: 'has_record',
+        strength: 'validated',
+        label: '填写记录',
+      });
+    }
+  }
+
+  private async expandRecordRoot(
+    builder: EvidenceChainBuilder,
+    recordId: string,
+  ): Promise<void> {
+    const rec = await this.prisma.record.findUnique({ where: { id: recordId } });
+    if (!rec) throw new NotFoundException(`Record ${recordId} not found`);
+    const rootNodeId = `record:${recordId}`;
+    builder.setRoot({
+      id: recordId,
+      nodeId: rootNodeId,
+      type: 'record',
+      label: rec.number ?? recordId,
+      route: `/records/${recordId}`,
+      depth: 0,
+    });
+  }
+
+  private async expandAuditFindingRoot(
+    builder: EvidenceChainBuilder,
+    auditFindingId: string,
+  ): Promise<void> {
+    const finding = await this.prisma.auditFinding.findUnique({ where: { id: auditFindingId } });
+    if (!finding) throw new NotFoundException(`AuditFinding ${auditFindingId} not found`);
+    type CorrectiveActionRow = { id: string; description?: string | null };
+    const rootNodeId = `audit_finding:${auditFindingId}`;
+    builder.setRoot({
+      id: auditFindingId,
+      nodeId: rootNodeId,
+      type: 'audit_finding',
+      label: finding.description ?? auditFindingId,
+      depth: 0,
+    });
+    const actions = (await this.prisma.correctiveAction.findMany({
+      where: { trigger_type: 'internal_audit', trigger_id: auditFindingId },
+    })) as unknown as CorrectiveActionRow[];
+    for (const action of actions) {
+      const actionNodeId = `corrective_action:${action.id}`;
+      builder.addNode({
+        id: action.id,
+        nodeId: actionNodeId,
+        type: 'corrective_action',
+        label: action.description ?? action.id,
+        depth: 1,
+      });
+      builder.addEdge({
+        id: `${rootNodeId}->${actionNodeId}`,
+        source: rootNodeId,
+        target: actionNodeId,
+        relationType: 'has_corrective_action',
+        strength: 'validated',
+        label: '整改动作',
+      });
+    }
+  }
+
+  private async expandCorrectiveActionRoot(
+    builder: EvidenceChainBuilder,
+    correctiveActionId: string,
+  ): Promise<void> {
+    const action = await this.prisma.correctiveAction.findUnique({
+      where: { id: correctiveActionId },
+    });
+    if (!action) throw new NotFoundException(`CorrectiveAction ${correctiveActionId} not found`);
+    const rootNodeId = `corrective_action:${correctiveActionId}`;
+    builder.setRoot({
+      id: correctiveActionId,
+      nodeId: rootNodeId,
+      type: 'corrective_action',
+      label: action.description ?? correctiveActionId,
+      depth: 0,
+    });
+  }
+}

--- a/server/src/modules/document/services/document-evidence-chain.service.ts
+++ b/server/src/modules/document/services/document-evidence-chain.service.ts
@@ -260,7 +260,7 @@ export class DocumentEvidenceChainService {
             nodeId: templateNodeId,
             type: 'record_template',
             label: template.name ?? template.id,
-            route: `/records/templates/${template.id}`,
+            route: null,
             depth: 2,
           });
           builder.addEdge({
@@ -507,7 +507,7 @@ export class DocumentEvidenceChainService {
       nodeId: rootNodeId,
       type: 'change_event',
       label: event.description ?? changeEventId,
-      route: `/change-events/${changeEventId}`,
+      route: null,
       depth: 0,
     });
 
@@ -667,7 +667,7 @@ export class DocumentEvidenceChainService {
       nodeId: rootNodeId,
       type: 'record_template',
       label: template.name ?? templateId,
-      route: `/records/templates/${templateId}`,
+      route: null,
       depth: 0,
     });
     const records = (await this.prisma.record.findMany({ where: { templateId } })) as unknown as RecordRow[];
@@ -696,7 +696,14 @@ export class DocumentEvidenceChainService {
     builder: EvidenceChainBuilder,
     recordId: string,
   ): Promise<void> {
-    const rec = await this.prisma.record.findUnique({ where: { id: recordId } });
+    type RecordRow = {
+      id: string;
+      number?: string | null;
+      templateId?: string | null;
+      changeEventId?: string | null;
+      approvalInstanceId?: string | null;
+    };
+    const rec = (await this.prisma.record.findUnique({ where: { id: recordId } })) as unknown as RecordRow | null;
     if (!rec) throw new NotFoundException(`Record ${recordId} not found`);
     const rootNodeId = `record:${recordId}`;
     builder.setRoot({
@@ -707,6 +714,36 @@ export class DocumentEvidenceChainService {
       route: `/records/${recordId}`,
       depth: 0,
     });
+
+    if (rec.templateId) {
+      type TemplateRow = { id: string; name?: string | null };
+      const template = (await this.prisma.recordTemplate.findUnique({
+        where: { id: rec.templateId },
+      })) as unknown as TemplateRow | null;
+      if (template) {
+        const tmplNodeId = `record_template:${template.id}`;
+        builder.addNode({ id: template.id, nodeId: tmplNodeId, type: 'record_template', label: template.name ?? template.id, route: null, depth: 1 });
+        builder.addEdge({ id: `${rootNodeId}->${tmplNodeId}`, source: rootNodeId, target: tmplNodeId, relationType: 'from_template', strength: 'strong', label: '所属模板' });
+      }
+    }
+
+    if (rec.changeEventId) {
+      type ChangeEventRow = { id: string; title?: string | null };
+      const event = (await this.prisma.changeEvent.findUnique({
+        where: { id: rec.changeEventId },
+      })) as unknown as ChangeEventRow | null;
+      if (event) {
+        const evtNodeId = `change_event:${event.id}`;
+        builder.addNode({ id: event.id, nodeId: evtNodeId, type: 'change_event', label: event.title ?? event.id, route: null, depth: 1 });
+        builder.addEdge({ id: `${rootNodeId}->${evtNodeId}`, source: rootNodeId, target: evtNodeId, relationType: 'triggered_by', strength: 'validated', label: '关联变更事件' });
+      }
+    }
+
+    if (rec.approvalInstanceId) {
+      const instNodeId = `approval_instance:${rec.approvalInstanceId}`;
+      builder.addNode({ id: rec.approvalInstanceId, nodeId: instNodeId, type: 'approval_instance', label: '审批实例', depth: 1 });
+      builder.addEdge({ id: `${rootNodeId}->${instNodeId}`, source: rootNodeId, target: instNodeId, relationType: 'has_approval', strength: 'validated', label: '审批' });
+    }
   }
 
   private async expandAuditFindingRoot(
@@ -751,9 +788,16 @@ export class DocumentEvidenceChainService {
     builder: EvidenceChainBuilder,
     correctiveActionId: string,
   ): Promise<void> {
-    const action = await this.prisma.correctiveAction.findUnique({
+    type CorrectiveActionRow = {
+      id: string;
+      description?: string | null;
+      trigger_type?: string | null;
+      trigger_id?: string | null;
+      approvalInstanceId?: string | null;
+    };
+    const action = (await this.prisma.correctiveAction.findUnique({
       where: { id: correctiveActionId },
-    });
+    })) as unknown as CorrectiveActionRow | null;
     if (!action) throw new NotFoundException(`CorrectiveAction ${correctiveActionId} not found`);
     const rootNodeId = `corrective_action:${correctiveActionId}`;
     builder.setRoot({
@@ -763,5 +807,35 @@ export class DocumentEvidenceChainService {
       label: action.description ?? correctiveActionId,
       depth: 0,
     });
+
+    if (action.trigger_type === 'internal_audit' && action.trigger_id) {
+      type AuditFindingRow = { id: string; description?: string | null };
+      const finding = (await this.prisma.auditFinding.findUnique({
+        where: { id: action.trigger_id },
+      })) as unknown as AuditFindingRow | null;
+      if (finding) {
+        const findingNodeId = `audit_finding:${finding.id}`;
+        builder.addNode({ id: finding.id, nodeId: findingNodeId, type: 'audit_finding', label: finding.description ?? finding.id, depth: 1 });
+        builder.addEdge({ id: `${rootNodeId}->${findingNodeId}`, source: rootNodeId, target: findingNodeId, relationType: 'triggered_by', strength: 'strong', label: '来源内审问题' });
+      } else {
+        builder.addWarning({ id: `warn-finding-${action.trigger_id}`, severity: 'warning', message: `关联内审问题 ${action.trigger_id} 不存在`, sourceNodeId: rootNodeId, targetId: action.trigger_id });
+      }
+    }
+
+    if (action.approvalInstanceId) {
+      const instNodeId = `approval_instance:${action.approvalInstanceId}`;
+      builder.addNode({ id: action.approvalInstanceId, nodeId: instNodeId, type: 'approval_instance', label: '审批实例', depth: 1 });
+      builder.addEdge({ id: `${rootNodeId}->${instNodeId}`, source: rootNodeId, target: instNodeId, relationType: 'has_approval', strength: 'validated', label: '审批' });
+    }
+
+    type VerificationRow = { id: string; result?: string | null };
+    const verifications = (await this.prisma.verificationRecord.findMany({
+      where: { corrective_action_id: correctiveActionId },
+    })) as unknown as VerificationRow[];
+    for (const v of verifications) {
+      const vNodeId = `verification_record:${v.id}`;
+      builder.addNode({ id: v.id, nodeId: vNodeId, type: 'verification_record', label: `验证记录 ${v.result ?? ''}`.trim(), depth: 1 });
+      builder.addEdge({ id: `${rootNodeId}->${vNodeId}`, source: rootNodeId, target: vNodeId, relationType: 'has_verification', strength: 'validated', label: '验证记录' });
+    }
   }
 }


### PR DESCRIPTION
## Summary

- 新增共享类型合约 `packages/types/document-evidence-chain.ts`，定义 `EvidenceChainResult`、`EvidenceNode`、`EvidenceEdge`、`EvidenceWarning` 等完整接口
- 新增后端服务 `DocumentEvidenceChainService`，支持从 6 种来源类型（document、record_template、record、change_event、audit_finding、corrective_action）构建证据链图
- 新增 `GET /documents/control/evidence-chain` API 端点，含输入校验，弱引用缺失返回警告而非 500
- 新增 `EvidenceChainGraph.vue` 前端组件，按深度分组展示节点、关系和警告
- 升级 `AuditChainExplorer.vue` 为"证据链"视角，支持来源类型选择、下载 JSON、复制摘要
- `DocumentDetail.vue` 新增"查看证据链"入口按钮

## Test Plan

- [x] 服务端：`document-evidence-chain.service.spec.ts` — 8 tests pass（document root、change_event root、弱引用缺失警告、invalid id NotFoundException、maxDepth clamping）
- [x] 客户端：`EvidenceChainGraph.spec.ts` — 6 tests pass
- [x] 客户端：`AuditChainExplorer.spec.ts` — 6 tests pass
- [x] 客户端：`DocumentDetail.spec.ts` — 27 tests pass（含新增证据链按钮测试）
- [x] Server build passes
- [x] Client build passes
- [x] `control/audit-chain` 原有端点保持兼容

## Deferred Work

- PDF/Excel 导出
- 更深层的追溯召回图（recall graph）