### PR TITLE
feat: markdown wikilink click navigation

### DIFF
--- a/client/src/api/document-control.ts
+++ b/client/src/api/document-control.ts
@@ -40,8 +40,10 @@ export interface DocumentReference {
   targetRoute?: string | null;
   targetLabel?: string | null;
   relationType: string;
-  targetDoc?: { id: string; title: string; status: string } | null;
-  sourceDoc?: { id: string; title: string; status: string } | null;
+  sectionId?: string | null;
+  wikilinkTarget?: string | null;
+  targetDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+  sourceDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
 }
 
 export type ReferenceHealthStatus = 'healthy' | 'dangling' | 'invalid' | 'conflict' | 'superseded';

--- a/client/src/components/documents/MarkdownViewer.spec.ts
+++ b/client/src/components/documents/MarkdownViewer.spec.ts
@@ -108,4 +108,39 @@ const status = 'ok';
     expect(wrapper.find('p code').text()).toContain('[[inline-ref]]');
     expect(wrapper.find('pre code').text()).toContain('[[fenced-ref|别名]]');
   });
+
+  it('emits wikilink-click with the data target when a wikilink is clicked', async () => {
+    const wrapper = mountMarkdown('参考 [[GRSS-CX-01|文件控制程序]]');
+
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(wrapper.emitted('wikilink-click')).toEqual([['GRSS-CX-01']]);
+  });
+
+  it('does not emit wikilink-click when plain text is clicked', async () => {
+    const wrapper = mountMarkdown('这里只是普通正文');
+
+    await wrapper.find('.markdown-viewer').trigger('click');
+
+    expect(wrapper.emitted('wikilink-click')).toBeUndefined();
+  });
+
+  it('applies wikilink status classes by target', () => {
+    const wrapper = mount(MarkdownViewer, {
+      props: {
+        content: '[[正常文件]] [[缺失文件]] [[重复文件]] [[未知文件]]',
+        wikilinkStatusByTarget: {
+          正常文件: 'resolved',
+          缺失文件: 'dangling',
+          重复文件: 'conflict',
+        },
+      },
+    });
+
+    const links = wrapper.findAll('.wikilink');
+    expect(links[0].classes()).toContain('wikilink-resolved');
+    expect(links[1].classes()).toContain('wikilink-dangling');
+    expect(links[2].classes()).toContain('wikilink-conflict');
+    expect(links[3].classes()).toContain('wikilink-unknown');
+  });
 });

--- a/client/src/components/documents/MarkdownViewer.vue
+++ b/client/src/components/documents/MarkdownViewer.vue
@@ -1,14 +1,31 @@
 <template>
-  <article class="markdown-viewer" v-html="html" />
+  <article class="markdown-viewer" v-html="html" @click="handleClick" />
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { renderMarkdown } from './markdown-renderer';
+import { renderMarkdown, type WikilinkStatus } from './markdown-renderer';
 
-const props = defineProps<{ content: string }>();
+const props = defineProps<{
+  content: string;
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}>();
 
-const html = computed(() => renderMarkdown(props.content));
+const emit = defineEmits<{
+  (event: 'wikilink-click', target: string): void;
+}>();
+
+const html = computed(() => renderMarkdown(props.content, {
+  wikilinkStatusByTarget: props.wikilinkStatusByTarget,
+}));
+
+const handleClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement | null;
+  const link = target?.closest?.('.wikilink') as HTMLElement | null;
+  const wikilinkTarget = link?.dataset?.target;
+  if (!wikilinkTarget) return;
+  emit('wikilink-click', wikilinkTarget);
+};
 </script>
 
 <style scoped>
@@ -184,10 +201,32 @@ const html = computed(() => renderMarkdown(props.content));
 }
 
 .markdown-viewer :deep(.wikilink) {
-  background: #eef6ff;
   border-radius: 4px;
-  color: #1677d2;
+  cursor: pointer;
   font-weight: 600;
   padding: 0 3px;
+}
+
+.markdown-viewer :deep(.wikilink-resolved) {
+  background: #eef6ff;
+  color: #1677d2;
+}
+
+.markdown-viewer :deep(.wikilink-dangling) {
+  background: #fff2f0;
+  color: #cf1322;
+  text-decoration: underline dotted;
+}
+
+.markdown-viewer :deep(.wikilink-conflict) {
+  background: #fff7e6;
+  color: #ad6800;
+  text-decoration: underline wavy;
+}
+
+.markdown-viewer :deep(.wikilink-unknown) {
+  background: #f5f7fa;
+  color: #606266;
+  text-decoration: underline dotted;
 }
 </style>

