### PR TITLE
feat(GAP-105): remove hardcoded company_id from SupplierEvaluation

### DIFF
--- a/server/src/modules/supplier-evaluation/supplier-evaluation.controller.ts
+++ b/server/src/modules/supplier-evaluation/supplier-evaluation.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Post, Body, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Request, UseGuards } from '@nestjs/common';
 import { SupplierEvaluationService } from './supplier-evaluation.service';
 import { CreateEvaluationDto } from './dto/create-evaluation.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 
 @Controller('supplier-evaluations')
 @UseGuards(JwtAuthGuard)
@@ -9,17 +10,17 @@ export class SupplierEvaluationController {
   constructor(private service: SupplierEvaluationService) {}
 
   @Post()
-  create(@Body() dto: CreateEvaluationDto) {
-    return this.service.create(dto);
+  create(@Body() dto: CreateEvaluationDto, @Request() req: AuthenticatedRequest) {
+    return this.service.create(dto, req.user.companyId);
   }
 
   @Get()
-  findAll() {
-    return this.service.findAll();
+  findAll(@Request() req: AuthenticatedRequest) {
+    return this.service.findAll(req.user.companyId);
   }
 
   @Get('supplier/:supplierId')
-  findBySupplier(@Param('supplierId') supplierId: string) {
-    return this.service.findBySupplier(supplierId);
+  findBySupplier(@Param('supplierId') supplierId: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findBySupplier(supplierId, req.user.companyId);
   }
 }

--- a/server/src/modules/supplier-evaluation/supplier-evaluation.service.spec.ts
+++ b/server/src/modules/supplier-evaluation/supplier-evaluation.service.spec.ts
@@ -1,0 +1,121 @@
+import { Test } from '@nestjs/testing';
+import { SupplierEvaluationService } from './supplier-evaluation.service';
+import { PrismaService } from '../../prisma/prisma.service';
+
+describe('SupplierEvaluationService - company scoping', () => {
+  let service: SupplierEvaluationService;
+
+  const mockEvaluation = {
+    id: 'eval-1',
+    company_id: 'company-a',
+    supplier_id: 'sup-1',
+    eval_period: '2026-Q1',
+    eval_date: new Date(),
+    quality_score: 90,
+    delivery_score: 80,
+    service_score: 85,
+    total_score: 85,
+    verdict: 'approved',
+    notes: null,
+    evaluator_id: null,
+    created_at: new Date(),
+  };
+
+  const mockPrisma = {
+    supplierEvaluation: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+    supplier: {
+      update: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      providers: [
+        SupplierEvaluationService,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+    service = module.get(SupplierEvaluationService);
+  });
+
+  describe('create', () => {
+    it('uses the provided companyId, not a hardcoded value', async () => {
+      mockPrisma.supplierEvaluation.create.mockResolvedValue(mockEvaluation);
+      mockPrisma.supplier.update.mockResolvedValue({});
+
+      const dto = {
+        supplier_id: 'sup-1',
+        eval_period: '2026-Q1',
+        quality_score: 90,
+        delivery_score: 80,
+        service_score: 85,
+        verdict: 'approved',
+        notes: null,
+      } as any;
+
+      await service.create(dto, 'company-a');
+
+      expect(mockPrisma.supplierEvaluation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ company_id: 'company-a' }),
+        }),
+      );
+    });
+
+    it('does not hardcode company_id as "1"', async () => {
+      mockPrisma.supplierEvaluation.create.mockResolvedValue(mockEvaluation);
+      mockPrisma.supplier.update.mockResolvedValue({});
+
+      const dto = {
+        supplier_id: 'sup-1',
+        eval_period: '2026-Q1',
+        quality_score: 90,
+        delivery_score: 80,
+        service_score: 85,
+        verdict: 'approved',
+        notes: null,
+      } as any;
+
+      await service.create(dto, 'company-b');
+
+      const callArg = mockPrisma.supplierEvaluation.create.mock.calls[0][0];
+      expect(callArg.data.company_id).toBe('company-b');
+      expect(callArg.data.company_id).not.toBe('1');
+    });
+  });
+
+  describe('findAll', () => {
+    it('filters by companyId', async () => {
+      mockPrisma.supplierEvaluation.findMany.mockResolvedValue([mockEvaluation]);
+
+      await service.findAll('company-a');
+
+      expect(mockPrisma.supplierEvaluation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ company_id: 'company-a' }),
+        }),
+      );
+    });
+  });
+
+  describe('findBySupplier', () => {
+    it('filters by both supplierId and companyId', async () => {
+      mockPrisma.supplierEvaluation.findMany.mockResolvedValue([mockEvaluation]);
+
+      await service.findBySupplier('sup-1', 'company-a');
+
+      expect(mockPrisma.supplierEvaluation.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            supplier_id: 'sup-1',
+            company_id: 'company-a',
+          }),
+        }),
+      );
+    });
+  });
+});

--- a/server/src/modules/supplier-evaluation/supplier-evaluation.service.ts
+++ b/server/src/modules/supplier-evaluation/supplier-evaluation.service.ts
@@ -6,7 +6,7 @@ import { CreateEvaluationDto } from './dto/create-evaluation.dto';
 export class SupplierEvaluationService {
   constructor(private prisma: PrismaService) {}
 
-  async create(dto: CreateEvaluationDto) {
+  async create(dto: CreateEvaluationDto, companyId: string) {
     const total_score =
       dto.quality_score != null &&
       dto.delivery_score != null &&
@@ -16,7 +16,7 @@ export class SupplierEvaluationService {
 
     const evaluation = await this.prisma.supplierEvaluation.create({
       data: {
-        company_id: '1',
+        company_id: companyId,
         supplier_id: dto.supplier_id,
         eval_period: dto.eval_period,
         eval_date: new Date(),
@@ -46,15 +46,16 @@ export class SupplierEvaluationService {
     return evaluation;
   }
 
-  async findBySupplier(supplierId: string) {
+  async findBySupplier(supplierId: string, companyId: string) {
     return this.prisma.supplierEvaluation.findMany({
-      where: { supplier_id: supplierId },
+      where: { supplier_id: supplierId, company_id: companyId },
       orderBy: { eval_date: 'desc' },
     });
   }
 
-  async findAll() {
+  async findAll(companyId: string) {
     return this.prisma.supplierEvaluation.findMany({
+      where: { company_id: companyId },
       include: { supplier: true },
       orderBy: { eval_date: 'desc' },
       take: 100,


### PR DESCRIPTION
## Summary

- Replace `company_id: '1'` hardcode with `req.user.companyId` in `SupplierEvaluation` service
- Controller injects `AuthenticatedRequest` and passes `companyId` to all service methods
- `findAll` and `findBySupplier` now filter by `company_id` for tenant isolation
- `Supplier` model has no `company_id` — supplier status update kept unchanged (no ownership guard needed)

## Test plan

- [x] Unit tests added: 4 tests covering `create`, `findAll`, `findBySupplier` company scoping
- [x] Static check: no `company_id: '1'` remains in `server/src/modules/supplier-evaluation`
- [x] `node tools/check-module-usage-docs.mjs` — all checks passed
- [x] `git diff --check` — no whitespace issues
- [ ] Integration test: verify create/list endpoints return only records for authenticated user's company