### PR TITLE
fix: GAP-005 prevent orphaned ProcessStep on create

### DIFF
--- a/server/src/modules/process-step/process-step.service.spec.ts
+++ b/server/src/modules/process-step/process-step.service.spec.ts
@@ -1,0 +1,60 @@
+import { BadRequestException } from '@nestjs/common';
+import { ProcessStepService } from './process-step.service';
+
+describe('ProcessStepService', () => {
+  const prisma = {
+    processStep: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+
+  let service: ProcessStepService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ProcessStepService(prisma as any);
+  });
+
+  const baseDto = {
+    step_no: 1,
+    step_name: '配料',
+    is_ccp: false,
+  };
+
+  it('rejects orphan process steps without product_id or recipe_id', async () => {
+    await expect(service.create(baseDto as any)).rejects.toThrow(BadRequestException);
+    expect(prisma.processStep.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects blank product_id and recipe_id', async () => {
+    await expect(service.create({ ...baseDto, product_id: ' ', recipe_id: '' } as any)).rejects.toThrow(BadRequestException);
+    expect(prisma.processStep.create).not.toHaveBeenCalled();
+  });
+
+  it('allows product-level process steps', async () => {
+    prisma.processStep.create.mockResolvedValue({ id: 'step-1' });
+
+    await service.create({ ...baseDto, product_id: 'prod-1' } as any);
+
+    expect(prisma.processStep.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ product_id: 'prod-1', recipe_id: undefined }),
+      }),
+    );
+  });
+
+  it('allows recipe-level process steps', async () => {
+    prisma.processStep.create.mockResolvedValue({ id: 'step-2' });
+
+    await service.create({ ...baseDto, recipe_id: 'recipe-1' } as any);
+
+    expect(prisma.processStep.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ product_id: undefined, recipe_id: 'recipe-1' }),
+      }),
+    );
+  });
+});

--- a/server/src/modules/process-step/process-step.service.ts
+++ b/server/src/modules/process-step/process-step.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateProcessStepDto } from './dto/create-process-step.dto';
 import { UpdateProcessStepDto } from './dto/update-process-step.dto';
@@ -6,6 +6,15 @@ import { UpdateProcessStepDto } from './dto/update-process-step.dto';
 @Injectable()
 export class ProcessStepService {
   constructor(private prisma: PrismaService) {}
+
+  private assertHasProductOrRecipe(productId?: string, recipeId?: string) {
+    const hasProduct = typeof productId === 'string' && productId.trim().length > 0;
+    const hasRecipe = typeof recipeId === 'string' && recipeId.trim().length > 0;
+
+    if (!hasProduct && !hasRecipe) {
+      throw new BadRequestException('工序必须关联产品或配方');
+    }
+  }
 
   async findAll() {
     return this.prisma.processStep.findMany({
@@ -32,6 +41,8 @@ export class ProcessStepService {
   }
 
   async create(dto: CreateProcessStepDto) {
+    this.assertHasProductOrRecipe(dto.product_id, dto.recipe_id);
+
     return this.prisma.processStep.create({
       data: {
         company_id: '1',


### PR DESCRIPTION
## Summary

- Adds service-level validation in `ProcessStepService.create()` to require at least one of `product_id` or `recipe_id`
- Throws `BadRequestException('工序必须关联产品或配方')` when both are absent or blank
- Adds `process-step.service.spec.ts` with 4 focused unit tests (orphan reject, blank reject, product-level allow, recipe-level allow)
- Schema (`schema.prisma`) is unchanged — fields remain nullable to allow both product-level and recipe-level process steps

## References

- Issue: MYL-19 (Multica issue `631af980-8abe-4476-8425-aa62b56c6111`)
- GAP: GAP-005
- Implementation plan: `docs/superpowers/plans/2026-05-01-gap-005-process-step-relation-validation-implementation.md`

## Test plan

- [x] `npx jest process-step.service.spec.ts --no-coverage` → 4 tests PASS
- [x] `git diff -- server/src/prisma/schema.prisma` → no diff (schema unchanged)
- [x] Build has 215 pre-existing TypeScript errors in unrelated files (workflow services, seed); zero errors in `src/modules/process-step/`