### PR TITLE
GAP-004: show notice for legacy product route redirects

### DIFF
--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,5 +1,11 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router';
 import { useUserStore } from '@/stores/user';
+import { ElMessage } from 'element-plus';
+
+const redirectToProductWorkbench = () => {
+  ElMessage.info('配方和工序已合并到产品详情/产品工作台，请在产品目录中进入对应产品维护。');
+  return '/products';
+};
 
 const routes: RouteRecordRaw[] = [
   {
@@ -847,17 +853,17 @@ const routes: RouteRecordRaw[] = [
       // 配方管理 / 工序步骤管理已合并至产品信息页面，旧路由跳转到产品列表
       {
         path: 'recipes',
-        redirect: '/products',
+        beforeEnter: redirectToProductWorkbench,
         meta: { hidden: true },
       },
       {
         path: 'recipes/:id/edit',
-        redirect: '/products',
+        beforeEnter: redirectToProductWorkbench,
         meta: { hidden: true },
       },
       {
         path: 'process-steps',
-        redirect: '/products',
+        beforeEnter: redirectToProductWorkbench,
         meta: { hidden: true },
       },
       // 回料/返工记录模块


### PR DESCRIPTION
## Summary

- Add `ElMessage.info` notice before redirecting legacy `/recipes`, `/recipes/:id/edit`, and `/process-steps` routes to `/products`
- Replace silent `redirect: '/products'` objects with `beforeEnter: redirectToProductWorkbench` guards
- No schema changes, no new pages, no product workbench modifications

## Changes

- `client/src/router/index.ts`: added `ElMessage` import, added `redirectToProductWorkbench` helper, replaced 3 silent redirects with `beforeEnter` guards

## Test plan

- [ ] Navigate to `/recipes` — should see info toast and land on `/products`
- [ ] Navigate to `/recipes/123/edit` — should see info toast and land on `/products`
- [ ] Navigate to `/process-steps` — should see info toast and land on `/products`
- [ ] Client build passes (`npm run build:client`)