### PR TITLE
feat: GAP-601 add class-level JwtAuthGuard to equipment controllers

### DIFF
--- a/server/src/modules/equipment/equipment.controller.ts
+++ b/server/src/modules/equipment/equipment.controller.ts
@@ -9,7 +9,9 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { EquipmentService } from './equipment.service';
 import {
   CreateEquipmentDto,
@@ -18,6 +20,7 @@ import {
   QueryEquipmentDto,
 } from './dto/equipment.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('equipment')
 export class EquipmentController {
   constructor(private readonly equipmentService: EquipmentService) {}

--- a/server/src/modules/equipment/fault.controller.ts
+++ b/server/src/modules/equipment/fault.controller.ts
@@ -7,7 +7,9 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { FaultService } from './fault.service';
 import {
   CreateFaultDto,
@@ -16,6 +18,7 @@ import {
   QueryFaultDto,
 } from './dto/fault.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('equipment/faults')
 export class FaultController {
   constructor(private readonly faultService: FaultService) {}

--- a/server/src/modules/equipment/plan.controller.ts
+++ b/server/src/modules/equipment/plan.controller.ts
@@ -4,10 +4,13 @@ import {
   Post,
   Param,
   Query,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { PlanService } from './plan.service';
 import { QueryPlanDto, CalendarQueryDto } from './dto/plan.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('maintenance-plans')
 export class PlanController {
   constructor(private readonly planService: PlanService) {}

--- a/server/src/modules/equipment/record.controller.ts
+++ b/server/src/modules/equipment/record.controller.ts
@@ -8,7 +8,9 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RecordService } from './record.service';
 import {
   CreateRecordDto,
@@ -18,6 +20,7 @@ import {
   QueryRecordDto,
 } from './dto/record.dto';
 
+@UseGuards(JwtAuthGuard)
 @Controller('maintenance-records')
 export class RecordController {
   constructor(private readonly recordService: RecordService) {}

--- a/server/src/modules/equipment/stats.controller.ts
+++ b/server/src/modules/equipment/stats.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { StatsService } from './stats.service';
 
+@UseGuards(JwtAuthGuard)
 @Controller('equipment/stats')
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}

--- a/server/src/modules/equipment/upload.controller.ts
+++ b/server/src/modules/equipment/upload.controller.ts
@@ -11,7 +11,9 @@ import {
   UploadedFile,
   UseInterceptors,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { StorageService } from '../../common/services/storage.service';
 
@@ -24,6 +26,7 @@ const ALLOWED_IMAGE_TYPES = [
   'image/webp',
 ];
 
+@UseGuards(JwtAuthGuard)
 @Controller('upload')
 export class UploadController {
   constructor(private readonly storageService: StorageService) {}


### PR DESCRIPTION
## Summary

- Add `@UseGuards(JwtAuthGuard)` at class level to all 6 equipment-management controllers
- Affected controllers: `equipment`, `maintenance-plans`, `maintenance-records`, `equipment/faults`, `equipment/stats`, `upload`
- No endpoint path changes, no DTO changes, no schema/migration changes

## Test plan

- [ ] Build: `npm run build:server` — no new errors in equipment module (pre-existing 1503 unrelated TypeScript errors unchanged)
- [ ] Module doc check: `node tools/check-module-usage-docs.mjs` — all 80 GAPs pass
- [ ] Whitespace: `git diff --check` — clean
- [ ] Runtime verification: `curl -i http://localhost:3000/api/v1/equipment` without Authorization header should return 401 (skipped — server not running in CI environment)