### PR TITLE
docs: GAP-502/503/504 审批/工作流/任务边界使用指南

### DIFF
--- a/docs/module-usage/12-task-approval-workflow.md
+++ b/docs/module-usage/12-task-approval-workflow.md
@@ -122,6 +122,10 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 
 ## 7. 当前系统差距
 
+> **边界说明见：** [`docs/superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md`](../superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md)
+>
+> 该文档包含旧 Approval、UnifiedApproval、Workflow、Task、RecordTaskAssignment 五类机制的定义、决策树和禁止事项，适用于 GAP-502/503/504 的后续整改。
+
 | GAP 编号 | 当前问题 | 根因 | 影响后果 | 严重级别 | 验证状态 | 证据 |
 |----------|----------|------|----------|----------|----------|------|
 | GAP-500 | 前端 `approveLevel1`/`approveLevel2` 调用 `/approvals/level1/:id/approve` 和 `/approvals/level2/:id/approve`，后端无此路由 | 旧接口残留调用未清理 | 旧审批"一级/二级审批"按钮调用后返回 404 | P1（高） | 已验证 | `client/src/api/approval.ts:L63,L76`；`server/src/modules/approval/approval.controller.ts` 无 level1/level2 路由 |

--- a/docs/module-usage/13-system-admin-ops.md
+++ b/docs/module-usage/13-system-admin-ops.md
@@ -65,6 +65,8 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 
 **关键结论**：`FineGrainedPermission` + `UserPermission` 是 ABAC 的细粒度定义源，`Permission` + `RolePermission` 是 RBAC 的粗粒度定义源。两者并存，由 `FineGrainedPermissionGuard` 在请求时联合评估。`DepartmentPermission` 是独立的数据边界层。
 
+> **新功能权限决策参考**：在新功能中决定使用哪个权限层时，请先阅读 [`docs/superpowers/specs/2026-05-01-permission-model-decision-guide.md`](../superpowers/specs/2026-05-01-permission-model-decision-guide.md)，其中包含各层职责定义、决策树和禁止重复实现规则（GAP-512）。
+
 ## 2. 使用角色
 
 | 角色 | 使用目的 | 关键动作 |

--- a/docs/module-usage/98-coverage-matrix.md
+++ b/docs/module-usage/98-coverage-matrix.md
@@ -3,6 +3,8 @@
 > 生成日期：2026-05-01  
 > 覆盖范围：前端路由、后端模块、Prisma 模型、API 适配器
 
+> **审批 / 工作流 / 任务机制选择指南：** [`docs/superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md`](../superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md)（涵盖 GAP-502/503/504 边界说明）
+
 ---
 
 ## 1. 前端路由覆盖表
@@ -220,7 +222,7 @@
 | notification | 13-system-admin-ops.md | 支撑能力 | 已覆盖 | 通知推送 |
 | operation-log | 13-system-admin-ops.md | 支撑能力 | 已覆盖 | 操作日志 |
 | packaging-material-usage | 06-mixing-production-packaging.md | 业务主链 | 已覆盖 | 包材用量，见 GAP-203 |
-| permission | 13-system-admin-ops.md | 支撑能力 | 已覆盖 | 权限模型，见 GAP-512 |
+| permission | 13-system-admin-ops.md | 支撑能力 | 已覆盖 | 权限模型，见 GAP-512；决策指南见 [2026-05-01-permission-model-decision-guide.md](../superpowers/specs/2026-05-01-permission-model-decision-guide.md) |
 | process | 02-master-data-and-boundaries.md | 业务主链 | 已覆盖 | 研发工艺流程，见 GAP-001/006 |
 | process-record | 07-quality-qc-release.md | 业务主链 | 已覆盖 | 生产过程记录 |
 | process-step | 02-master-data-and-boundaries.md | 业务主链 | 已覆盖 | 工序，见 GAP-005 |

