### PR TITLE
feat: GAP-403 batch confirm record form landing suggestions

### DIFF
--- a/client/src/api/document-control.ts
+++ b/client/src/api/document-control.ts
@@ -177,6 +177,10 @@ export const documentControlApi = {
     return request.post(`/documents/record-form-index/${code}/confirm`, payload);
   },
 
+  batchConfirmRecordFormLanding(codes: string[]) {
+    return request.post('/documents/record-form-index/batch-confirm-suggested', { codes });
+  },
+
   getRecordFormFieldCoverage(code: string) {
     return request.get(`/documents/record-form-index/${code}/field-coverage`);
   },

--- a/client/src/views/documents/RecordFormLandingIndex.vue
+++ b/client/src/views/documents/RecordFormLandingIndex.vue
@@ -3,9 +3,17 @@
     <div class="toolbar">
       <el-input v-model="keyword" placeholder="搜索表单编号或名称" clearable @keyup.enter="fetchRows" />
       <el-button type="primary" @click="fetchRows">搜索</el-button>
+      <el-button
+        type="primary"
+        :disabled="selectedRows.length === 0"
+        @click="batchConfirmSelected"
+      >
+        批量确认建议
+      </el-button>
     </div>
 
-    <el-table :data="rows" v-loading="loading" stripe>
+    <el-table :data="rows" v-loading="loading" stripe @selection-change="selectedRows = $event">
+      <el-table-column type="selection" width="48" />
       <el-table-column prop="code" label="源编号" width="150" />
       <el-table-column prop="formName" label="表单名" min-width="220" show-overflow-tooltip />
       <el-table-column prop="department" label="部门" width="120" />
@@ -167,6 +175,16 @@ const saveEdit = async () => {
   }
 };
 
+const selectedRows = ref<RecordFormLandingEntry[]>([]);
+
+const batchConfirmSelected = async () => {
+  const codes = selectedRows.value.map((row) => row.code);
+  const res: any = await documentControlApi.batchConfirmRecordFormLanding(codes);
+  ElMessage.success(`已确认 ${res.confirmed || 0} 条，跳过 ${res.skipped || 0} 条`);
+  selectedRows.value = [];
+  await fetchRows();
+};
+
 const activeSuggestion = ref<any>(null);
 
 async function loadSuggestion(row: any) {
@@ -189,7 +207,7 @@ onMounted(fetchRows);
 <style scoped>
 .toolbar {
   display: grid;
-  grid-template-columns: minmax(240px, 1fr) auto;
+  grid-template-columns: minmax(240px, 1fr) auto auto;
   gap: 10px;
   margin-bottom: 12px;
 }

--- a/server/src/modules/document/document.controller.ts
+++ b/server/src/modules/document/document.controller.ts
@@ -38,7 +38,7 @@ import { DocumentEvidenceChainService } from './services/document-evidence-chain
 import { DocumentReferenceHealthService } from './services/document-reference-health.service';
 import { NumberRuleService } from './services/number-rule.service';
 import { CreateDocumentDto, UpdateDocumentDto, DocumentQueryDto, ArchiveDocumentDto, ObsoleteDocumentDto, ApproveDocumentDto, CreateGenericDocumentReferenceDto, WorkbenchQueryDto, WorkbenchIssueQueryDto, CreateReadRequirementDto, TrainingNeedActionDto, ImpactReviewCreateDto, ImpactItemUpdateDto, CoverageQueryDto, AuditChainQueryDto, UpdateMarkdownDto } from './dto';
-import { ConfirmRecordFormLandingDto, UpdateRecordFormLandingEntryDto, UpsertNumberRuleDto } from './dto/document-control.dto';
+import { BatchConfirmRecordFormLandingDto, ConfirmRecordFormLandingDto, UpdateRecordFormLandingEntryDto, UpsertNumberRuleDto } from './dto/document-control.dto';
 import { PublishDocumentDto, RollbackDocumentVersionDto } from './dto/document-lifecycle.dto';
 import { RestoreDocumentDto } from './dto/archive-document.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -171,6 +171,14 @@ export class DocumentController {
     @Query('templateGroupId') templateGroupId?: string,
   ) {
     return this.recordFormLandingService.list({ keyword, department, templateGroupId });
+  }
+
+  @Post('record-form-index/batch-confirm-suggested')
+  @UseGuards(PermissionGuard)
+  @CheckPermission('record_form:landing_manage')
+  @ApiOperation({ summary: '批量确认选中表单的落地建议' })
+  batchConfirmRecordFormLanding(@Body() dto: BatchConfirmRecordFormLandingDto, @Req() req: any) {
+    return this.recordFormLandingService.batchConfirmSuggested(dto.codes, req.user?.id || 'system');
   }
 
   @Get('record-form-index/:code/suggestion')

--- a/server/src/modules/document/dto/document-control.dto.ts
+++ b/server/src/modules/document/dto/document-control.dto.ts
@@ -282,6 +282,12 @@ export class UpsertNumberRuleDto {
   resetPolicy?: string;
 }
 