--- a/client/src/components/documents/markdown-renderer.ts
+++ b/client/src/components/documents/markdown-renderer.ts
@@ -9,6 +9,12 @@ const markdown = new MarkdownIt({
 
 const CALLOUT_TYPES = new Set(['note', 'info', 'tip', 'warning', 'danger']);
 
+export type WikilinkStatus = 'resolved' | 'dangling' | 'conflict' | 'unknown';
+
+export interface RenderMarkdownOptions {
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}
+
 const escapeAttribute = (value: string) =>
   value
     .replace(/&/g, '&amp;')
@@ -51,7 +57,7 @@ const enhanceTaskLists = (html: string) =>
       '<li class="task-list-item"><p><input class="task-list-item-checkbox" type="checkbox" checked disabled> ',
     );
 
-const enhanceWikilinks = (html: string) => {
+const enhanceWikilinks = (html: string, options: RenderMarkdownOptions = {}) => {
   const codeBlocks: string[] = [];
   const guarded = html.replace(/<code[^>]*>[\s\S]*?<\/code>/g, (match) => {
     codeBlocks.push(match);
@@ -63,7 +69,8 @@ const enhanceWikilinks = (html: string) => {
     (_match, rawTarget: string, rawLabel?: string) => {
       const target = rawTarget.trim();
       const label = (rawLabel || rawTarget).trim();
-      return `<span class="wikilink" data-target="${escapeAttribute(target)}">${label}</span>`;
+      const status = options.wikilinkStatusByTarget?.[target] || 'unknown';
+      return `<span class="wikilink wikilink-${escapeAttribute(status)}" data-target="${escapeAttribute(target)}">${label}</span>`;
     },
   );
 
@@ -89,9 +96,9 @@ const enhanceCallouts = (html: string) =>
     },
   );
 
-export const renderMarkdown = (content: string) => {
+export const renderMarkdown = (content: string, options: RenderMarkdownOptions = {}) => {
   const withoutFrontmatter = stripFrontmatter(content);
   const rendered = markdown.render(withoutFrontmatter);
 
-  return enhanceWikilinks(enhanceTaskLists(enhanceCallouts(rendered)));
+  return enhanceWikilinks(enhanceTaskLists(enhanceCallouts(rendered)), options);
 };

--- a/client/src/views/documents/DocumentDetail.vue
+++ b/client/src/views/documents/DocumentDetail.vue
@@ -818,9 +818,12 @@ const wikilinkStatusByTarget = computed(() => {
     const target = wikilinkReferenceTarget(ref);
     if (target) statusMap[target] = 'resolved';
   }
-  for (const issue of referenceHealthIssues.value) {
-    if (issue.status === 'dangling') statusMap[issue.label] = 'dangling';
-    if (issue.status === 'conflict') statusMap[issue.label] = 'conflict';
+  for (const ref of sourceReferences.value) {
+    if (ref.relationType !== 'WIKILINK') continue;
+    const target = wikilinkReferenceTarget(ref);
+    if (!target) continue;
+    if (ref.targetType === 'unresolved_document') statusMap[target] = 'dangling';
+    if (ref.targetType === 'conflict_document') statusMap[target] = 'conflict';
   }
 
   return statusMap;
@@ -851,20 +854,28 @@ const handleMarkdownWikilinkClick = (target: string) => {
     return;
   }
 
-  const dangling = referenceHealthIssues.value.find(
-    (issue) => issue.status === 'dangling' && issue.label === normalizedTarget,
+  const danglingRef = sourceReferences.value.find(
+    (ref) => ref.relationType === 'WIKILINK' &&
+             ref.targetType === 'unresolved_document' &&
+             wikilinkReferenceTarget(ref) === normalizedTarget,
   );
-  if (dangling) {
-    handleReferenceHealthIssue(dangling);
+  if (danglingRef) {
+    const issue = referenceHealthIssues.value.find((i) => i.referenceId === danglingRef.id);
+    if (issue) handleReferenceHealthIssue(issue);
+    else activeReferenceLabel.value = normalizedTarget;
     ElMessage.warning('引用未解析，请在引用关系中处理。');
     return;
   }
 
-  const conflict = referenceHealthIssues.value.find(
-    (issue) => issue.status === 'conflict' && issue.label === normalizedTarget,
+  const conflictRef = sourceReferences.value.find(
+    (ref) => ref.relationType === 'WIKILINK' &&
+             ref.targetType === 'conflict_document' &&
+             wikilinkReferenceTarget(ref) === normalizedTarget,
   );
-  if (conflict) {
-    handleReferenceHealthIssue(conflict);
+  if (conflictRef) {
+    const issue = referenceHealthIssues.value.find((i) => i.referenceId === conflictRef.id);
+    if (issue) handleReferenceHealthIssue(issue);
+    else expandedConflictReferenceId.value = conflictRef.id;
     ElMessage.warning('引用存在多个候选，请选择正确目标。');
     return;
   }

--- a/client/src/views/documents/DocumentDetail.vue
+++ b/client/src/views/documents/DocumentDetail.vue
@@ -182,6 +182,8 @@
       <MarkdownViewer
         v-else
         :content="document.content_md"
+        :wikilink-status-by-target="wikilinkStatusByTarget"
+        @wikilink-click="handleMarkdownWikilinkClick"
       />
     </el-card>
 
@@ -434,11 +436,14 @@ interface DocumentReference {
   sourceDocId?: string;
   relationType: string;
   targetType?: string;
+  targetDocId?: string | null;
   targetLabel?: string;
   targetRoute?: string;
   targetId?: string;
-  targetDoc?: { id: string; title: string; status: string } | null;
-  sourceDoc?: { id: string; title: string; status: string } | null;
+  sectionId?: string | null;
+  wikilinkTarget?: string | null;
+  targetDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+  sourceDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
   snapshot?: {
     candidates?: Array<{ id: string; title?: string | null; number?: string | null; doc_code?: string | null }>;
   } | null;
@@ -795,6 +800,76 @@ const saveMarkdown = async () => {
   } finally {
     savingMarkdown.value = false;
   }
+};
+
+const wikilinkLegacyTarget = (ref: DocumentReference): string | null => (
+  ref.sectionId?.startsWith('wikilink:') ? ref.sectionId.slice('wikilink:'.length) : null
+);
+
+const wikilinkReferenceTarget = (ref: DocumentReference): string | null => (
+  ref.wikilinkTarget || wikilinkLegacyTarget(ref) || ref.targetLabel || null
+);
+
+const wikilinkStatusByTarget = computed(() => {
+  const statusMap: Record<string, 'resolved' | 'dangling' | 'conflict' | 'unknown'> = {};
+
+  for (const ref of outboundReferences.value) {
+    if (ref.relationType !== 'WIKILINK' || !ref.targetDocId) continue;
+    const target = wikilinkReferenceTarget(ref);
+    if (target) statusMap[target] = 'resolved';
+  }
+  for (const issue of referenceHealthIssues.value) {
+    if (issue.status === 'dangling') statusMap[issue.label] = 'dangling';
+    if (issue.status === 'conflict') statusMap[issue.label] = 'conflict';
+  }
+
+  return statusMap;
+});
+
+const findResolvedWikilinkReference = (target: string): DocumentReference | undefined => (
+  outboundReferences.value.find((ref) =>
+    ref.relationType === 'WIKILINK' &&
+    Boolean(ref.targetDocId) &&
+    (
+      ref.wikilinkTarget === target ||
+      ref.sectionId === `wikilink:${target}` ||
+      ref.targetLabel === target ||
+      ref.targetDoc?.number === target ||
+      ref.targetDoc?.doc_code === target ||
+      ref.targetDoc?.title === target
+    ),
+  )
+);
+
+const handleMarkdownWikilinkClick = (target: string) => {
+  const normalizedTarget = target.trim();
+  if (!normalizedTarget) return;
+
+  const resolved = findResolvedWikilinkReference(normalizedTarget);
+  if (resolved?.targetDocId) {
+    router.push(`/documents/${resolved.targetDocId}`);
+    return;
+  }
+
+  const dangling = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'dangling' && issue.label === normalizedTarget,
+  );
+  if (dangling) {
+    handleReferenceHealthIssue(dangling);
+    ElMessage.warning('引用未解析，请在引用关系中处理。');
+    return;
+  }
+
+  const conflict = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'conflict' && issue.label === normalizedTarget,
+  );
+  if (conflict) {
+    handleReferenceHealthIssue(conflict);
+    ElMessage.warning('引用存在多个候选，请选择正确目标。');
+    return;
+  }
+
+  ElMessage.warning('未找到该引用的解析结果，请保存正文后刷新引用关系。');
 };
 
 const handleReferenceHealthIssue = (issue: DocumentReferenceHealthIssue) => {

--- a/client/src/views/documents/__tests__/DocumentDetail.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentDetail.spec.ts
@@ -512,6 +512,81 @@ describe('DocumentDetail', () => {
     expect(ElMessage.warning).toHaveBeenCalledWith('引用存在多个候选，请选择正确目标。');
   });
 
+  it('shows alias dangling wikilink as wikilink-dangling and handles click', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 1, invalid: 0, conflict: 0, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-alias-dangling', label: '显示名', status: 'dangling', reason: '引用文本未匹配到受控文件。' },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[缺失编号|显示名]]',
+        sourceReferences: [
+          {
+            id: 'ref-alias-dangling',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'unresolved_document',
+            targetLabel: '显示名',
+            wikilinkTarget: '缺失编号',
+            sectionId: 'wikilink:缺失编号',
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+
+    expect(wrapper.find('.wikilink').classes()).toContain('wikilink-dangling');
+
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用未解析，请在引用关系中处理。');
+  });
+
+  it('shows alias conflict wikilink as wikilink-conflict and handles click', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 0, invalid: 0, conflict: 1, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-alias-conflict', label: '显示名', status: 'conflict', reason: '引用文本匹配到多个候选文件。', candidates: [{ id: 'doc-x', title: '冲突文件A' }] },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[冲突编号|显示名]]',
+        sourceReferences: [
+          {
+            id: 'ref-alias-conflict',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'conflict_document',
+            targetLabel: '显示名',
+            wikilinkTarget: '冲突编号',
+            sectionId: 'wikilink:冲突编号',
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+
+    expect(wrapper.find('.wikilink').classes()).toContain('wikilink-conflict');
+
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).expandedConflictReferenceId).toBe('ref-alias-conflict');
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用存在多个候选，请选择正确目标。');
+  });
+
   it('passes resolved dangling and conflict wikilink status to MarkdownViewer', async () => {
     mockGetReferenceHealth.mockResolvedValue({
       totals: { total: 3, healthy: 1, dangling: 1, invalid: 0, conflict: 1, superseded: 0 },

--- a/client/src/views/documents/__tests__/DocumentDetail.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentDetail.spec.ts
@@ -384,6 +384,163 @@ describe('DocumentDetail', () => {
     expect(c.find('.markdown-viewer').text()).toContain('这是 Markdown 正文');
   });
 
+  it('routes resolved markdown wikilinks to the target document', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[GRSS-CX-01|文件控制程序]]',
+        sourceReferences: [
+          {
+            id: 'ref-resolved',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'document',
+            targetDocId: 'doc-2',
+            targetId: 'doc-2',
+            targetLabel: '文件控制程序',
+            wikilinkTarget: 'GRSS-CX-01',
+            sectionId: 'wikilink:GRSS-CX-01',
+            targetDoc: { id: 'doc-2', title: '文件控制程序', number: 'GRSS-CX-01', doc_code: null, status: 'effective' },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/documents/doc-2');
+  });
+
+  it('uses legacy sectionId to route old resolved wikilinks', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[旧文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-legacy',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'document',
+            targetDocId: 'doc-legacy',
+            targetId: 'doc-legacy',
+            targetLabel: '旧文件',
+            sectionId: 'wikilink:旧文件',
+            targetDoc: { id: 'doc-legacy', title: '旧文件', status: 'effective' },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/documents/doc-legacy');
+  });
+
+  it('warns and locates dangling markdown wikilinks without navigating', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 1, invalid: 0, conflict: 0, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-dangling', label: '缺失文件', status: 'dangling', reason: '引用文本未匹配到受控文件。' },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[缺失文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-dangling',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'unresolved_document',
+            targetLabel: '缺失文件',
+            wikilinkTarget: '缺失文件',
+            sectionId: 'wikilink:缺失文件',
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).activeReferenceLabel).toBe('缺失文件');
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用未解析，请在引用关系中处理。');
+  });
+
+  it('warns and expands conflict markdown wikilinks without navigating', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 0, invalid: 0, conflict: 1, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-conflict', label: '重复文件', status: 'conflict', reason: '引用文本匹配到多个候选文件。', candidates: [{ id: 'doc-a', title: '重复文件' }] },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[重复文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-conflict',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'conflict_document',
+            targetLabel: '重复文件',
+            wikilinkTarget: '重复文件',
+            sectionId: 'wikilink:重复文件',
+            snapshot: { candidates: [{ id: 'doc-a', title: '重复文件' }] },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).expandedConflictReferenceId).toBe('ref-conflict');
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用存在多个候选，请选择正确目标。');
+  });
+
+  it('passes resolved dangling and conflict wikilink status to MarkdownViewer', async () => {
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 3, healthy: 1, dangling: 1, invalid: 0, conflict: 1, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-dangling', label: '缺失文件', status: 'dangling', reason: '引用文本未匹配到受控文件。' },
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-conflict', label: '重复文件', status: 'conflict', reason: '引用文本匹配到多个候选文件。' },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '[[正常文件]] [[缺失文件]] [[重复文件]]',
+        sourceReferences: [
+          { id: 'ref-ok', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'document', targetDocId: 'doc-ok', targetLabel: '正常文件', wikilinkTarget: '正常文件', targetDoc: { id: 'doc-ok', title: '正常文件', status: 'effective' } },
+          { id: 'ref-dangling', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'unresolved_document', targetLabel: '缺失文件', wikilinkTarget: '缺失文件' },
+          { id: 'ref-conflict', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'conflict_document', targetLabel: '重复文件', wikilinkTarget: '重复文件' },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    const links = wrapper.findAll('.wikilink');
+
+    expect(links[0].classes()).toContain('wikilink-resolved');
+    expect(links[1].classes()).toContain('wikilink-dangling');
+    expect(links[2].classes()).toContain('wikilink-conflict');
+  });
+
   it('saves markdown edits for draft documents and refreshes detail', async () => {
     const c = w();
     await flushPromises();

--- a/docs/superpowers/plans/2026-04-28-markdown-wikilink-click-navigation-implementation.md
+++ b/docs/superpowers/plans/2026-04-28-markdown-wikilink-click-navigation-implementation.md
@@ -1,0 +1,883 @@
+# Markdown Wikilink Click Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Markdown `[[...]]` links clickable, route resolved links to target documents, visually mark unresolved/conflict links, and persist the raw wikilink target on `DocumentReference`.
+
+**Architecture:** Backend wikilink sync stores `wikilinkTarget` as the canonical raw target for every WIKILINK reference, with `sectionId` kept only for legacy compatibility. The renderer remains business-agnostic and only emits styled spans plus click events; `DocumentDetail.vue` owns document-control semantics and decides whether to navigate, warn, or expand reference issues.
+
+**Tech Stack:** NestJS, Prisma/PostgreSQL, Jest, Vue 3, Vue Test Utils, Vitest, Element Plus, markdown-it.
+
+---
+
+## File Structure
+
+- Modify `server/src/prisma/schema.prisma`
+  Adds nullable `DocumentReference.wikilinkTarget` plus index.
+- Create `server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql`
+  Adds the database column, backfills legacy `sectionId = wikilink:<target>` rows, and adds an index.
+- Modify `server/src/modules/document/services/markdown-wikilink.service.ts`
+  Parses alias wikilinks as target/display label, writes `wikilinkTarget` for resolved, unresolved, and conflict references.
+- Modify `server/src/modules/document/services/markdown-wikilink.service.spec.ts`
+  Covers alias parsing and `wikilinkTarget` persistence.
+- Modify `client/src/api/document-control.ts`
+  Exposes `wikilinkTarget`, `sectionId`, and richer `targetDoc` fields to the UI.
+- Modify `client/src/components/documents/markdown-renderer.ts`
+  Adds `WikilinkStatus`, render options, status classes, and keeps code-block protection.
+- Modify `client/src/components/documents/MarkdownViewer.vue`
+  Accepts status map, forwards options to renderer, emits `wikilink-click`, and styles link states.
+- Modify `client/src/components/documents/MarkdownViewer.spec.ts`
+  Covers click emission, no emission for plain text/code links, and status classes.
+- Modify `client/src/views/documents/DocumentDetail.vue`
+  Passes status map, handles click navigation/warnings, and prioritizes `wikilinkTarget`.
+- Modify `client/src/views/documents/__tests__/DocumentDetail.spec.ts`
+  Covers resolved/dangling/conflict/alias click behavior and status map generation.
+
+---
+
+### Task 1: Backend Schema And Migration
+
+**Files:**
+- Modify: `server/src/prisma/schema.prisma`
+- Create: `server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql`
+
+- [ ] **Step 1: Add the Prisma field**
+
+In `server/src/prisma/schema.prisma`, update `model DocumentReference`:
+
+```prisma
+model DocumentReference {
+  id          String   @id @default(cuid())
+  sourceDocId String
+  sourceDoc   Document @relation("SourceRefs", fields: [sourceDocId], references: [id], onDelete: Cascade)
+
+  targetDocId String?
+  targetDoc   Document? @relation("TargetRefs", fields: [targetDocId], references: [id], onDelete: SetNull)
+
+  targetType  String   @default("document")
+  targetId    String?
+  targetRoute String?
+  targetLabel String?
+  relationType String @default("RELATED_TO")
+
+  sectionId      String?
+  wikilinkTarget String?
+  snapshot       Json?
+  syncedAt       DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  @@unique([sourceDocId, targetType, targetId, targetRoute, sectionId])
+  @@index([sourceDocId])
+  @@index([targetDocId])
+  @@index([targetType, targetId])
+  @@index([relationType])
+  @@index([wikilinkTarget])
+  @@map("document_references")
+}
+```
+
+- [ ] **Step 2: Add the SQL migration**
+
+Create `server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql`:
+
+```sql
+ALTER TABLE "document_references"
+ADD COLUMN "wikilinkTarget" TEXT;
+
+UPDATE "document_references"
+SET "wikilinkTarget" = substring("sectionId" from 10)
+WHERE "relationType" = 'WIKILINK'
+  AND "wikilinkTarget" IS NULL
+  AND "sectionId" LIKE 'wikilink:%';
+
+CREATE INDEX "document_references_wikilinkTarget_idx"
+ON "document_references"("wikilinkTarget");
+```
+
+The `substring(... from 10)` starts after the nine-character prefix `wikilink:`.
+
+- [ ] **Step 3: Regenerate Prisma client**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/server
+npm run prisma:generate
+```
+
+Expected: Prisma Client generation succeeds without schema errors.
+
+- [ ] **Step 4: Commit schema and migration**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+git add server/src/prisma/schema.prisma server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql
+git commit -m "feat: add wikilink target field"
+```
+
+---
+
+### Task 2: Backend Wikilink Sync
+
+**Files:**
+- Modify: `server/src/modules/document/services/markdown-wikilink.service.spec.ts`
+- Modify: `server/src/modules/document/services/markdown-wikilink.service.ts`
+
+- [ ] **Step 1: Update the extraction test to prove alias handling**
+
+In `server/src/modules/document/services/markdown-wikilink.service.spec.ts`, replace the extraction test with:
+
+```ts
+it('extracts unique trimmed wikilink targets without alias display labels', () => {
+  expect(service.extractWikilinks('引用 [[GRSS-CX-01|文件控制程序]]、[[ 原辅料验收标准 ]]、[[]]、[[GRSS-CX-01|重复显示]]')).toEqual([
+    'GRSS-CX-01',
+    '原辅料验收标准',
+  ]);
+});
+```
+
+- [ ] **Step 2: Add `wikilinkTarget` expectations to existing create tests**
+
+In the resolved reference test, add:
+
+```ts
+wikilinkTarget: '原辅料验收标准',
+```
+
+inside the existing `expect.objectContaining({ ... })`.
+
+In the unresolved reference test, add:
+
+```ts
+wikilinkTarget: '不存在的文件',
+```
+
+inside the existing `expect.objectContaining({ ... })`.
+
+In the conflict reference test, add:
+
+```ts
+wikilinkTarget: '原辅料验收标准',
+```
+
+inside the existing `expect.objectContaining({ ... })`.
+
+- [ ] **Step 3: Add a dedicated alias persistence test**
+
+Append this test before the self-reference test:
+
+```ts
+it('stores the alias target as wikilinkTarget and not the display label', async () => {
+  prisma.document.findMany.mockResolvedValueOnce([
+    { id: 'target1', title: '文件控制程序', number: 'GRSS-CX-01', doc_code: null },
+  ]);
+
+  await service.syncDocumentWikilinks('source1', '见 [[GRSS-CX-01|文件控制程序]]');
+
+  expect(prisma.document.findMany).toHaveBeenCalledWith(expect.objectContaining({
+    where: expect.objectContaining({
+      OR: [
+        { number: 'GRSS-CX-01' },
+        { title: 'GRSS-CX-01' },
+        { doc_code: 'GRSS-CX-01' },
+      ],
+    }),
+  }));
+  expect(prisma.documentReference.create).toHaveBeenCalledWith({
+    data: expect.objectContaining({
+      targetDocId: 'target1',
+      targetLabel: '文件控制程序',
+      sectionId: 'wikilink:GRSS-CX-01',
+      wikilinkTarget: 'GRSS-CX-01',
+    }),
+  });
+});
+```
+
+- [ ] **Step 4: Run backend test and confirm failure**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/server
+npm test -- markdown-wikilink.service.spec.ts --runInBand
+```
+
+Expected: FAIL because `extractWikilinks()` still returns the alias string and creates references without `wikilinkTarget`.
+
+- [ ] **Step 5: Implement target parsing and persistence**
+
+In `server/src/modules/document/services/markdown-wikilink.service.ts`, replace the current `extractWikilinks()` with:
+
+```ts
+  extractWikilinks(content: string): string[] {
+    const targets = Array.from(content.matchAll(/\[\[([^\]]+)\]\]/g))
+      .map((match) => this.extractTarget(match[1]))
+      .filter((target): target is string => Boolean(target));
+    return Array.from(new Set(targets));
+  }
+
+  private extractTarget(raw: string): string | null {
+    const target = raw.split('|')[0]?.trim();
+    return target || null;
+  }
+```
+
+In the resolved `documentReference.create()` data object, add:
+
+```ts
+            wikilinkTarget: label,
+```
+
+In the unresolved/conflict `documentReference.create()` data object, add:
+
+```ts
+          wikilinkTarget: label,
+```
+
+- [ ] **Step 6: Run backend test and confirm pass**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/server
+npm test -- markdown-wikilink.service.spec.ts --runInBand
+```
+
+Expected: PASS for `markdown-wikilink.service.spec.ts`.
+
+- [ ] **Step 7: Commit backend sync**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+git add server/src/modules/document/services/markdown-wikilink.service.ts server/src/modules/document/services/markdown-wikilink.service.spec.ts
+git commit -m "feat: persist markdown wikilink targets"
+```
+
+---
+
+### Task 3: Renderer Status Classes
+
+**Files:**
+- Modify: `client/src/components/documents/markdown-renderer.ts`
+- Modify: `client/src/components/documents/MarkdownViewer.spec.ts`
+
+- [ ] **Step 1: Add renderer status tests**
+
+In `client/src/components/documents/MarkdownViewer.spec.ts`, after the existing code-block test, add:
+
+```ts
+  it('emits wikilink-click with the data target when a wikilink is clicked', async () => {
+    const wrapper = mountMarkdown('参考 [[GRSS-CX-01|文件控制程序]]');
+
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(wrapper.emitted('wikilink-click')).toEqual([['GRSS-CX-01']]);
+  });
+
+  it('does not emit wikilink-click when plain text is clicked', async () => {
+    const wrapper = mountMarkdown('这里只是普通正文');
+
+    await wrapper.find('.markdown-viewer').trigger('click');
+
+    expect(wrapper.emitted('wikilink-click')).toBeUndefined();
+  });
+
+  it('applies wikilink status classes by target', () => {
+    const wrapper = mount(MarkdownViewer, {
+      props: {
+        content: '[[正常文件]] [[缺失文件]] [[重复文件]] [[未知文件]]',
+        wikilinkStatusByTarget: {
+          正常文件: 'resolved',
+          缺失文件: 'dangling',
+          重复文件: 'conflict',
+        },
+      },
+    });
+
+    const links = wrapper.findAll('.wikilink');
+    expect(links[0].classes()).toContain('wikilink-resolved');
+    expect(links[1].classes()).toContain('wikilink-dangling');
+    expect(links[2].classes()).toContain('wikilink-conflict');
+    expect(links[3].classes()).toContain('wikilink-unknown');
+  });
+```
+
+- [ ] **Step 2: Run frontend test and confirm failure**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- MarkdownViewer.spec.ts
+```
+
+Expected: FAIL because `MarkdownViewer` has no emit and renderer has no status option.
+
+- [ ] **Step 3: Update renderer types and `enhanceWikilinks()`**
+
+In `client/src/components/documents/markdown-renderer.ts`, add the public types after the `CALLOUT_TYPES` declaration:
+
+```ts
+export type WikilinkStatus = 'resolved' | 'dangling' | 'conflict' | 'unknown';
+
+export interface RenderMarkdownOptions {
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}
+```
+
+Replace `const enhanceWikilinks = (html: string) => { ... }` with:
+
+```ts
+const enhanceWikilinks = (html: string, options: RenderMarkdownOptions = {}) => {
+  const codeBlocks: string[] = [];
+  const guarded = html.replace(/<code[^>]*>[\s\S]*?<\/code>/g, (match) => {
+    codeBlocks.push(match);
+    return `__NOIDEAR_CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  const withLinks = guarded.replace(
+    /\[\[([^\]|<]+?)(?:\|([^\]<]+?))?\]\]/g,
+    (_match, rawTarget: string, rawLabel?: string) => {
+      const target = rawTarget.trim();
+      const label = (rawLabel || rawTarget).trim();
+      const status = options.wikilinkStatusByTarget?.[target] || 'unknown';
+      return `<span class="wikilink wikilink-${escapeAttribute(status)}" data-target="${escapeAttribute(target)}">${label}</span>`;
+    },
+  );
+
+  return withLinks.replace(/__NOIDEAR_CODE_BLOCK_(\d+)__/g, (_, i) => codeBlocks[parseInt(i, 10)]);
+};
+```
+
+Replace `renderMarkdown()` with:
+
+```ts
+export const renderMarkdown = (content: string, options: RenderMarkdownOptions = {}) => {
+  const withoutFrontmatter = stripFrontmatter(content);
+  const rendered = markdown.render(withoutFrontmatter);
+
+  return enhanceWikilinks(enhanceTaskLists(enhanceCallouts(rendered)), options);
+};
+```
+
+- [ ] **Step 4: Run frontend test and keep expected failure**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- MarkdownViewer.spec.ts
+```
+
+Expected: status-class assertions may pass, click emit tests still FAIL until `MarkdownViewer.vue` is updated in Task 4.
+
+---
+
+### Task 4: MarkdownViewer Click Event And Styles
+
+**Files:**
+- Modify: `client/src/components/documents/MarkdownViewer.vue`
+- Modify: `client/src/components/documents/MarkdownViewer.spec.ts`
+
+- [ ] **Step 1: Update MarkdownViewer script and template**
+
+In `client/src/components/documents/MarkdownViewer.vue`, replace the template and script with:
+
+```vue
+<template>
+  <article class="markdown-viewer" v-html="html" @click="handleClick" />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { renderMarkdown, type WikilinkStatus } from './markdown-renderer';
+
+const props = defineProps<{
+  content: string;
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}>();
+
+const emit = defineEmits<{
+  (event: 'wikilink-click', target: string): void;
+}>();
+
+const html = computed(() => renderMarkdown(props.content, {
+  wikilinkStatusByTarget: props.wikilinkStatusByTarget,
+}));
+
+const handleClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement | null;
+  const link = target?.closest?.('.wikilink') as HTMLElement | null;
+  const wikilinkTarget = link?.dataset?.target;
+  if (!wikilinkTarget) return;
+  emit('wikilink-click', wikilinkTarget);
+};
+</script>
+```
+
+Keep the existing style block and replace only the `.wikilink` section with the next step.
+
+- [ ] **Step 2: Replace wikilink CSS**
+
+In the same file, replace the existing `.markdown-viewer :deep(.wikilink)` block with:
+
+```css
+.markdown-viewer :deep(.wikilink) {
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0 3px;
+}
+
+.markdown-viewer :deep(.wikilink-resolved) {
+  background: #eef6ff;
+  color: #1677d2;
+}
+
+.markdown-viewer :deep(.wikilink-dangling) {
+  background: #fff2f0;
+  color: #cf1322;
+  text-decoration: underline dotted;
+}
+
+.markdown-viewer :deep(.wikilink-conflict) {
+  background: #fff7e6;
+  color: #ad6800;
+  text-decoration: underline wavy;
+}
+
+.markdown-viewer :deep(.wikilink-unknown) {
+  background: #f5f7fa;
+  color: #606266;
+  text-decoration: underline dotted;
+}
+```
+
+- [ ] **Step 3: Run MarkdownViewer tests**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- MarkdownViewer.spec.ts
+```
+
+Expected: PASS for all `MarkdownViewer` tests.
+
+- [ ] **Step 4: Commit renderer and viewer**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+git add client/src/components/documents/markdown-renderer.ts client/src/components/documents/MarkdownViewer.vue client/src/components/documents/MarkdownViewer.spec.ts
+git commit -m "feat: emit markdown wikilink clicks"
+```
+
+---
+
+### Task 5: Document Detail Navigation Semantics
+
+**Files:**
+- Modify: `client/src/api/document-control.ts`
+- Modify: `client/src/views/documents/DocumentDetail.vue`
+- Modify: `client/src/views/documents/__tests__/DocumentDetail.spec.ts`
+
+- [ ] **Step 1: Extend frontend reference types**
+
+In `client/src/api/document-control.ts`, update `DocumentReference`:
+
+```ts
+export interface DocumentReference {
+  id: string;
+  sourceDocId: string;
+  targetDocId?: string | null;
+  targetType: string;
+  targetId?: string | null;
+  targetRoute?: string | null;
+  targetLabel?: string | null;
+  relationType: string;
+  sectionId?: string | null;
+  wikilinkTarget?: string | null;
+  targetDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+  sourceDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+}
+```
+
+In `client/src/views/documents/DocumentDetail.vue`, update the local `DocumentReference` interface to include:
+
+```ts
+  targetDocId?: string | null;
+  sectionId?: string | null;
+  wikilinkTarget?: string | null;
+  targetDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+  sourceDoc?: { id: string; title: string; status: string; number?: string | null; doc_code?: string | null } | null;
+```
+
+- [ ] **Step 2: Add DocumentDetail click tests**
+
+In `client/src/views/documents/__tests__/DocumentDetail.spec.ts`, add these tests after `renders markdown body when document has content_md`:
+
+```ts
+  it('routes resolved markdown wikilinks to the target document', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[GRSS-CX-01|文件控制程序]]',
+        sourceReferences: [
+          {
+            id: 'ref-resolved',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'document',
+            targetDocId: 'doc-2',
+            targetId: 'doc-2',
+            targetLabel: '文件控制程序',
+            wikilinkTarget: 'GRSS-CX-01',
+            sectionId: 'wikilink:GRSS-CX-01',
+            targetDoc: { id: 'doc-2', title: '文件控制程序', number: 'GRSS-CX-01', doc_code: null, status: 'effective' },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/documents/doc-2');
+  });
+
+  it('uses legacy sectionId to route old resolved wikilinks', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[旧文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-legacy',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'document',
+            targetDocId: 'doc-legacy',
+            targetId: 'doc-legacy',
+            targetLabel: '旧文件',
+            sectionId: 'wikilink:旧文件',
+            targetDoc: { id: 'doc-legacy', title: '旧文件', status: 'effective' },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).toHaveBeenCalledWith('/documents/doc-legacy');
+  });
+
+  it('warns and locates dangling markdown wikilinks without navigating', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 1, invalid: 0, conflict: 0, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-dangling', label: '缺失文件', status: 'dangling', reason: '引用文本未匹配到受控文件。' },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[缺失文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-dangling',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'unresolved_document',
+            targetLabel: '缺失文件',
+            wikilinkTarget: '缺失文件',
+            sectionId: 'wikilink:缺失文件',
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).activeReferenceLabel).toBe('缺失文件');
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用未解析，请在引用关系中处理。');
+  });
+
+  it('warns and expands conflict markdown wikilinks without navigating', async () => {
+    const { ElMessage } = await import('element-plus');
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 1, healthy: 0, dangling: 0, invalid: 0, conflict: 1, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-conflict', label: '重复文件', status: 'conflict', reason: '引用文本匹配到多个候选文件。', candidates: [{ id: 'doc-a', title: '重复文件' }] },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '见 [[重复文件]]',
+        sourceReferences: [
+          {
+            id: 'ref-conflict',
+            sourceDocId: 'doc-1',
+            relationType: 'WIKILINK',
+            targetType: 'conflict_document',
+            targetLabel: '重复文件',
+            wikilinkTarget: '重复文件',
+            sectionId: 'wikilink:重复文件',
+            snapshot: { candidates: [{ id: 'doc-a', title: '重复文件' }] },
+          },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    await wrapper.find('.wikilink').trigger('click');
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect((wrapper.vm as any).expandedConflictReferenceId).toBe('ref-conflict');
+    expect(ElMessage.warning).toHaveBeenCalledWith('引用存在多个候选，请选择正确目标。');
+  });
+
+  it('passes resolved dangling and conflict wikilink status to MarkdownViewer', async () => {
+    mockGetReferenceHealth.mockResolvedValue({
+      totals: { total: 3, healthy: 1, dangling: 1, invalid: 0, conflict: 1, superseded: 0 },
+      issues: [
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-dangling', label: '缺失文件', status: 'dangling', reason: '引用文本未匹配到受控文件。' },
+        { sourceDocId: 'doc-1', sourceTitle: '测试文档', referenceId: 'ref-conflict', label: '重复文件', status: 'conflict', reason: '引用文本匹配到多个候选文件。' },
+      ],
+    });
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) return Promise.resolve([]);
+      return Promise.resolve(makeDocument({
+        content_md: '[[正常文件]] [[缺失文件]] [[重复文件]]',
+        sourceReferences: [
+          { id: 'ref-ok', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'document', targetDocId: 'doc-ok', targetLabel: '正常文件', wikilinkTarget: '正常文件', targetDoc: { id: 'doc-ok', title: '正常文件', status: 'effective' } },
+          { id: 'ref-dangling', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'unresolved_document', targetLabel: '缺失文件', wikilinkTarget: '缺失文件' },
+          { id: 'ref-conflict', sourceDocId: 'doc-1', relationType: 'WIKILINK', targetType: 'conflict_document', targetLabel: '重复文件', wikilinkTarget: '重复文件' },
+        ],
+      }));
+    });
+
+    const wrapper = w();
+    await flushPromises();
+    const links = wrapper.findAll('.wikilink');
+
+    expect(links[0].classes()).toContain('wikilink-resolved');
+    expect(links[1].classes()).toContain('wikilink-dangling');
+    expect(links[2].classes()).toContain('wikilink-conflict');
+  });
+```
+
+- [ ] **Step 3: Run DocumentDetail test and confirm failure**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- DocumentDetail.spec.ts
+```
+
+Expected: FAIL because `DocumentDetail.vue` does not pass status props or handle wikilink clicks.
+
+- [ ] **Step 4: Pass props and event to MarkdownViewer**
+
+In `client/src/views/documents/DocumentDetail.vue`, replace:
+
+```vue
+      <MarkdownViewer
+        v-else
+        :content="document.content_md"
+      />
+```
+
+with:
+
+```vue
+      <MarkdownViewer
+        v-else
+        :content="document.content_md"
+        :wikilink-status-by-target="wikilinkStatusByTarget"
+        @wikilink-click="handleMarkdownWikilinkClick"
+      />
+```
+
+- [ ] **Step 5: Add helper methods and computed status map**
+
+In `client/src/views/documents/DocumentDetail.vue`, near `referenceHealthIssues`, add:
+
+```ts
+const wikilinkLegacyTarget = (ref: DocumentReference): string | null => (
+  ref.sectionId?.startsWith('wikilink:') ? ref.sectionId.slice('wikilink:'.length) : null
+);
+
+const wikilinkReferenceTarget = (ref: DocumentReference): string | null => (
+  ref.wikilinkTarget || wikilinkLegacyTarget(ref) || ref.targetLabel || null
+);
+
+const wikilinkStatusByTarget = computed(() => {
+  const statusMap: Record<string, 'resolved' | 'dangling' | 'conflict' | 'unknown'> = {};
+
+  for (const ref of outboundReferences.value) {
+    if (ref.relationType !== 'WIKILINK' || !ref.targetDocId) continue;
+    const target = wikilinkReferenceTarget(ref);
+    if (target) statusMap[target] = 'resolved';
+  }
+  for (const issue of referenceHealthIssues.value) {
+    if (issue.status === 'dangling') statusMap[issue.label] = 'dangling';
+    if (issue.status === 'conflict') statusMap[issue.label] = 'conflict';
+  }
+
+  return statusMap;
+});
+
+const findResolvedWikilinkReference = (target: string): DocumentReference | undefined => (
+  outboundReferences.value.find((ref) =>
+    ref.relationType === 'WIKILINK' &&
+    Boolean(ref.targetDocId) &&
+    (
+      ref.wikilinkTarget === target ||
+      ref.sectionId === `wikilink:${target}` ||
+      ref.targetLabel === target ||
+      ref.targetDoc?.number === target ||
+      ref.targetDoc?.doc_code === target ||
+      ref.targetDoc?.title === target
+    ),
+  )
+);
+```
+
+Near `handleReferenceHealthIssue`, add:
+
+```ts
+const handleMarkdownWikilinkClick = (target: string) => {
+  const normalizedTarget = target.trim();
+  if (!normalizedTarget) return;
+
+  const resolved = findResolvedWikilinkReference(normalizedTarget);
+  if (resolved?.targetDocId) {
+    router.push(`/documents/${resolved.targetDocId}`);
+    return;
+  }
+
+  const dangling = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'dangling' && issue.label === normalizedTarget,
+  );
+  if (dangling) {
+    handleReferenceHealthIssue(dangling);
+    ElMessage.warning('引用未解析，请在引用关系中处理。');
+    return;
+  }
+
+  const conflict = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'conflict' && issue.label === normalizedTarget,
+  );
+  if (conflict) {
+    handleReferenceHealthIssue(conflict);
+    ElMessage.warning('引用存在多个候选，请选择正确目标。');
+    return;
+  }
+
+  ElMessage.warning('未找到该引用的解析结果，请保存正文后刷新引用关系。');
+};
+```
+
+- [ ] **Step 6: Run DocumentDetail tests**
+
+Run:
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- DocumentDetail.spec.ts
+```
+
+Expected: PASS for `DocumentDetail.spec.ts`.
+
+- [ ] **Step 7: Commit document detail behavior**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+git add client/src/api/document-control.ts client/src/views/documents/DocumentDetail.vue client/src/views/documents/__tests__/DocumentDetail.spec.ts
+git commit -m "feat: navigate document markdown wikilinks"
+```
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify all files changed in previous tasks.
+
+- [ ] **Step 1: Run targeted backend tests**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/server
+npm test -- markdown-wikilink.service.spec.ts --runInBand
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted frontend tests**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run test -- MarkdownViewer.spec.ts DocumentDetail.spec.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run frontend build check**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation/client
+npm run build:check
+```
+
+Expected: `vue-tsc` and `vite build` complete successfully.
+
+- [ ] **Step 4: Inspect migration and generated Prisma type state**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+rg -n "wikilinkTarget" server/src/prisma/schema.prisma server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql server/src/modules/document/services/markdown-wikilink.service.ts client/src
+```
+
+Expected: output shows schema, migration, backend sync, frontend API type, renderer, viewer, and detail page references.
+
+- [ ] **Step 5: Confirm working tree is clean except intended commits**
+
+```bash
+cd /Users/jiashenglin/Desktop/好玩的项目/noidear-markdown-wikilink-click-navigation
+git status --short
+git log --oneline --decorate -6
+```
+
+Expected: no unstaged or staged files. Recent commits include the schema, backend sync, renderer/viewer, and detail navigation commits.
+
+---
+
+## Self-Review
+
+Spec coverage:
+
+- Resolved wikilink navigation is implemented in Task 5.
+- Dangling/conflict click handling and warnings are implemented in Task 5.
+- `DocumentReference.wikilinkTarget` schema, migration, backfill, and backend persistence are implemented in Tasks 1 and 2.
+- Visible resolved/dangling/conflict/unknown styles are implemented in Tasks 3 and 4.
+- Alias `[[target|label]]` uses the target, not display label, in Tasks 2 and 5.
+- Code block protection remains in Task 3 because `enhanceWikilinks()` still guards `<code>...</code>`.
+- Tests and build verification are covered in Tasks 2, 4, 5, and 6.
+
+Risk notes:
+
+- `DocumentDetail.vue` already has a local `DocumentReference` interface separate from `client/src/api/document-control.ts`; update both so TypeScript and runtime assumptions stay aligned.
+- Migration uses PostgreSQL quoted column names because Prisma maps camelCase fields directly unless `@map` is used.
+- `wikilinkStatusByTarget` only marks resolved WIKILINK references with `targetDocId`; generic document references should not color Markdown wikilinks as resolved.

--- a/docs/superpowers/specs/2026-04-28-markdown-wikilink-click-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-28-markdown-wikilink-click-navigation-design.md
@@ -13,6 +13,8 @@ Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样
 - 如果引用唯一解析到目标文件，直接跳转到目标文档详情页。
 - 如果引用未解析，不跳转，提示用户并定位到引用问题区。
 - 如果引用冲突，不跳转，提示用户并展开候选列表。
+- `DocumentReference` 明确保存原始 `wikilinkTarget`，前端不再依赖 `sectionId` 字符串拆解。
+- 未解析和冲突 wikilink 在正文里有可见差异，用户不用点击也能看出问题。
 
 ## 非目标
 
@@ -21,6 +23,7 @@ Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样
 - 不允许绕过文控编号、状态、审批、负责部门等受控文件规则创建文件。
 - 不支持本次实现 `[[文档#标题]]` 段落锚点跳转。
 - 不支持 `![[嵌入内容]]` 嵌入块。
+- 不做 hover 预览或 hover 状态浮层。
 
 ## 设计原则
 
@@ -51,6 +54,18 @@ Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样
 - `conflictWikilinks`
 
 这样可以复用现有引用健康逻辑，不在前端新增第二套解析规则。
+
+### 原始引用目标是强字段
+
+后端同步 wikilink 时必须把 `[[目标]]` 或 `[[目标|显示名]]` 里的 `目标` 保存到 `DocumentReference.wikilinkTarget`。
+
+这样前端可以直接按字段匹配：
+
+```ts
+ref.wikilinkTarget === clickedTarget
+```
+
+不再把 `sectionId = wikilink:<target>` 当成主要匹配依据。`sectionId` 可以继续保留用于兼容旧数据。
 
 ## 用户交互
 
@@ -85,6 +100,7 @@ Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样
 - 显示提示：`引用未解析，请在引用关系中处理。`
 - 设置 `activeReferenceLabel`。
 - 滚动到 Markdown/引用关系区域。
+- 正文中的该 wikilink 使用 unresolved 样式，例如红色虚线下划线。
 
 ### 冲突引用
 
@@ -94,10 +110,79 @@ Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样
 - 显示提示：`引用存在多个候选，请选择正确目标。`
 - 设置 `expandedConflictReferenceId`。
 - 滚动到引用关系区域。
+- 正文中的该 wikilink 使用 conflict 样式，例如黄色背景或黄色下划线。
+
+## 数据模型
+
+### DocumentReference
+
+新增字段：
+
+```prisma
+model DocumentReference {
+  // existing fields...
+  wikilinkTarget String?
+
+  @@index([wikilinkTarget])
+}
+```
+
+字段含义：
+
+- 对于 `[[GRSS-CX-01]]`，`wikilinkTarget = "GRSS-CX-01"`。
+- 对于 `[[GRSS-CX-01|文件控制程序]]`，`wikilinkTarget = "GRSS-CX-01"`。
+- 对于非 wikilink 引用，`wikilinkTarget = null`。
+
+迁移要求：
+
+- 新增 nullable 字段，不阻塞旧数据读取。
+- 对旧的 `relationType = 'WIKILINK'` 且 `sectionId` 形如 `wikilink:<target>` 的数据，可在 migration 中回填 `wikilinkTarget`。
+- 不能只改 Prisma schema，必须补 migration。
+
+后端同步要求：
+
+- `MarkdownWikilinkService.extractWikilinks()` 继续返回去重后的目标文本。
+- `syncDocumentWikilinks()` 创建 `DocumentReference` 时写入 `wikilinkTarget: label`。
+- 已解析、未解析、冲突三类引用都必须写入 `wikilinkTarget`。
 
 ## 组件接口
 
+### markdown-renderer.ts
+
+`renderMarkdown()` 需要支持按引用状态输出 class。推荐新增可选参数：
+
+```ts
+export type WikilinkStatus = 'resolved' | 'dangling' | 'conflict' | 'unknown';
+
+export interface RenderMarkdownOptions {
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}
+
+export const renderMarkdown = (content: string, options: RenderMarkdownOptions = {}) => {
+  // existing rendering pipeline
+};
+```
+
+`enhanceWikilinks()` 输出：
+
+```html
+<span class="wikilink wikilink-resolved" data-target="GRSS-CX-01">GRSS-CX-01</span>
+<span class="wikilink wikilink-dangling" data-target="缺失文件">缺失文件</span>
+<span class="wikilink wikilink-conflict" data-target="重复文件">重复文件</span>
+```
+
+状态缺省时使用 `wikilink-unknown`，保持可点击但不误报为正常。
+
 ### MarkdownViewer.vue
+
+新增 props：
+
+```ts
+const props = defineProps<{
+  content: string;
+  wikilinkStatusByTarget?: Record<string, WikilinkStatus>;
+}>();
+```
 
 新增 emit：
 
@@ -133,6 +218,7 @@ const handleClick = (event: MouseEvent) => {
 <MarkdownViewer
   v-else
   :content="document.content_md"
+  :wikilink-status-by-target="wikilinkStatusByTarget"
   @wikilink-click="handleMarkdownWikilinkClick"
 />
 ```
@@ -144,9 +230,14 @@ const handleMarkdownWikilinkClick = (target: string) => {
   const normalizedTarget = target.trim();
   const resolved = outboundReferences.value.find((ref) =>
     ref.targetDocId &&
-    [ref.targetLabel, ref.targetDoc?.title, ref.targetDoc?.number, ref.targetDoc?.doc_code]
-      .filter(Boolean)
-      .includes(normalizedTarget),
+    (
+      ref.wikilinkTarget === normalizedTarget ||
+      ref.sectionId === `wikilink:${normalizedTarget}` ||
+      ref.targetLabel === normalizedTarget ||
+      ref.targetDoc?.number === normalizedTarget ||
+      ref.targetDoc?.doc_code === normalizedTarget ||
+      ref.targetDoc?.title === normalizedTarget
+    ),
   );
 
   if (resolved?.targetDocId) {
@@ -178,6 +269,28 @@ const handleMarkdownWikilinkClick = (target: string) => {
 
 实际实现可以把匹配逻辑拆成 `findResolvedWikilinkReference(target)`，避免 `DocumentDetail.vue` 继续变长。
 
+`wikilinkStatusByTarget` 由当前引用健康数据派生：
+
+```ts
+const wikilinkStatusByTarget = computed(() => {
+  const statusMap: Record<string, WikilinkStatus> = {};
+
+  for (const ref of outboundReferences.value) {
+    const legacyTarget = ref.sectionId?.startsWith('wikilink:')
+      ? ref.sectionId.slice('wikilink:'.length)
+      : null;
+    const target = ref.wikilinkTarget || legacyTarget;
+    if (target) statusMap[target] = 'resolved';
+  }
+  for (const issue of referenceHealthIssues.value) {
+    if (issue.status === 'dangling') statusMap[issue.label] = 'dangling';
+    if (issue.status === 'conflict') statusMap[issue.label] = 'conflict';
+  }
+
+  return statusMap;
+});
+```
+
 ## 数据匹配规则
 
 点击目标来自 `data-target`，即：
@@ -194,13 +307,53 @@ const handleMarkdownWikilinkClick = (target: string) => {
 
 匹配优先级：
 
-1. `DocumentReference.sectionId === wikilink:<target>`
-2. `DocumentReference.targetLabel === target`
-3. `targetDoc.number === target`
-4. `targetDoc.doc_code === target`
-5. `targetDoc.title === target`
+1. `DocumentReference.wikilinkTarget === target`
+2. `DocumentReference.sectionId === wikilink:<target>`，仅兼容旧数据
+3. `DocumentReference.targetLabel === target`
+4. `targetDoc.number === target`
+5. `targetDoc.doc_code === target`
+6. `targetDoc.title === target`
 
-如果未来后端给 `DocumentReference` 增加更明确的 `sourceLabel` 或 `wikilinkTarget` 字段，前端应优先使用该字段。
+新数据必须有 `wikilinkTarget`。`sectionId` 只能作为旧数据兜底，不应成为长期主路径。
+
+## 正文样式
+
+基础样式：
+
+```css
+.wikilink {
+  cursor: pointer;
+}
+```
+
+状态样式：
+
+```css
+.wikilink-resolved {
+  background: #eef6ff;
+  color: #1677d2;
+}
+
+.wikilink-dangling {
+  background: #fff2f0;
+  color: #cf1322;
+  text-decoration: underline dotted;
+}
+
+.wikilink-conflict {
+  background: #fff7e6;
+  color: #ad6800;
+  text-decoration: underline wavy;
+}
+
+.wikilink-unknown {
+  background: #f5f7fa;
+  color: #606266;
+  text-decoration: underline dotted;
+}
+```
+
+样式只表达引用健康状态，不改变点击规则。
 
 ## 错误与边界
 
@@ -209,6 +362,7 @@ const handleMarkdownWikilinkClick = (target: string) => {
 - 当前文档自己引用自己时，后端同步逻辑会跳过，不应跳转。
 - 如果引用刚刚编辑但尚未保存，前端没有新的 `DocumentReference`，应提示保存后刷新。
 - 如果 `referenceHealth` 加载失败，wikilink 点击仍可以尝试 resolved 跳转；未解析和冲突提示退化为通用提示。
+- 旧数据没有 `wikilinkTarget` 时，前端可以用 `sectionId` 兼容一次，但新保存后的引用必须写入 `wikilinkTarget`。
 
 ## 测试计划
 
@@ -219,6 +373,7 @@ const handleMarkdownWikilinkClick = (target: string) => {
 - 点击 `.wikilink` 会 emit `wikilink-click`，payload 为 `data-target`。
 - 点击普通文本不会 emit。
 - inline code 和 fenced code block 中的 `[[...]]` 不会生成 `.wikilink`，因此不会 emit。
+- 根据 `wikilinkStatusByTarget` 给 wikilink 加上 `wikilink-resolved`、`wikilink-dangling`、`wikilink-conflict`。
 
 ### DocumentDetail.spec.ts
 
@@ -228,19 +383,37 @@ const handleMarkdownWikilinkClick = (target: string) => {
 - dangling wikilink 点击后不跳转，设置 `activeReferenceLabel`，显示 warning。
 - conflict wikilink 点击后不跳转，设置 `expandedConflictReferenceId`，显示 warning。
 - alias wikilink `[[GRSS-CX-01|文件控制程序]]` 点击时按 `GRSS-CX-01` 匹配，而不是按显示名匹配。
+- 传给 `MarkdownViewer` 的 `wikilinkStatusByTarget` 能区分 resolved、dangling、conflict。
+
+### 后端测试
+
+更新 `MarkdownWikilinkService.spec.ts`：
+
+- 已解析 wikilink 创建 `DocumentReference.wikilinkTarget`。
+- 未解析 wikilink 创建 `DocumentReference.wikilinkTarget`。
+- 冲突 wikilink 创建 `DocumentReference.wikilinkTarget`。
+- alias wikilink 保存 target，不保存显示名。
+
+增加 migration 验证：
+
+- 新 migration 包含 `wikilinkTarget` 字段。
+- 旧 `sectionId = wikilink:<target>` 数据可回填 `wikilinkTarget`。
 
 ## 验收标准
 
 - Markdown 正文中的已解析 wikilink 可以点击进入目标文档。
 - 未解析 wikilink 点击不会跳错页面，会提示并定位到引用问题。
 - 冲突 wikilink 点击不会跳错页面，会提示并展开候选。
+- 未解析和冲突 wikilink 在正文里有不同样式。
+- 新保存的 wikilink 引用记录有 `DocumentReference.wikilinkTarget`。
+- 前端优先使用 `wikilinkTarget` 匹配点击目标，`sectionId` 只作旧数据兼容。
 - Markdown 渲染安全边界保持不变：HTML 仍禁用，代码块内 wikilink 不被转换。
+- Prisma schema 和 migration 同步。
 - `npm run test -- MarkdownViewer DocumentDetail` 通过。
+- `npm test -- markdown-wikilink.service.spec.ts` 通过。
 - `npm run build:check` 通过。
 
 ## 后续可选增强
 
-- 增加 `DocumentReference.wikilinkTarget` 字段，让前端匹配不依赖 `sectionId` 字符串。
 - 支持 `[[文档#标题]]` 锚点。
-- 给 unresolved/conflict wikilink 加不同颜色或下划线。
 - 在 hover 时显示引用健康状态。

--- a/docs/superpowers/specs/2026-04-28-markdown-wikilink-click-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-28-markdown-wikilink-click-navigation-design.md
@@ -1,0 +1,246 @@
+# Markdown Wikilink Click Navigation Design
+
+## 背景
+
+Markdown 正文已经可以正常渲染，`[[...]]` 也会显示为 wikilink 样式。当前问题是：wikilink 只是一个带 `data-target` 的静态 `span`，不能像 Obsidian 一样点击跳转。
+
+本设计只补“点击 wikilink 后如何处理”。不重新设计 Markdown 渲染器，不改变文档保存逻辑，不引入图谱或新建文件流程。
+
+## 目标
+
+点击 Markdown 正文中的 `[[引用]]` 时：
+
+- 如果引用唯一解析到目标文件，直接跳转到目标文档详情页。
+- 如果引用未解析，不跳转，提示用户并定位到引用问题区。
+- 如果引用冲突，不跳转，提示用户并展开候选列表。
+
+## 非目标
+
+- 不做 Obsidian 式“点击未解析链接即新建文件”。
+- 不在点击时重新扫描全文或重新解析 Markdown。
+- 不允许绕过文控编号、状态、审批、负责部门等受控文件规则创建文件。
+- 不支持本次实现 `[[文档#标题]]` 段落锚点跳转。
+- 不支持 `![[嵌入内容]]` 嵌入块。
+
+## 设计原则
+
+### 渲染层不懂业务
+
+`MarkdownViewer.vue` 只负责：
+
+- 展示 `renderMarkdown(content)` 生成的安全 HTML。
+- 监听用户点击 `.wikilink`。
+- 把点击到的 `data-target` 作为事件向外抛出。
+
+它不负责：
+
+- 查询文档。
+- 判断引用是否健康。
+- 直接处理冲突候选。
+- 直接依赖 `DocumentReference` 结构。
+
+### 页面层负责文控语义
+
+`DocumentDetail.vue` 负责根据当前文档已经加载到的数据判断点击结果：
+
+- `sourceReferences`
+- `referenceHealth`
+- `referenceHealthIssues`
+- `outboundReferences`
+- `unresolvedWikilinks`
+- `conflictWikilinks`
+
+这样可以复用现有引用健康逻辑，不在前端新增第二套解析规则。
+
+## 用户交互
+
+### 已解析引用
+
+用户点击：
+
+```markdown
+[[GRSS-CX-01]]
+[[文件控制程序]]
+[[GRSS-CX-01|文件控制程序]]
+```
+
+如果当前文档的 `sourceReferences` 中存在：
+
+- `relationType === 'WIKILINK'`
+- `targetDocId` 存在
+- `targetDoc.id` 或 `targetDocId` 可用
+- 引用文本匹配当前点击的 `data-target`
+
+则跳转到：
+
+```text
+/documents/<targetDocId>
+```
+
+### 未解析引用
+
+如果点击目标命中 `unresolvedWikilinks` 或 `referenceHealthIssues.status === 'dangling'`：
+
+- 不跳转。
+- 显示提示：`引用未解析，请在引用关系中处理。`
+- 设置 `activeReferenceLabel`。
+- 滚动到 Markdown/引用关系区域。
+
+### 冲突引用
+
+如果点击目标命中 `conflictWikilinks` 或 `referenceHealthIssues.status === 'conflict'`：
+
+- 不跳转。
+- 显示提示：`引用存在多个候选，请选择正确目标。`
+- 设置 `expandedConflictReferenceId`。
+- 滚动到引用关系区域。
+
+## 组件接口
+
+### MarkdownViewer.vue
+
+新增 emit：
+
+```ts
+const emit = defineEmits<{
+  (event: 'wikilink-click', target: string): void;
+}>();
+```
+
+点击处理：
+
+```ts
+const handleClick = (event: MouseEvent) => {
+  const target = event.target as HTMLElement | null;
+  const link = target?.closest?.('.wikilink') as HTMLElement | null;
+  const wikilinkTarget = link?.dataset?.target;
+  if (!wikilinkTarget) return;
+  emit('wikilink-click', wikilinkTarget);
+};
+```
+
+模板变为：
+
+```vue
+<article class="markdown-viewer" v-html="html" @click="handleClick" />
+```
+
+### DocumentDetail.vue
+
+`MarkdownViewer` 使用：
+
+```vue
+<MarkdownViewer
+  v-else
+  :content="document.content_md"
+  @wikilink-click="handleMarkdownWikilinkClick"
+/>
+```
+
+新增方法：
+
+```ts
+const handleMarkdownWikilinkClick = (target: string) => {
+  const normalizedTarget = target.trim();
+  const resolved = outboundReferences.value.find((ref) =>
+    ref.targetDocId &&
+    [ref.targetLabel, ref.targetDoc?.title, ref.targetDoc?.number, ref.targetDoc?.doc_code]
+      .filter(Boolean)
+      .includes(normalizedTarget),
+  );
+
+  if (resolved?.targetDocId) {
+    router.push(`/documents/${resolved.targetDocId}`);
+    return;
+  }
+
+  const dangling = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'dangling' && issue.label === normalizedTarget,
+  );
+  if (dangling) {
+    handleReferenceHealthIssue(dangling);
+    ElMessage.warning('引用未解析，请在引用关系中处理。');
+    return;
+  }
+
+  const conflict = referenceHealthIssues.value.find(
+    (issue) => issue.status === 'conflict' && issue.label === normalizedTarget,
+  );
+  if (conflict) {
+    handleReferenceHealthIssue(conflict);
+    ElMessage.warning('引用存在多个候选，请选择正确目标。');
+    return;
+  }
+
+  ElMessage.warning('未找到该引用的解析结果，请保存正文后刷新引用关系。');
+};
+```
+
+实际实现可以把匹配逻辑拆成 `findResolvedWikilinkReference(target)`，避免 `DocumentDetail.vue` 继续变长。
+
+## 数据匹配规则
+
+点击目标来自 `data-target`，即：
+
+```markdown
+[[目标]]
+[[目标|显示名]]
+```
+
+其中：
+
+- `[[目标]]` 的点击 target 是 `目标`。
+- `[[目标|显示名]]` 的点击 target 仍是 `目标`，不是 `显示名`。
+
+匹配优先级：
+
+1. `DocumentReference.sectionId === wikilink:<target>`
+2. `DocumentReference.targetLabel === target`
+3. `targetDoc.number === target`
+4. `targetDoc.doc_code === target`
+5. `targetDoc.title === target`
+
+如果未来后端给 `DocumentReference` 增加更明确的 `sourceLabel` 或 `wikilinkTarget` 字段，前端应优先使用该字段。
+
+## 错误与边界
+
+- 点击代码块内的 `[[...]]` 不应触发，因为 renderer 已保护 code block，不会生成 `.wikilink`。
+- 点击普通 Markdown 链接 `<a>` 不受影响。
+- 当前文档自己引用自己时，后端同步逻辑会跳过，不应跳转。
+- 如果引用刚刚编辑但尚未保存，前端没有新的 `DocumentReference`，应提示保存后刷新。
+- 如果 `referenceHealth` 加载失败，wikilink 点击仍可以尝试 resolved 跳转；未解析和冲突提示退化为通用提示。
+
+## 测试计划
+
+### MarkdownViewer.spec.ts
+
+新增测试：
+
+- 点击 `.wikilink` 会 emit `wikilink-click`，payload 为 `data-target`。
+- 点击普通文本不会 emit。
+- inline code 和 fenced code block 中的 `[[...]]` 不会生成 `.wikilink`，因此不会 emit。
+
+### DocumentDetail.spec.ts
+
+新增测试：
+
+- resolved wikilink 点击后调用 `router.push('/documents/<targetDocId>')`。
+- dangling wikilink 点击后不跳转，设置 `activeReferenceLabel`，显示 warning。
+- conflict wikilink 点击后不跳转，设置 `expandedConflictReferenceId`，显示 warning。
+- alias wikilink `[[GRSS-CX-01|文件控制程序]]` 点击时按 `GRSS-CX-01` 匹配，而不是按显示名匹配。
+
+## 验收标准
+
+- Markdown 正文中的已解析 wikilink 可以点击进入目标文档。
+- 未解析 wikilink 点击不会跳错页面，会提示并定位到引用问题。
+- 冲突 wikilink 点击不会跳错页面，会提示并展开候选。
+- Markdown 渲染安全边界保持不变：HTML 仍禁用，代码块内 wikilink 不被转换。
+- `npm run test -- MarkdownViewer DocumentDetail` 通过。
+- `npm run build:check` 通过。
+
+## 后续可选增强
+
+- 增加 `DocumentReference.wikilinkTarget` 字段，让前端匹配不依赖 `sectionId` 字符串。
+- 支持 `[[文档#标题]]` 锚点。
+- 给 unresolved/conflict wikilink 加不同颜色或下划线。
+- 在 hover 时显示引用健康状态。

--- a/server/src/modules/document/services/markdown-wikilink.service.spec.ts
+++ b/server/src/modules/document/services/markdown-wikilink.service.spec.ts
@@ -9,14 +9,14 @@ describe('MarkdownWikilinkService', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    prisma.document.findUnique.mockResolvedValue({ id: 'source1', title: '当前文件', number: 'DOC-001', doc_code: 'GRSS-CX-01' });
+    prisma.document.findUnique.mockResolvedValue({ id: 'source1', title: '当前文件', number: 'DOC-001', doc_code: null });
     prisma.documentReference.deleteMany.mockResolvedValue({ count: 0 });
     prisma.documentReference.create.mockResolvedValue({ id: 'ref1' });
     service = new MarkdownWikilinkService(prisma as any);
   });
 
-  it('extracts unique trimmed non-empty wikilink labels', () => {
-    expect(service.extractWikilinks('引用 [[GRSS-CX-01]]、[[ 原辅料验收标准 ]]、[[]]、[[GRSS-CX-01]]')).toEqual([
+  it('extracts unique trimmed wikilink targets without alias display labels', () => {
+    expect(service.extractWikilinks('引用 [[GRSS-CX-01|文件控制程序]]、[[ 原辅料验收标准 ]]、[[]]、[[GRSS-CX-01|重复显示]]')).toEqual([
       'GRSS-CX-01',
       '原辅料验收标准',
     ]);
@@ -38,6 +38,7 @@ describe('MarkdownWikilinkService', () => {
         targetLabel: '原辅料验收标准',
         relationType: 'WIKILINK',
         sectionId: 'wikilink:原辅料验收标准',
+        wikilinkTarget: '原辅料验收标准',
       }),
     });
     expect(prisma.document.findMany).toHaveBeenCalledWith(expect.objectContaining({
@@ -61,6 +62,7 @@ describe('MarkdownWikilinkService', () => {
         targetLabel: '不存在的文件',
         relationType: 'WIKILINK',
         sectionId: 'wikilink:不存在的文件',
+        wikilinkTarget: '不存在的文件',
       }),
     });
   });
@@ -84,6 +86,7 @@ describe('MarkdownWikilinkService', () => {
         relationType: 'WIKILINK',
         sectionId: 'wikilink:原辅料验收标准',
         snapshot: { candidates },
+        wikilinkTarget: '原辅料验收标准',
       }),
     });
   });
@@ -99,6 +102,32 @@ describe('MarkdownWikilinkService', () => {
     expect(prisma.documentReference.deleteMany.mock.invocationCallOrder[0]).toBeLessThan(
       prisma.documentReference.create.mock.invocationCallOrder[0],
     );
+  });
+
+  it('stores the alias target as wikilinkTarget and not the display label', async () => {
+    prisma.document.findMany.mockResolvedValueOnce([
+      { id: 'target1', title: '文件控制程序', number: 'GRSS-CX-01', doc_code: null },
+    ]);
+
+    await service.syncDocumentWikilinks('source1', '见 [[GRSS-CX-01|文件控制程序]]');
+
+    expect(prisma.document.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        OR: [
+          { number: 'GRSS-CX-01' },
+          { title: 'GRSS-CX-01' },
+          { doc_code: 'GRSS-CX-01' },
+        ],
+      }),
+    }));
+    expect(prisma.documentReference.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        targetDocId: 'target1',
+        targetLabel: '文件控制程序',
+        sectionId: 'wikilink:GRSS-CX-01',
+        wikilinkTarget: 'GRSS-CX-01',
+      }),
+    });
   });
 
   it('skips self-references when wikilink matches the source document', async () => {

--- a/server/src/modules/document/services/markdown-wikilink.service.ts
+++ b/server/src/modules/document/services/markdown-wikilink.service.ts
@@ -8,14 +8,19 @@ export class MarkdownWikilinkService {
   constructor(private readonly prisma: PrismaService) {}
 
   extractWikilinks(content: string): string[] {
-    const labels = Array.from(content.matchAll(/\[\[([^\]]+)\]\]/g))
-      .map((match) => match[1].trim())
-      .filter(Boolean);
-    return Array.from(new Set(labels));
+    const targets = Array.from(content.matchAll(/\[\[([^\]]+)\]\]/g))
+      .map((match) => this.extractTarget(match[1]))
+      .filter((target): target is string => Boolean(target));
+    return Array.from(new Set(targets));
+  }
+
+  private extractTarget(raw: string): string | null {
+    const target = raw.split('|')[0]?.trim();
+    return target || null;
   }
 
   async syncDocumentWikilinks(sourceDocId: string, content: string, client: WikilinkPrismaClient = this.prisma) {
-    const labels = this.extractWikilinks(content);
+    const wikilinkEntries = this.parseWikilinks(content);
 
     await client.documentReference.deleteMany({
       where: { sourceDocId, relationType: 'WIKILINK' },
@@ -26,8 +31,8 @@ export class MarkdownWikilinkService {
       select: { id: true, title: true, number: true, doc_code: true },
     });
 
-    for (const label of labels) {
-      if (this.matchesDocumentLabel(sourceDocument, label)) {
+    for (const { target, displayLabel } of wikilinkEntries) {
+      if (this.matchesDocumentLabel(sourceDocument, target)) {
         continue;
       }
 
@@ -36,28 +41,29 @@ export class MarkdownWikilinkService {
           id: { not: sourceDocId },
           deletedAt: null,
           OR: [
-            { number: label },
-            { title: label },
-            { doc_code: label },
+            { number: target },
+            { title: target },
+            { doc_code: target },
           ],
         },
         select: { id: true, title: true, number: true, doc_code: true },
         take: 10,
       });
 
-      const sectionId = `wikilink:${label}`;
+      const sectionId = `wikilink:${target}`;
 
       if (targets.length === 1) {
-        const target = targets[0];
+        const resolvedTarget = targets[0];
         await client.documentReference.create({
           data: {
             sourceDocId,
-            targetDocId: target.id,
+            targetDocId: resolvedTarget.id,
             targetType: 'document',
-            targetId: target.id,
-            targetLabel: target.title || target.number || label,
+            targetId: resolvedTarget.id,
+            targetLabel: displayLabel || resolvedTarget.title || resolvedTarget.number || target,
             relationType: 'WIKILINK',
             sectionId,
+            wikilinkTarget: target,
             syncedAt: new Date(),
           },
         });
@@ -70,14 +76,33 @@ export class MarkdownWikilinkService {
           targetDocId: null,
           targetType: targets.length > 1 ? 'conflict_document' : 'unresolved_document',
           targetId: null,
-          targetLabel: label,
+          targetLabel: displayLabel || target,
           relationType: 'WIKILINK',
           sectionId,
+          wikilinkTarget: target,
           snapshot: targets.length > 1 ? { candidates: targets } : undefined,
           syncedAt: new Date(),
         },
       });
     }
+  }
+
+  private parseWikilinks(content: string): Array<{ target: string; displayLabel: string | null }> {
+    const seen = new Set<string>();
+    const entries: Array<{ target: string; displayLabel: string | null }> = [];
+
+    for (const match of content.matchAll(/\[\[([^\]]+)\]\]/g)) {
+      const raw = match[1];
+      const parts = raw.split('|');
+      const target = parts[0]?.trim();
+      if (!target) continue;
+      if (seen.has(target)) continue;
+      seen.add(target);
+      const displayLabel = parts[1]?.trim() || null;
+      entries.push({ target, displayLabel });
+    }
+
+    return entries;
   }
 
   private matchesDocumentLabel(

--- a/server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql
+++ b/server/src/prisma/migrations/20260428000000_add_document_reference_wikilink_target/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "document_references"
+ADD COLUMN "wikilinkTarget" TEXT;
+
+UPDATE "document_references"
+SET "wikilinkTarget" = substring("sectionId" from 10)
+WHERE "relationType" = 'WIKILINK'
+  AND "wikilinkTarget" IS NULL
+  AND "sectionId" LIKE 'wikilink:%';
+
+CREATE INDEX "document_references_wikilinkTarget_idx"
+ON "document_references"("wikilinkTarget");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -2372,17 +2372,19 @@ model DocumentReference {
   targetLabel String?
   relationType String @default("RELATED_TO")
 
-  sectionId   String?
-  snapshot    Json?
-  syncedAt    DateTime?
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  sectionId      String?
+  wikilinkTarget String?
+  snapshot       Json?
+  syncedAt       DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   @@unique([sourceDocId, targetType, targetId, targetRoute, sectionId])
   @@index([sourceDocId])
   @@index([targetDocId])
   @@index([targetType, targetId])
   @@index([relationType])
+  @@index([wikilinkTarget])
   @@map("document_references")
 }
 


### PR DESCRIPTION
## Summary

- 新增 `DocumentReference.wikilinkTarget` 字段（Prisma schema + SQL migration + 回填逻辑）
- 后端 wikilink 同步服务支持 `[[target|label]]` 别名语法，所有引用类型持久化 `wikilinkTarget`
- `markdown-renderer.ts` 添加 `WikilinkStatus` 类型和状态 CSS 类（resolved / dangling / conflict / unknown）
- `MarkdownViewer.vue` 支持 `wikilinkStatusByTarget` prop 和 `wikilink-click` 事件
- `DocumentDetail.vue` 处理 wikilink 点击：已解析 → 导航到目标文档；悬空 → 警告并定位正文引用；冲突 → 警告并展开候选列表

## Test plan

- [x] 后端单元测试：7/7 PASS（`markdown-wikilink.service.spec.ts`）
- [x] 前端组件测试：8/8 PASS（`MarkdownViewer.spec.ts`）
- [x] 前端集成测试：32/32 PASS（`DocumentDetail.spec.ts`，含 5 个新 wikilink 点击导航用例）
- [x] 前端构建检查：`vue-tsc` + `vite build` 通过