### PR TITLE
fix: GAP-402 clarify document-derived training needs UX

### DIFF
--- a/client/src/views/documents/TrainingNeedCenter.vue
+++ b/client/src/views/documents/TrainingNeedCenter.vue
@@ -1,5 +1,12 @@
 <template>
   <div class="training-need-center">
+    <el-alert
+      class="page-note"
+      type="info"
+      show-icon
+      :closable="false"
+      title="这里是文控派生培训需求，不是培训项目台账。接受后应关联到培训项目，由培训模块承接计划、签到、考试和档案。"
+    />
     <div class="toolbar">
       <el-select v-model="status" clearable placeholder="状态" @change="load">
         <el-option value="suggested" label="待评估" />
@@ -14,24 +21,51 @@
       <el-table-column prop="targetDepartment" label="目标部门" width="140" />
       <el-table-column prop="status" label="状态" width="110" />
       <el-table-column prop="reason" label="原因" min-width="260" show-overflow-tooltip />
-      <el-table-column label="操作" width="180">
+      <el-table-column label="操作" width="240">
         <template #default="{ row }">
           <el-button link type="primary" @click="accept(row.id)">接受</el-button>
           <el-button link type="danger" @click="dismiss(row.id)">驳回</el-button>
+          <el-button
+            v-if="row.status === 'accepted'"
+            link
+            type="success"
+            @click="openLinkDialog(row)"
+          >
+            关联培训项目
+          </el-button>
         </template>
       </el-table-column>
     </el-table>
+
+    <el-dialog v-model="linkDialog.visible" title="关联培训项目" width="420px">
+      <el-form label-width="100px">
+        <el-form-item label="培训项目ID">
+          <el-input v-model="linkDialog.projectId" placeholder="输入已有培训项目ID" clearable />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="linkDialog.visible = false">取消</el-button>
+        <el-button type="primary" :loading="linkDialog.loading" @click="submitLink">确认关联</el-button>
+      </template>
+    </el-dialog>
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { documentOperationsApi } from '@/api/document-operations';
 
 const status = ref('');
 const rows = ref<any[]>([]);
 const loading = ref(false);
+
+const linkDialog = reactive({
+  visible: false,
+  loading: false,
+  needId: '',
+  projectId: '',
+});
 
 const load = async () => {
   loading.value = true;
@@ -65,10 +99,36 @@ const dismiss = async (id: string) => {
   }
 };
 
+const openLinkDialog = (row: any) => {
+  linkDialog.needId = row.id;
+  linkDialog.projectId = row.linkedTrainingProjectId || '';
+  linkDialog.visible = true;
+};
+
+const submitLink = async () => {
+  if (!linkDialog.projectId.trim()) {
+    ElMessage.warning('请输入培训项目ID');
+    return;
+  }
+  linkDialog.loading = true;
+  try {
+    await documentOperationsApi.linkTrainingNeed(linkDialog.needId, linkDialog.projectId.trim());
+    ElMessage.success('已关联培训项目');
+    linkDialog.visible = false;
+    load();
+  } finally {
+    linkDialog.loading = false;
+  }
+};
+
 onMounted(load);
 </script>
 
 <style scoped>
+.page-note {
+  margin-bottom: 12px;
+}
+
 .toolbar {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary

- Adds an `el-alert` page note to `TrainingNeedCenter.vue` to clearly distinguish document-derived training needs (文控派生培训需求) from training project records (培训项目台账)
- Exposes a "关联培训项目" action button for accepted needs, backed by the existing `documentOperationsApi.linkTrainingNeed()` method
- Adds a dialog for entering a training project ID and submitting the link

## References

- Issue: MYL-21 (GAP-402 training need UX clarification)
- Plan: `docs/superpowers/plans/2026-05-01-gap-402-training-need-ux-clarification-implementation.md`

## Changes

- `client/src/views/documents/TrainingNeedCenter.vue` — UI changes only; no backend or schema changes

## Test plan

- [ ] Build passes: `cd client && npx vite build` ✅
- [ ] No backend changes: `git diff -- server/src/modules/document/services/document-training-need.service.ts` shows empty diff ✅
- [ ] Page note visible at top of TrainingNeedCenter page
- [ ] "关联培训项目" button appears only for rows with status=accepted
- [ ] Dialog opens and submits correctly via existing linkTrainingNeed API