### PR TITLE
fix(GAP-600/602): scope measuring equipment and calibration by JWT companyId

### DIFF
--- a/server/src/modules/measuring-equipment/measuring-equipment.controller.ts
+++ b/server/src/modules/measuring-equipment/measuring-equipment.controller.ts
@@ -1,8 +1,9 @@
-import { Controller, Get, Post, Body, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, UseGuards, Request } from '@nestjs/common';
 import { MeasuringEquipmentService } from './measuring-equipment.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { CreateCalibrationDto } from './dto/create-calibration.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 
 @Controller('measuring-equipment')
 @UseGuards(JwtAuthGuard)
@@ -10,27 +11,27 @@ export class MeasuringEquipmentController {
   constructor(private service: MeasuringEquipmentService) {}
 
   @Post()
-  createEquipment(@Body() dto: CreateEquipmentDto) {
-    return this.service.createEquipment(dto);
+  createEquipment(@Body() dto: CreateEquipmentDto, @Request() req: AuthenticatedRequest) {
+    return this.service.createEquipment(dto, req.user.companyId);
   }
 
   @Get()
-  findAllEquipment() {
-    return this.service.findAllEquipment();
+  findAllEquipment(@Request() req: AuthenticatedRequest) {
+    return this.service.findAllEquipment(req.user.companyId);
   }
 
   @Get('overdue')
-  findOverdue() {
-    return this.service.findOverdue();
+  findOverdue(@Request() req: AuthenticatedRequest) {
+    return this.service.findOverdue(req.user.companyId);
   }
 
   @Post('calibrations')
-  createCalibration(@Body() dto: CreateCalibrationDto) {
-    return this.service.createCalibration(dto);
+  createCalibration(@Body() dto: CreateCalibrationDto, @Request() req: AuthenticatedRequest) {
+    return this.service.createCalibration(dto, req.user.companyId);
   }
 
   @Get(':id/calibrations')
-  findCalibrationsByEquipment(@Param('id') id: string) {
-    return this.service.findCalibrationsByEquipment(id);
+  findCalibrationsByEquipment(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findCalibrationsByEquipment(id, req.user.companyId);
   }
 }

--- a/server/src/modules/measuring-equipment/measuring-equipment.service.spec.ts
+++ b/server/src/modules/measuring-equipment/measuring-equipment.service.spec.ts
@@ -1,0 +1,87 @@
+import { NotFoundException } from '@nestjs/common';
+import { MeasuringEquipmentService } from './measuring-equipment.service';
+
+describe('MeasuringEquipmentService', () => {
+  const prisma = {
+    measuringEquipment: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    calibrationRecord: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+
+  let service: MeasuringEquipmentService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new MeasuringEquipmentService(prisma as any);
+  });
+
+  it('creates equipment for the current company', async () => {
+    prisma.measuringEquipment.create.mockResolvedValue({ id: 'eq1' });
+
+    await service.createEquipment({ name: '电子秤' } as any, 'company-2');
+
+    expect(prisma.measuringEquipment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ company_id: 'company-2' }) }),
+    );
+  });
+
+  it('lists only current company equipment', async () => {
+    await service.findAllEquipment('company-2');
+
+    expect(prisma.measuringEquipment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ company_id: 'company-2' }) }),
+    );
+  });
+
+  it('lists only current company overdue equipment', async () => {
+    await service.findOverdue('company-2');
+
+    expect(prisma.measuringEquipment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ company_id: 'company-2' }) }),
+    );
+  });
+
+  it('blocks calibration creation for equipment outside current company', async () => {
+    prisma.measuringEquipment.findFirst.mockResolvedValue(null);
+
+    await expect(service.createCalibration({
+      measuring_equipment_id: 'eq-other',
+      calibrated_at: '2026-05-01',
+      valid_until: '2027-05-01',
+      result: 'pass',
+    } as any, 'company-2')).rejects.toThrow(NotFoundException);
+
+    expect(prisma.calibrationRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('creates calibration records for the current company', async () => {
+    prisma.measuringEquipment.findFirst.mockResolvedValue({ id: 'eq1' });
+    prisma.calibrationRecord.create.mockResolvedValue({ id: 'cal1' });
+    prisma.measuringEquipment.update.mockResolvedValue({ id: 'eq1' });
+
+    await service.createCalibration({
+      measuring_equipment_id: 'eq1',
+      calibrated_at: '2026-05-01',
+      valid_until: '2027-05-01',
+      result: 'pass',
+    } as any, 'company-2');
+
+    expect(prisma.calibrationRecord.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ company_id: 'company-2' }) }),
+    );
+  });
+
+  it('blocks calibration history lookup for equipment outside current company', async () => {
+    prisma.measuringEquipment.findFirst.mockResolvedValue(null);
+
+    await expect(service.findCalibrationsByEquipment('eq-other', 'company-2')).rejects.toThrow(NotFoundException);
+    expect(prisma.calibrationRecord.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/measuring-equipment/measuring-equipment.service.ts
+++ b/server/src/modules/measuring-equipment/measuring-equipment.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateEquipmentDto } from './dto/create-equipment.dto';
 import { CreateCalibrationDto } from './dto/create-calibration.dto';
@@ -7,15 +7,15 @@ import { CreateCalibrationDto } from './dto/create-calibration.dto';
 export class MeasuringEquipmentService {
   constructor(private prisma: PrismaService) {}
 
-  async createEquipment(dto: CreateEquipmentDto) {
+  async createEquipment(dto: CreateEquipmentDto, companyId: string) {
     return this.prisma.measuringEquipment.create({
-      data: { ...dto, company_id: '1' },
+      data: { ...dto, company_id: companyId },
     });
   }
 
-  async findAllEquipment() {
+  async findAllEquipment(companyId: string) {
     return this.prisma.measuringEquipment.findMany({
-      where: { status: { not: 'scrapped' } },
+      where: { company_id: companyId, status: { not: 'scrapped' } },
       include: {
         calibration_records: {
           orderBy: { calibrated_at: 'desc' },
@@ -26,19 +26,27 @@ export class MeasuringEquipmentService {
     });
   }
 
-  async findOverdue() {
+  async findOverdue(companyId: string) {
     return this.prisma.measuringEquipment.findMany({
       where: {
+        company_id: companyId,
         status: { not: 'scrapped' },
         next_calibration_at: { lte: new Date() },
       },
     });
   }
 
-  async createCalibration(dto: CreateCalibrationDto) {
+  async createCalibration(dto: CreateCalibrationDto, companyId: string) {
+    const equipment = await this.prisma.measuringEquipment.findFirst({
+      where: { id: dto.measuring_equipment_id, company_id: companyId },
+    });
+    if (!equipment) {
+      throw new NotFoundException('计量器具不存在');
+    }
+
     const record = await this.prisma.calibrationRecord.create({
       data: {
-        company_id: '1',
+        company_id: companyId,
         measuring_equipment_id: dto.measuring_equipment_id,
         calibrated_at: new Date(dto.calibrated_at),
         valid_until: new Date(dto.valid_until),
@@ -60,9 +68,16 @@ export class MeasuringEquipmentService {
     return record;
   }
 
-  async findCalibrationsByEquipment(equipmentId: string) {
+  async findCalibrationsByEquipment(equipmentId: string, companyId: string) {
+    const equipment = await this.prisma.measuringEquipment.findFirst({
+      where: { id: equipmentId, company_id: companyId },
+    });
+    if (!equipment) {
+      throw new NotFoundException('计量器具不存在');
+    }
+
     return this.prisma.calibrationRecord.findMany({
-      where: { measuring_equipment_id: equipmentId },
+      where: { measuring_equipment_id: equipmentId, company_id: companyId },
       orderBy: { calibrated_at: 'desc' },
     });
   }


### PR DESCRIPTION
## Summary

- Remove hardcoded `company_id: '1'` from measuring equipment and calibration record writes and queries
- Controller extracts `req.user.companyId` from `AuthenticatedRequest` and passes it to all service methods
- Service validates equipment ownership before creating calibration records or returning calibration history, throwing `NotFoundException` for cross-company access attempts

## Files Changed

- `server/src/modules/measuring-equipment/measuring-equipment.controller.ts` — add `@Request() req` param to all endpoints, pass `req.user.companyId` to service
- `server/src/modules/measuring-equipment/measuring-equipment.service.ts` — add `companyId` param to all methods, scope all Prisma queries, add ownership validation in `createCalibration` and `findCalibrationsByEquipment`
- `server/src/modules/measuring-equipment/measuring-equipment.service.spec.ts` — new file: 6 unit tests covering tenant write/read isolation and cross-company blocking

## Test Plan

- [x] `npx jest measuring-equipment.service.spec.ts` — 6/6 tests pass
- [x] No `company_id: '1'` remaining in module files
- [x] No schema change (`git diff -- schema.prisma` is empty)
- [ ] Manual smoke test: create equipment and calibration with a real JWT, verify tenant isolation in DB