### PR TITLE
fix: GAP-317 add NonConformance query indexes

### DIFF
--- a/server/prisma/migrations/20260501_add_nonconformance_indexes/migration.sql
+++ b/server/prisma/migrations/20260501_add_nonconformance_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- Migration: 20260501_add_nonconformance_indexes
+-- Adds company/status and source lookup indexes to NonConformance for query performance
+
+CREATE INDEX IF NOT EXISTS "NonConformance_company_id_status_idx" ON "NonConformance"("company_id", "status");
+CREATE INDEX IF NOT EXISTS "NonConformance_company_id_source_type_source_id_idx" ON "NonConformance"("company_id", "source_type", "source_id");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -3047,6 +3047,8 @@ model NonConformance {
   created_at      DateTime  @default(now())
   updated_at      DateTime  @updatedAt
   @@unique([company_id, nc_no])
+  @@index([company_id, status])
+  @@index([company_id, source_type, source_id])
 }
 
 model CorrectiveAction {


### PR DESCRIPTION
## Summary

- Add `@@index([company_id, status])` to `NonConformance` in `schema.prisma`
- Add `@@index([company_id, source_type, source_id])` to `NonConformance` in `schema.prisma`
- Add migration `20260501_add_nonconformance_indexes` with `CREATE INDEX IF NOT EXISTS` statements

Schema-only performance change. No service behavior, DTO contracts, or business logic changed.

## References

- Issue: MYL-20 (GAP-317 nonconformance indexes)
- Plan: `docs/superpowers/plans/2026-05-01-gap-317-nonconformance-indexes-implementation.md`
- GAP: GAP-317

## Test plan

- [x] `non-conformance.service.spec.ts` — 2 tests passed
- [x] Prisma client generated successfully (v5.22.0)
- [x] Schema syntax valid (loaded by Prisma CLI without syntax errors)
- [x] `git diff -- server/src/modules/non-conformance` — no diff (service untouched)