--- a/docs/superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md
+++ b/docs/superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md
@@ -1,0 +1,166 @@
+# 审批 / 工作流 / 任务边界使用指南
+
+> **GAP-502 / GAP-503 / GAP-504**
+> 本文档说明旧审批、统一审批、工作流、任务、记录任务派发五类机制的适用边界，帮助后续 agent 和开发者在不阅读 schema 的前提下选择正确机制。
+
+---
+
+## 结论先行
+
+| 场景 | 选择 |
+|------|------|
+| 文档模块的历史审批记录兼容 | 旧 `Approval`（只读/维护，禁止新接入） |
+| 新业务需要多步骤审批（如培训、偏差、来料、变更） | `UnifiedApproval`（ApprovalDefinition → ApprovalInstance → ApprovalTask） |
+| 需要按模板配置多步骤流程、支持条件路由 | `Workflow`（WorkflowTemplate → WorkflowInstance → WorkflowTask） |
+| 管理员向部门下发一次性数据收集任务 | `Task`（含 TaskRecord 提交，接入 UnifiedApproval 审批） |
+| 按计划周期性生成记录表单填写任务 | `RecordTaskAssignment`（由 cron 自动生成 RecordTaskInstance） |
+
+---
+
+## 一、五类机制定义
+
+### 1. 旧 `Approval`（Legacy Approval）
+
+**表：** `approvals`
+
+**用途：** 文档模块的链式签批，支持 `single`（单级）、`countersign`（会签）、`sequential`（顺签）三种模式，直接关联 `documents.id`。
+
+**权威性：** 历史/兼容性口径。当前只有文档模块使用，且 `ApprovalService.getPendingApprovals()` 已做 fallback 兼容两套 API。
+
+**状态：** 迁移冻结——禁止新业务继续接入，不迁移历史数据，不删除现有接口。
+
+---
+
+### 2. `UnifiedApproval`（统一审批平台）
+
+**表：** `approval_definitions` / `approval_instances` / `approval_tasks` / `approval_actions`
+
+**用途：** 新一代多步骤审批引擎。支持：
+- 审批模式：`single`、`countersign_all`、`countersign_any`、`sequential`、`parallel_groups`
+- 分配策略：`user`、`role`、`department`、`permission`
+- Claim 模式：`DIRECT`（直接分配）、`CLAIMABLE`（抢单池）
+- 回调机制：`ApprovalCallbackRegistry` 在审批通过后更新业务状态
+
+**接入方式：**
+1. 在 `approval_definitions` 写入审批流程定义（`resourceType + triggerKey + version`）
+2. 业务事件触发时调用 `ApprovalEngineService.startApproval()`
+3. 等待 `ApprovalCallbackRegistry` 回调更新业务状态
+
+**已接入模块：** 研发流程（ProcessInstance）、培训计划（TrainingPlan）、任务记录（TaskRecord）、偏差报告（DeviationReport）、来料、变更、文档。
+
+**权威性：** 后续审批工作的权威方向。
+
+---
+
+### 3. `Workflow`（通用工作流引擎）
+
+**表：** `workflow_templates` / `workflow_instances` / `workflow_tasks`
+
+**用途：** 通用流程编排，按模板 JSON 配置多步骤任务流转，支持：
+- 条件路由（ConditionParser）
+- 任务委托（delegatedTo）
+- 步骤回滚
+- 10 分钟 cron 超时升级
+
+**与 UnifiedApproval 的区别：**
+
+| 维度 | Workflow | UnifiedApproval |
+|------|----------|-----------------|
+| 定位 | 通用步骤流转编排 | 业务对象审批决策 |
+| 步骤定义 | JSON 配置，灵活条件 | 固定审批步骤 + 分配策略 |
+| 审批语义 | 无内置审批语义 | approve / reject / comment |
+| 回调机制 | 无内置回调注册 | ApprovalCallbackRegistry |
+| 待办聚合 | 通过 WorkflowTodoBridge 写 TodoTask | 通过 ApprovalTodoBridge 写 TodoTask |
+
+**已接入模块：** Record（记录填写）、Training（培训）。
+
+**权威性：** 独立系统，无融合计划前不与统一审批平台互通。
+
+---
+
+### 4. `Task`（一次性任务管理）
+
+**表：** `tasks` / `task_records`
+
+**用途：** 管理员向部门下发一次性数据收集任务。流程：
+1. 管理员创建 `Task`（关联 `RecordTemplate`，指定部门和截止日期）
+2. 部门成员提交 `TaskRecord`（支持草稿、偏差检测）
+3. `TaskRecord` 接入 `UnifiedApprovalEngine` 完成审批
+4. 审批通过后归档
+
+**与 RecordTaskAssignment 的区别：** `Task` 是管理员手动下发的单次事项，有明确截止和审批链路；`RecordTaskAssignment` 是计划性周期配置，由系统自动触发。
+
+---
+
+### 5. `RecordTaskAssignment`（周期性记录任务派发）
+
+**表：** `record_task_assignments` / `record_task_instances`
+
+**用途：** 管理员为特定 `RecordTemplate` 配置周期性或单次填写任务计划：
+- 周期性：通过 `cron_expression` 配置，由 `ScheduledTaskService` 自动生成 `RecordTaskInstance`
+- 单次：设置 `deadline`，系统触发后生成实例
+- 状态控制：`active` / `paused` / `closed`
+
+**实例生命周期：** `RecordTaskInstance` 生成 → 员工在 `/record-tasks/my` 查看 → 提交 Record → 实例状态更新。
+
+**与 Task 的区别：** `RecordTaskAssignment` 没有内置审批链路，关注的是周期性数据采集的触发和派发；`Task` 关注一次性下发 + 提交审批。
+
+---
+
+## 二、新业务接入决策树
+
+```
+需要发起一次业务审批（需要人工 approve/reject）？
+  ├─ 是 → 是否是文档模块的旧链式审批兼容场景？
+  │         ├─ 是 → 维护旧 Approval（不允许新增接入）
+  │         └─ 否 → 使用 UnifiedApproval（ApprovalDefinition + startApproval）
+  └─ 否 → 是否是多步骤流程编排（含条件路由、步骤回滚）？
+             ├─ 是 → 使用 Workflow（WorkflowTemplate + WorkflowInstance）
+             └─ 否 → 是否是管理员手动下发给部门的一次性填写任务？
+                        ├─ 是 → 使用 Task（Task + TaskRecord，自动接入 UnifiedApproval）
+                        └─ 否 → 是否是按计划周期性生成记录表单填写任务？
+                                   ├─ 是 → 使用 RecordTaskAssignment（cron 触发）
+                                   └─ 否 → 重新确认需求
+```
+
+---
+
+## 三、禁止事项
+
+1. **禁止新业务接入旧 `Approval`**
+   旧 `Approval` 仅供文档模块历史兼容，不允许任何新业务模块直接写 `approvals` 表或调用 `approval.controller` 的链式审批接口。
+
+2. **禁止把 `Workflow` 当审批平台替代品**
+   `Workflow` 是通用流程编排引擎，无内置 approve/reject 语义，不能替代 `UnifiedApproval` 做业务审批决策。混用会导致审批状态无法通过 `ApprovalCallbackRegistry` 回传业务，待办无法聚合。
+
+3. **禁止把周期性记录表单派发塞进一次性 `Task`**
+   `Task` 没有 cron 配置，也没有 `paused`/`closed` 生命周期控制。周期性采集场景应使用 `RecordTaskAssignment`。
+
+4. **禁止在业务模块里重新建一套审批状态字段**
+   不允许在业务表（如偏差报告、培训计划）上新增 `approvalStatus`、`approvalResult` 等字段来绕过统一审批平台。业务状态应通过 `approvalInstanceId` 关联 `approval_instances`，由 `ApprovalCallbackRegistry` 回调更新。
+
+---
+
+## 四、后续迁移建议
+
+> 本 PR 不执行迁移，仅记录建议方向。
+
+| 项目 | 建议 | 前置条件 |
+|------|------|----------|
+| 旧 `Approval` → UnifiedApproval | 文档模块历史审批逐步迁移至统一审批平台，旧接口标注 `@deprecated` | 需业务确认文档审批链路改造范围 |
+| 旧审批接口废弃 | 在 `approval.controller.ts` 加 deprecation 注释，前端移除 `approveLevel1`/`approveLevel2` 调用 | GAP-500 已记录，可并行推进 |
+| Workflow 与 UnifiedApproval 融合评估 | 两套系统目前独立，无融合计划。如果出现同一业务对象同时需要审批决策和步骤流转，再评估桥接方案 | 需业务场景出现后再决策 |
+
+---
+
+## 五、证据索引
+
+| 声明 | 证据来源 |
+|------|----------|
+| 旧 Approval 仅文档模块使用 | `server/src/modules/approval/approval.service.ts`：注释"仅支持文档审批" |
+| UnifiedApproval 已接入多模块 | `server/src/modules/unified-approval/approval-engine.service.ts`：ApprovalCallbackRegistry |
+| Workflow 独立于统一审批 | `server/src/modules/workflow/workflow-template.controller.ts` 和 `approval-instance.controller.ts` 无交叉注入 |
+| Task 接入 UnifiedApproval | `server/src/modules/task/task.service.ts`：TaskRecord.approvalInstanceId 关联 approval_instances |
+| RecordTaskAssignment cron 触发 | `server/src/modules/record-task/record-task-cron.service.ts` |
+| schema 行号 | `schema.prisma:L401`（Approval）、`L434`（ApprovalDefinition）、`L686`（WorkflowTemplate）、`L3832`（Task）、`L2368`（RecordTaskAssignment） |
+| 模块使用文档 | `docs/module-usage/12-task-approval-workflow.md`：GAP-502/503/504 |

