### PR TITLE
feat: GAP-500 remove legacy level1/level2 approval frontend API calls

### DIFF
--- a/client/src/__tests__/approval-api.spec.ts
+++ b/client/src/__tests__/approval-api.spec.ts
@@ -37,49 +37,6 @@ describe('Approval API', () => {
     });
   });
 
-  describe('approveLevel1', () => {
-    it('should POST approved action with comment', async () => {
-      await approvalApi.approveLevel1('ap-1', 'approved', '同意');
-
-      expect(mockPost).toHaveBeenCalledWith(
-        '/approvals/level1/ap-1/approve',
-        {
-          approvalId: 'ap-1',
-          action: 'approved',
-          comment: '同意',
-        },
-      );
-    });
-
-    it('should POST rejected action with rejectionReason', async () => {
-      await approvalApi.approveLevel1('ap-1', 'rejected', '数据有误，请修正后重新提交');
-
-      expect(mockPost).toHaveBeenCalledWith(
-        '/approvals/level1/ap-1/approve',
-        {
-          approvalId: 'ap-1',
-          action: 'rejected',
-          rejectionReason: '数据有误，请修正后重新提交',
-        },
-      );
-    });
-  });
-
-  describe('approveLevel2', () => {
-    it('should POST to level2 approve endpoint', async () => {
-      await approvalApi.approveLevel2('ap-2', 'approved', '同意');
-
-      expect(mockPost).toHaveBeenCalledWith(
-        '/approvals/level2/ap-2/approve',
-        {
-          approvalId: 'ap-2',
-          action: 'approved',
-          comment: '同意',
-        },
-      );
-    });
-  });
-
   describe('getApprovalChain', () => {
     it('should GET approval chain by recordId', async () => {
       await approvalApi.getApprovalChain('record-456');

--- a/client/src/api/approval.ts
+++ b/client/src/api/approval.ts
@@ -75,28 +75,6 @@ export default {
   },
 
   /**
-   * 一级审批（主管审批）- 向后兼容
-   */
-  approveLevel1(id: string, action: 'approved' | 'rejected', commentOrReason?: string) {
-    return request.post<Approval>(`/approvals/level1/${id}/approve`, {
-      approvalId: id,
-      action,
-      ...(action === 'approved' ? { comment: commentOrReason } : { rejectionReason: commentOrReason }),
-    });
-  },
-
-  /**
-   * 二级审批（经理审批）- 向后兼容
-   */
-  approveLevel2(id: string, action: 'approved' | 'rejected', commentOrReason?: string) {
-    return request.post<Approval>(`/approvals/level2/${id}/approve`, {
-      approvalId: id,
-      action,
-      ...(action === 'approved' ? { comment: commentOrReason } : { rejectionReason: commentOrReason }),
-    });
-  },
-
-  /**
    * 获取审批链
    */
   getApprovalChain(recordId: string) {


### PR DESCRIPTION
## Summary

- Remove `approveLevel1` and `approveLevel2` helper functions from `client/src/api/approval.ts` — these called dead routes `/approvals/level1/:id/approve` and `/approvals/level2/:id/approve` that no longer exist on the backend
- Remove the corresponding unit tests in `client/src/__tests__/approval-api.spec.ts`
- No call sites in component/view files — legacy helpers were unused outside their own module and test file
- `approveUnified` and `rejectUnified` remain intact as the authoritative unified approval surface

## Verification

- `rg "approveLevel1|approveLevel2|/approvals/level1|/approvals/level2" client/src` → no matches
- `npm run build:client` → ✓ built in 1m 4s, no TypeScript errors
- `node tools/check-module-usage-docs.mjs` → ✓ All checks passed. 80 GAP(s) registered
- `git diff --check` → clean

## Test plan

- [ ] Confirm no TypeScript compilation errors in client
- [ ] Confirm `client/src/api/approval.ts` exports only unified approval helpers
- [ ] Confirm approval task UI (pending approvals page) still functions using `approveUnified`
- [ ] No schema or migration changes