### PR TITLE
fix: tag audit report documents with AUDIT_REPORT type (GAP-405/GAP-413)

### DIFF
--- a/server/src/modules/document/constants/document-control.constants.ts
+++ b/server/src/modules/document/constants/document-control.constants.ts
@@ -5,6 +5,7 @@ export const DOCUMENT_TYPES = [
   'RECORD_FORM_INDEX',
   'COMPANY_FILE',
   'EXTERNAL_FILE',
+  'AUDIT_REPORT',
 ] as const;
 
 export type DocumentType = (typeof DOCUMENT_TYPES)[number];
@@ -120,4 +121,5 @@ export const REQUIRED_METADATA_BY_TYPE: Record<DocumentType, string[]> = {
   RECORD_FORM_INDEX: ['sourceCode', 'landingStrategy'],
   COMPANY_FILE: ['organizationScope'],
   EXTERNAL_FILE: ['externalSource', 'applicableScope'],
+  AUDIT_REPORT: [],
 };

--- a/server/src/modules/internal-audit/report/report.service.spec.ts
+++ b/server/src/modules/internal-audit/report/report.service.spec.ts
@@ -265,6 +265,8 @@ describe('ReportService', () => {
         expect.objectContaining({
           data: expect.objectContaining({
             number: `REC-AUDIT-${year}-006`,
+            document_type: 'AUDIT_REPORT',
+            source_folder: null,
           }),
         }),
       );

--- a/server/src/modules/internal-audit/report/report.service.ts
+++ b/server/src/modules/internal-audit/report/report.service.ts
@@ -391,6 +391,8 @@ export class ReportService {
         fileType: 'application/pdf',
         status: 'published',
         creatorId: userId,
+        document_type: 'AUDIT_REPORT',
+        source_folder: null,
       },
     });
 


### PR DESCRIPTION
## Summary

- Adds `AUDIT_REPORT` to `DOCUMENT_TYPES` constant in `document-control.constants.ts`
- Tags archived internal audit report PDFs with `document_type='AUDIT_REPORT'` and `source_folder=null` in `archiveToDocumentSystem()`
- Updates test expectation to assert the new fields are written
- No changes to `SystemFileLibrary.vue` needed — its hardcoded `documentTypes` array already excludes `AUDIT_REPORT`, so audit reports are automatically filtered out

## Problem

Archived internal audit report PDFs were being created as `Document` records without a `document_type`, causing them to appear in the system file library (which shows documents with `document_type` in `[MANUAL, PROCEDURE, WORK_INSTRUCTION, COMPANY_FILE, EXTERNAL_FILE]` **or** null).

## Fix

By writing `document_type = 'AUDIT_REPORT'` during archival, these documents are now excluded from the system file library filter (`!document.document_type || systemLibraryDocumentTypes.has(document.document_type)` → false for AUDIT_REPORT).

## Related

- GAP-405 / GAP-413
- Implementation plan: `docs/superpowers/plans/2026-05-01-gap-405-413-audit-report-document-boundary-implementation.md`
- Issue: MYL-23

## Test plan

- [ ] Run `npm test -- report.service.spec.ts` in `server/` — expect PASS (blocked by pre-existing TS error in `operation-log.service.ts:77` that exists on baseline; test logic verified correct)
- [ ] Manually verify that completing an audit plan archives a document with `document_type='AUDIT_REPORT'`
- [ ] Verify the archived document does NOT appear in the System File Library UI