--- a/docs/superpowers/specs/2026-05-01-permission-model-decision-guide.md
+++ b/docs/superpowers/specs/2026-05-01-permission-model-decision-guide.md
@@ -1,0 +1,226 @@
+# GAP-512 权限模型决策指南
+
+> **本文档用途**：让新 agent 或开发者在不阅读 schema 的前提下，能决定「新功能的权限检查应该用哪一层」。
+>
+> **本文档范围**：仅描述现有权限层的职责和使用规则，不改变任何 schema、guard、seed 或运行时行为。
+
+---
+
+## 结论先行
+
+| 你要做的事 | 应该用哪一层 |
+|-----------|-------------|
+| 新功能的菜单/路由/接口能不能进 | `Role + Permission`（RBAC 粗粒度） |
+| 某角色能不能执行某个操作（resource+action） | `RoleFineGrainedPermission`（ABAC-Role） |
+| 给某个具体用户开临时例外权限（可选有效期、资源范围） | `UserPermission + FineGrainedPermission`（ABAC-User） |
+| 限制某个部门能看哪些数据资源 | `DepartmentPermission`（数据边界层） |
+| 记录谁改了谁的权限 | `PermissionLog`（审计事实源） |
+
+**运行时行为不变**：本文档是描述文档，不触发任何 guard、decorator、seed 或 schema 变更。
+
+---
+
+## 1. 权限层定义
+
+### 层 1：Role + Permission（RBAC 粗粒度）
+
+**职责**：控制用户是否有权访问某个功能入口（菜单/路由/API endpoint）。
+
+**Schema 来源**：
+- `server/src/prisma/schema.prisma` — `Role`、`Permission`、`RolePermission`
+
+**关键字段**：
+- `Role.code`：`"admin"` / `"leader"` / `"user"`（三个预置角色）
+- `Permission.resource`：如 `"document"`、`"template"`、`"task"`、`"approval"`
+- `Permission.action`：如 `"create"`、`"read"`、`"update"`、`"delete"`、`"approve"`
+- `RolePermission`：多对多桥接，绑定角色和权限
+
+**Guard/Decorator**：
+- Guard：`RolesGuard`（`server/src/common/guards/roles.guard.ts`）
+- Decorator：`@Roles(...roles: string[])`（`server/src/common/decorators/roles.decorator.ts`）
+- 当前读取 `User.role` 字符串字段（该字段已废弃，待迁移到 `User.roleId`，见"已知未解决问题"）
+
+**使用时机**：
+- 新 API endpoint 需要限制只有 `admin` 或 `leader` 能访问时，使用 `@Roles('admin', 'leader')`
+- 新功能菜单需要按角色控制显示时，查 `Role + Permission`
+
+---
+
+### 层 2：RoleFineGrainedPermission（ABAC-Role，角色级细粒度）
+
+**职责**：在角色维度配置 resource+action 粒度的白名单，是对 RBAC 粗粒度的操作级别补充。
+
+**Schema 来源**：
+- `server/src/prisma/schema.prisma` — `RoleFineGrainedPermission`
+
+**关键字段**：
+- `roleId`：绑定到哪个角色
+- `resource`：资源名称
+- `action`：操作名称
+- `allowed`：是否允许（布尔值）
+
+**管理接口**：
+- `PUT /fine-grained-permissions/role/:roleId`（`fine-grained-permission.controller.ts`）
+
+**使用时机**：
+- 需要在角色层面配置操作级别权限时（不针对单个用户）
+
+---
+
+### 层 3：UserPermission + FineGrainedPermission（ABAC-User，用户例外授权）
+
+**职责**：对特定用户进行例外授权，支持有效期和资源范围限制。这是最细粒度的权限控制。
+
+**Schema 来源**：
+- `server/src/prisma/schema.prisma` — `FineGrainedPermission`、`UserPermission`
+
+**关键字段**（`FineGrainedPermission`）：
+- `code`：唯一权限代码，如 `"view:department:document"`
+- `category`：如 `"document"`、`"record"`、`"task"`
+- `scope`：`"global"` / `"cross_department"` / `"department"`
+
+**关键字段**（`UserPermission`）：
+- `userId`：被授权用户
+- `fineGrainedPermissionId`：绑定的细粒度权限
+- `grantedBy`：授权人 userId
+- `expiresAt`：可选有效期（为 null 则永久有效）
+- `resourceType`：可选资源类型（如 `"document"`）
+- `resourceId`：可选资源 ID（精确到单条记录的授权）
+
+**Guard/Decorator**：
+- Guard：`PermissionGuard`（`server/src/common/guards/permission.guard.ts`）
+- 支持缓存（Redis，TTL 300 秒，key：`user_permissions:{userId}`）
+- Decorator：
+  - `@CheckPermission(code)` — 检查单个权限
+  - `@CheckPermissions(codes[])` — 检查多个权限（AND 逻辑）
+  - `@CheckAnyPermission(codes[])` — 检查多个权限（OR 逻辑）
+  - `@Resource(type, idParam)` — 资源级别权限范围
+
+**管理接口**：
+- `POST /user-permissions/grant` — 授权
+- `DELETE /user-permissions/:id/revoke` — 撤销
+- `GET /user-permissions/:userId/effective` — 查看有效权限
+
+**运行时行为**：
+- 过期权限（`expiresAt < now`）在检查时自动跳过（BR-354）
+- Admin 用户绕过所有权限检查（`if (user.role === 'admin') return true`）
+
+**使用时机**：
+- 需要对某个用户临时开放权限时
+- 需要针对单条资源（如某份文件）授权时
+- 需要设置有效期的权限时
+
+---
+
+### 层 4：DepartmentPermission（数据边界层）
+
+**职责**：限制部门对特定资源的访问范围，是数据隔离层，不是功能权限层。
+
+**Schema 来源**：
+- `server/src/prisma/schema.prisma` — `DepartmentPermission`
+
+**关键字段**：
+- `departmentId`：哪个部门
+- `resource`：资源类型
+- `action`：操作
+- `allowed`：是否允许
+
+**Service**：`DepartmentPermissionService`（`server/src/modules/department-permission/`）
+
+**核心方法**：
+- `canAccessDepartmentResource(userId, departmentId, action, resourceType)` — 检查用户是否能访问某部门数据（BR-356）
+- `hasCrossDepartmentPermission(userId, permissionCode)` — 检查是否有跨部门权限（BR-357）
+- `getAccessibleDepartments(userId, resourceType)` — 列出用户可访问的部门列表
+
+**运行时行为**：
+- 默认：用户只能访问自己部门的数据
+- 例外：如果用户在 `UserPermission` 中有 `scope = "cross_department"` 或 `"global"` 的权限，可跨部门访问
+
+**使用时机**：
+- 新功能需要按部门隔离数据时，调用 `DepartmentPermissionService`
+- 不要在 DepartmentPermission 中存储功能权限（功能权限归层 1/2/3）
+
+---
+
+### 层 5：PermissionLog（审计事实源）
+
+**职责**：记录权限变更操作，是权限审计的事实源。
+
+**Schema 来源**：
+- `server/src/prisma/schema.prisma` — `PermissionLog`
+
+**关键字段**：
+- `operatorId` / `operatorName`：操作人
+- `targetUserId` / `targetUsername`：被操作对象
+- `action`：`"assign_role"` / `"revoke_role"` / `"change_department"`
+- `beforeValue` / `afterValue`：变更前后值（JSON）
+- `reason`：变更原因
+- `ipAddress`：来源 IP
+
+**注意**：当前未发现独立的 `PermissionLog` controller，日志写入集成在 `UserPermissionService` 中。权限审计查询端点尚未确认（见 GAP-506，已知未解决问题）。
+
+---
+
+## 2. 决策树：新功能应该用哪一层？
+
+```
+新功能需要权限控制
+│
+├─► 控制「谁能进这个菜单/路由/API」？
+│   └─► 用层 1：@Roles('admin') 或 @Roles('leader', 'admin')
+│
+├─► 控制「某个角色能否执行某 resource+action」？
+│   └─► 用层 2：RoleFineGrainedPermission
+│       通过 /fine-grained-permissions/role/:roleId 配置
+│
+├─► 控制「某个具体用户的例外权限」？
+│   ├─► 需要有效期或资源范围？
+│   │   └─► 用层 3：UserPermission（带 expiresAt / resourceType / resourceId）
+│   └─► 永久全局例外？
+│       └─► 用层 3：UserPermission（expiresAt = null）
+│
+├─► 控制「某部门能看哪些数据」（数据隔离）？
+│   └─► 用层 4：DepartmentPermission
+│       调用 DepartmentPermissionService.canAccessDepartmentResource()
+│
+└─► 记录「谁改了谁的权限」？
+    └─► 用层 5：PermissionLog（在 UserPermissionService 中写入）
+```
+
+---
+
+## 3. 禁止重复实现规则
+
+1. **禁止在业务模块中自建权限表**：不得在除 `permission`、`fine-grained-permission`、`user-permission`、`department-permission` 以外的模块中新建平行权限存储。
+2. **禁止在 controller 中直接读 User.role 字段做权限判断**：应使用 `@Roles()` decorator + `RolesGuard`，或 `@CheckPermission()` + `PermissionGuard`。
+3. **禁止绕过 Guard 直接查 UserPermission 表**：业务逻辑中如需检查权限，调用 `UserPermissionService.hasPermission(userId, permissionCode)`。
+4. **禁止在 DepartmentPermission 中存储功能权限**：部门层只用于数据边界隔离，功能访问控制归层 1/2/3。
+5. **禁止直接写 PermissionLog**：权限变更日志由 `UserPermissionService` 统一写入，不得在其他服务中直接创建 `PermissionLog` 记录。
+
+---
+
+## 4. 已知未解决问题
+
+以下问题不在本计划修复范围内，留作后续跟进：
+
+| 编号 | 问题 | 当前状态 | 影响 |
+|------|------|----------|------|
+| GAP-505 | `User.role` 字符串字段仍被 `RolesGuard` 读取，未完成向 `User.roleId` 外键的迁移 | schema 中两个字段并存，`role` 字段标注 `@deprecated` | Guard 行为依赖已废弃字段，迁移后需同步更新 `RolesGuard` |
+| GAP-506 | 权限审计日志查询端点（`GET /permission-logs`）未确认是否存在 | `PermissionLog` 模型存在于 schema，但未找到独立 controller | 前端 `/permissions/audit-log` 页面可能无法正常工作 |
+
+---
+
+## 5. 文件引用索引
+
+| 概念 | 权威文件 |
+|------|---------|
+| 权限模型层次总览 | `docs/module-usage/13-system-admin-ops.md` § 1.1 |
+| Schema 定义 | `server/src/prisma/schema.prisma`（Role L596, Permission L612, RolePermission L627, FineGrainedPermission L642, UserPermission L663, RoleFineGrainedPermission L2333, DepartmentPermission L2350, PermissionLog L1825） |
+| RBAC Guard | `server/src/common/guards/roles.guard.ts` |
+| ABAC Guard | `server/src/common/guards/permission.guard.ts` |
+| RBAC Decorator | `server/src/common/decorators/roles.decorator.ts` |
+| ABAC Decorator | `server/src/common/decorators/permission.decorator.ts` |
+| 用户授权管理 | `server/src/modules/user-permission/` |
+| 部门数据边界 | `server/src/modules/department-permission/` |
+| 细粒度权限定义 | `server/src/modules/fine-grained-permission/` |
+| 业务规则参考 | BR-352, BR-354, BR-355, BR-356, BR-357, BR-358, P1-2, P1-10, P1-12, P1-13, P2-20 |


### PR DESCRIPTION
## Summary

- 新增 `docs/superpowers/specs/2026-05-01-approval-workflow-task-boundary-guide.md`：五类机制（旧 Approval、UnifiedApproval、Workflow、Task、RecordTaskAssignment）的边界定义、新业务接入决策树和禁止事项
- 更新 `docs/module-usage/12-task-approval-workflow.md`：在 GAP-502/503/504 区段加入边界指南链接
- `docs/module-usage/98-coverage-matrix.md` 链接已包含在本分支

关闭 GAP-502、GAP-503、GAP-504 的文档治理部分。不改 schema、运行时代码或 migration。

Issue: MYL-18
Plan: docs/superpowers/plans/2026-05-01-gap-502-503-504-workflow-task-governance-docs-implementation.md

## Test plan

- [x] node tools/check-module-usage-docs.mjs → ✓ All checks passed. 80 GAP(s) registered.
- [x] git diff --check HEAD → 无空白错误
- [x] 新指南链接从 12-task-approval-workflow.md 第 7 节可跳转
- [x] 指南包含五类机制定义、决策树、禁止事项、迁移建议
- [x] 未改动 schema、controller、前端页面或运行时代码