+export class BatchConfirmRecordFormLandingDto {
+  @IsArray()
+  @IsString({ each: true })
+  codes!: string[];
+}
+
 export class ConfirmRecordFormLandingDto extends UpdateRecordFormLandingEntryDto {
   @IsIn(LANDING_STATUSES)
   landingStatus!: string;

--- a/server/src/modules/document/services/record-form-landing.service.spec.ts
+++ b/server/src/modules/document/services/record-form-landing.service.spec.ts
@@ -109,7 +109,7 @@ describe('RecordFormLandingService', () => {
       const service = makeService();
       const result = await service.list({});
 
-      expect(result[0].landingEntry!.targetTemplate).toEqual({
+      expect((result[0].landingEntry as any)!.targetTemplate).toEqual({
         id: 'tmpl1',
         code: 'TMP-01',
         name: '记录模板',
@@ -127,7 +127,7 @@ describe('RecordFormLandingService', () => {
       const service = makeService();
       const result = await service.list({});
 
-      expect(result[0].landingEntry!.targetTemplate).toBeNull();
+      expect((result[0].landingEntry as any)!.targetTemplate).toBeNull();
     });
   });
 
@@ -158,7 +158,7 @@ describe('RecordFormLandingService', () => {
       const service = makeService();
       const result = await service.get('GRSS-KF-JL-01');
 
-      expect(result.landingEntry!.targetTemplate).toEqual({
+      expect((result.landingEntry as any)!.targetTemplate).toEqual({
         id: 'tmpl1',
         code: 'TMP-01',
         name: '记录模板',

--- a/server/src/modules/document/services/record-form-landing.service.ts
+++ b/server/src/modules/document/services/record-form-landing.service.ts
@@ -117,6 +117,38 @@ export class RecordFormLandingService {
     };
   }
 
+  async batchConfirmSuggested(codes: string[], userId: string) {
+    const uniqueCodes = [...new Set(codes.map((code) => code.trim()).filter(Boolean))];
+    const results: Array<{ code: string; status: string; reason?: string; entry?: any }> = [];
+
+    for (const code of uniqueCodes) {
+      const suggestion = await this.suggest(code);
+      if (suggestion.landingStatus === 'unimplemented') {
+        results.push({ code, status: 'skipped', reason: '没有可确认的落地建议' });
+        continue;
+      }
+
+      const entry = await this.confirm(code, {
+        landingStatus: suggestion.landingStatus,
+        landingStrategy: suggestion.landingStatus,
+        targetModule: suggestion.targetModule,
+        targetModel: suggestion.targetModel,
+        targetRoute: suggestion.targetRoute,
+        targetTemplateId: suggestion.targetTemplateId,
+        confirmationStatus: 'confirmed',
+        fieldCoverageStatus: (suggestion.fieldCoverageStatus as any) ?? 'unknown',
+      }, userId);
+      results.push({ code, status: 'confirmed', entry });
+    }
+
+    return {
+      total: uniqueCodes.length,
+      confirmed: results.filter((r) => r.status === 'confirmed').length,
+      skipped: results.filter((r) => r.status === 'skipped').length,
+      results,
+    };
+  }
+
   async confirm(code: string, dto: ConfirmRecordFormLandingDto, userId: string) {
     const form = this.modelLanding.getFormByCode(code);
     if (!form) throw new NotFoundException(`Unknown source form: ${code}`);

--- a/server/src/modules/document/services/record-form-landing.service.ts
+++ b/server/src/modules/document/services/record-form-landing.service.ts
@@ -32,7 +32,7 @@ export class RecordFormLandingService {
         targetTemplate: { select: { id: true, code: true, name: true, status: true } },
       },
     });
-    const overrideMap = new Map(overrides.map((entry) => [entry.sourceCode, entry]));
+    const overrideMap = new Map(overrides.map((entry: (typeof overrides)[number]) => [entry.sourceCode, entry]));
 
     return filtered.map((form) => ({
       ...form,
@@ -112,6 +112,7 @@ export class RecordFormLandingService {
       targetModule: (form as any).primaryEntity || null,
       targetModel: (form as any).primaryEntity || null,
       targetRoute,
+      targetTemplateId: null as string | null,
       fieldCoverageStatus: targetRoute ? 'partial' : 'unknown',
       reason: targetRoute ? 'model-landing 已存在候选业务入口' : '未识别到业务入口或动态模板',
     };


### PR DESCRIPTION
## Summary

- Add `BatchConfirmRecordFormLandingDto` to `document-control.dto.ts`
- Add `batchConfirmSuggested()` method to `RecordFormLandingService` — iterates selected form codes, calls `suggest()` then `confirm()` for each, skips `unimplemented` entries
- Expose `POST /documents/record-form-index/batch-confirm-suggested` endpoint in `DocumentController`
- Add `batchConfirmRecordFormLanding()` API method to `document-control.ts`
- Add row-selection column and "批量确认建议" button to `RecordFormLandingIndex.vue`

## References

- Issue: MYL-22
- GAP: GAP-403
- Plan: `docs/superpowers/plans/2026-05-01-gap-403-record-form-landing-batch-confirm-implementation.md`

## Test plan

- [ ] Select multiple rows in the 04 record form index table
- [ ] Click "批量确认建议" button — button should be disabled when no rows selected
- [ ] Verify success message shows count of confirmed and skipped entries
- [ ] Verify entries with suggestions get `confirmationStatus: confirmed` in the database
- [ ] Verify entries without targetRoute (unimplemented) are skipped with reason message
- [ ] Backend TypeScript check passes (`tsc --noEmit`)
- [ ] Frontend build succeeds (`npm run build`)