### PR TITLE
feat: add GET /backup/available and GET /backup/:id/status (GAP-509/510)

### DIFF
--- a/server/src/modules/backup/backup.controller.ts
+++ b/server/src/modules/backup/backup.controller.ts
@@ -72,6 +72,25 @@ export class BackupController {
     return this.backupService.getBackupStats();
   }
 
+  @Get('available')
+  @ApiOperation({ summary: '列出可用于恢复的备份' })
+  @ApiResponse({ status: 200, description: '查询成功' })
+  async getAvailableBackups(
+    @Query('backupType') backupType?: string,
+    @Query('limit') limit?: number,
+  ) {
+    return this.backupService.listAvailableForRestore(backupType, limit || 10);
+  }
+
+  @Get(':id/status')
+  @ApiOperation({ summary: '查询单条备份记录状态' })
+  @ApiParam({ name: 'id', description: '备份记录 ID' })
+  @ApiResponse({ status: 200, description: '查询成功' })
+  @ApiResponse({ status: 404, description: '备份记录不存在' })
+  async getBackupStatus(@Param('id') id: string) {
+    return this.backupService.getBackupStatus(id);
+  }
+
   @Delete(':id')
   @ApiOperation({ summary: '删除备份记录' })
   @ApiParam({ name: 'id', description: '备份记录 ID' })

--- a/server/src/modules/backup/backup.controller.ts
+++ b/server/src/modules/backup/backup.controller.ts
@@ -77,9 +77,10 @@ export class BackupController {
   @ApiResponse({ status: 200, description: '查询成功' })
   async getAvailableBackups(
     @Query('backupType') backupType?: string,
-    @Query('limit') limit?: number,
+    @Query('limit') limit?: string,
   ) {
-    return this.backupService.listAvailableForRestore(backupType, limit || 10);
+    const parsedLimit = limit ? parseInt(limit, 10) : 10;
+    return this.backupService.listAvailableForRestore(backupType, parsedLimit || 10);
   }
 
   @Get(':id/status')

--- a/server/src/modules/backup/backup.service.ts
+++ b/server/src/modules/backup/backup.service.ts
@@ -136,6 +136,16 @@ export class BackupService {
     };
   }
 
+  async getBackupStatus(id: string) {
+    const record = await this.prisma.backupHistory.findUnique({
+      where: { id: BigInt(id) },
+    });
+    if (!record) {
+      throw new NotFoundException(`Backup record with ID ${id} not found`);
+    }
+    return record;
+  }
+
   /**
    * 删除备份记录
    * TASK-365: Delete backup record


### PR DESCRIPTION
## Summary

- Adds `GET /backup/available` (GAP-509): lists available-for-restore backups via existing `BackupService.listAvailableForRestore()`. Accepts `backupType` and `limit` query params; `limit` is explicitly parsed with `parseInt` to avoid Prisma `take` receiving a string.
- Adds `GET /backup/:id/status` (GAP-510): returns persisted `BackupHistory` record via new `BackupService.getBackupStatus()`; throws 404 for unknown IDs.
- Fixed routes (`available`, `:id/status`) are declared before `DELETE :id` to prevent route ambiguity.

## Files changed

- `server/src/modules/backup/backup.controller.ts`
- `server/src/modules/backup/backup.service.ts`

## References

- Issue: MYL-15 (01422a69-443f-48c3-a69c-b4e1b30a442e)
- GAPs: GAP-509, GAP-510
- Plan: `docs/superpowers/plans/2026-05-01-gap-509-510-backup-endpoints-implementation.md`
- Replaces: #80 (contained unrelated commits)

## No scope creep

- No restore execution added
- No backup deletion performed
- No schema changes or migrations
- `POST /backup/restore` behavior unchanged

## Test plan

- [ ] `GET /backup/available` returns available backup list
- [ ] `GET /backup/available?backupType=postgres&limit=5` filters and limits correctly (integer conversion verified)
- [ ] `GET /backup/:id/status` returns persisted backup record for valid ID
- [ ] `GET /backup/:id/status` returns 404 for non-existent ID
- [ ] `DELETE /backup/:id` still works
- [ ] `npm run build:server` passes