### PR TITLE
feat: [GAP-601] Add JwtAuthGuard to equipment management controllers

### DIFF
--- a/server/src/modules/equipment/equipment.controller.ts
+++ b/server/src/modules/equipment/equipment.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { EquipmentService } from './equipment.service';
 import {
@@ -17,8 +18,10 @@ import {
   UpdateEquipmentStatusDto,
   QueryEquipmentDto,
 } from './dto/equipment.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('equipment')
+@UseGuards(JwtAuthGuard)
 export class EquipmentController {
   constructor(private readonly equipmentService: EquipmentService) {}
 

--- a/server/src/modules/equipment/fault.controller.ts
+++ b/server/src/modules/equipment/fault.controller.ts
@@ -7,6 +7,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { FaultService } from './fault.service';
 import {
@@ -15,8 +16,10 @@ import {
   CompleteFaultDto,
   QueryFaultDto,
 } from './dto/fault.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('equipment/faults')
+@UseGuards(JwtAuthGuard)
 export class FaultController {
   constructor(private readonly faultService: FaultService) {}
 

--- a/server/src/modules/equipment/plan.controller.ts
+++ b/server/src/modules/equipment/plan.controller.ts
@@ -4,11 +4,14 @@ import {
   Post,
   Param,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { PlanService } from './plan.service';
 import { QueryPlanDto, CalendarQueryDto } from './dto/plan.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('maintenance-plans')
+@UseGuards(JwtAuthGuard)
 export class PlanController {
   constructor(private readonly planService: PlanService) {}
 

--- a/server/src/modules/equipment/record.controller.ts
+++ b/server/src/modules/equipment/record.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { RecordService } from './record.service';
 import {
@@ -17,8 +18,10 @@ import {
   RejectRecordDto,
   QueryRecordDto,
 } from './dto/record.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('maintenance-records')
+@UseGuards(JwtAuthGuard)
 export class RecordController {
   constructor(private readonly recordService: RecordService) {}
 

--- a/server/src/modules/equipment/stats.controller.ts
+++ b/server/src/modules/equipment/stats.controller.ts
@@ -1,7 +1,9 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { StatsService } from './stats.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('equipment/stats')
+@UseGuards(JwtAuthGuard)
 export class StatsController {
   constructor(private readonly statsService: StatsService) {}
 

--- a/server/src/modules/equipment/upload.controller.ts
+++ b/server/src/modules/equipment/upload.controller.ts
@@ -11,9 +11,11 @@ import {
   UploadedFile,
   UseInterceptors,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { StorageService } from '../../common/services/storage.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 const PHOTO_MAX_SIZE = 5 * 1024 * 1024;
 const SIGNATURE_MAX_SIZE = 1 * 1024 * 1024;
@@ -25,6 +27,7 @@ const ALLOWED_IMAGE_TYPES = [
 ];
 
 @Controller('upload')
+@UseGuards(JwtAuthGuard)
 export class UploadController {
   constructor(private readonly storageService: StorageService) {}
 


### PR DESCRIPTION
## Summary

- Add class-level `@UseGuards(JwtAuthGuard)` to all 6 equipment-related controllers
- Controllers protected: `equipment`, `maintenance-plans`, `maintenance-records`, `equipment/faults`, `equipment/stats`, `upload`
- Import pattern matches the existing `measuring-equipment` module

## Files Modified

- `server/src/modules/equipment/equipment.controller.ts`
- `server/src/modules/equipment/plan.controller.ts`
- `server/src/modules/equipment/record.controller.ts`
- `server/src/modules/equipment/fault.controller.ts`
- `server/src/modules/equipment/stats.controller.ts`
- `server/src/modules/equipment/upload.controller.ts`

## Test Plan

- [x] `npm run build:server` — no new errors (215 pre-existing TS errors unrelated to equipment controllers)
- [x] `node tools/check-module-usage-docs.mjs` — ✓ All checks passed, 80 GAPs registered
- [x] `git diff --check` — no whitespace issues
- [ ] Runtime curl check skipped (no local server running in this environment)

## Notes

- No endpoint paths changed
- No role/permission-level authorization added
- No schema or migration changes