### PR TITLE
fix(GAP-002/003): require product and recipe on production batches

### DIFF
--- a/server/prisma/migrations/20260501_require_production_batch_product_recipe/migration.sql
+++ b/server/prisma/migrations/20260501_require_production_batch_product_recipe/migration.sql
@@ -1,0 +1,47 @@
+-- Require every production batch to link to Product and Recipe.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "production_batches" WHERE "productId" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require production_batches.productId: legacy rows with NULL productId exist';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM "production_batches" WHERE "recipeId" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require production_batches.recipeId: legacy rows with NULL recipeId exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "production_batches" pb
+    LEFT JOIN "products" p ON p."id" = pb."productId"
+    WHERE p."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add production_batches.productId FK: orphan productId rows exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "production_batches" pb
+    LEFT JOIN "recipes" r ON r."id" = pb."recipeId"
+    WHERE r."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add production_batches.recipeId FK: orphan recipeId rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "production_batches" ALTER COLUMN "productId" SET NOT NULL;
+ALTER TABLE "production_batches" ALTER COLUMN "recipeId" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "production_batches_productId_idx" ON "production_batches"("productId");
+CREATE INDEX IF NOT EXISTS "production_batches_recipeId_idx" ON "production_batches"("recipeId");
+
+ALTER TABLE "production_batches"
+  ADD CONSTRAINT "production_batches_productId_fkey"
+  FOREIGN KEY ("productId") REFERENCES "products"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "production_batches"
+  ADD CONSTRAINT "production_batches_recipeId_fkey"
+  FOREIGN KEY ("recipeId") REFERENCES "recipes"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/modules/batch-trace/services/production-batch.service.spec.ts
+++ b/server/src/modules/batch-trace/services/production-batch.service.spec.ts
@@ -102,6 +102,12 @@ describe('ProductionBatchService', () => {
           status: 'pending',
         },
       });
+      expect(mockPrisma.product.findFirst).toHaveBeenCalledWith({
+        where: { id: 'p1', company_id: '1', status: 'active', deleted_at: null },
+      });
+      expect(mockPrisma.recipe.findFirst).toHaveBeenCalledWith({
+        where: { id: 'r1', product_id: 'p1', company_id: '1', status: 'active' },
+      });
     });
   });
 
@@ -245,6 +251,12 @@ describe('ProductionBatchService', () => {
       const result = await service.confirmProductBatch(validDto);
 
       expect(result).toEqual(mockBatch);
+      expect(mockPrisma.product.findFirst).toHaveBeenCalledWith({
+        where: { id: 'p1', company_id: '1', status: 'active', deleted_at: null },
+      });
+      expect(mockPrisma.recipe.findFirst).toHaveBeenCalledWith({
+        where: { id: 'r1', product_id: 'p1', company_id: '1', status: 'active' },
+      });
       expect(mockPrisma.productionBatch.create).toHaveBeenCalledWith({
         data: {
           batchNumber: 'PROD-PKG-001',
@@ -284,6 +296,17 @@ describe('ProductionBatchService', () => {
       mockPrisma.recipe.findFirst.mockResolvedValue(null);
 
       await expect(service.confirmProductBatch(validDto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject recipe that does not belong to the selected product', async () => {
+      mockPrisma.productionBatch.findUnique.mockResolvedValue(null);
+      mockPrisma.product.findFirst.mockResolvedValue({ id: 'p1', name: '蛋糕', status: 'active' });
+      mockPrisma.recipe.findFirst.mockResolvedValue(null);
+
+      await expect(service.confirmProductBatch(validDto)).rejects.toThrow(BadRequestException);
+      expect(mockPrisma.recipe.findFirst).toHaveBeenCalledWith({
+        where: { id: 'r1', product_id: 'p1', company_id: '1', status: 'active' },
+      });
     });
   });
 });

--- a/server/src/modules/batch-trace/services/production-batch.service.ts
+++ b/server/src/modules/batch-trace/services/production-batch.service.ts
@@ -129,14 +129,14 @@ export class ProductionBatchService {
     }
 
     const product = await this.prisma.product.findFirst({
-      where: { id: dto.productId, status: 'active', deleted_at: null },
+      where: { id: dto.productId, company_id: '1', status: 'active', deleted_at: null },
     });
     if (!product) {
       throw new BadRequestException('产品不存在');
     }
 
     const recipe = await this.prisma.recipe.findFirst({
-      where: { id: dto.recipeId, product_id: dto.productId, status: 'active' },
+      where: { id: dto.recipeId, product_id: dto.productId, company_id: '1', status: 'active' },
     });
     if (!recipe) {
       throw new BadRequestException('产品配方不存在或未启用');

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1464,9 +1464,11 @@ model MaterialScrapItem {
 model ProductionBatch {
   id              String           @id @default(cuid())
   batchNumber     String           @unique // 生产批次号（BR-241: 唯一性，BR-242: 不可修改）
-  productId       String? // 产品ID
+  productId       String // 产品ID
+  product         Product @relation(fields: [productId], references: [id], onDelete: Restrict)
   productName     String
-  recipeId        String? // 配方ID
+  recipeId        String // 配方ID
+  recipe          Recipe  @relation(fields: [recipeId], references: [id], onDelete: Restrict)
   recipeName      String?
   plannedQuantity Float?
   actualQuantity  Float?
@@ -1527,6 +1529,8 @@ model ProductionBatch {
   @@index([productionDate])
   @@index([status])
   @@index([production_run_id])
+  @@index([productId])
+  @@index([recipeId])
   @@map("production_batches")
 }
 
@@ -2783,6 +2787,7 @@ model Product {
   production_runs  ProductionRun[]
   mixingExecutions MixingExecution[]
   productProcessChangePlans ProductProcessChangePlan[]
+  productionBatches ProductionBatch[]
 
   @@unique([company_id, code])
   @@index([source])
@@ -2890,6 +2895,7 @@ model Recipe {
 
   production_runs ProductionRun[]
   mixingExecutions MixingExecution[]
+  productionBatches ProductionBatch[]
 
   changeEventId String?
 


### PR DESCRIPTION
## Summary

- Make `ProductionBatch.productId` and `recipeId` non-nullable at the database level (GAP-002/GAP-003)
- Add `@relation` declarations linking `ProductionBatch` to `Product` and `Recipe` with `onDelete: Restrict`
- Add reverse relations on `Product.productionBatches` and `Recipe.productionBatches`
- Add `@@index([productId])` and `@@index([recipeId])` to `ProductionBatch`
- Add guarded migration with preflight checks — fails fast if legacy NULL or orphan rows exist
- Tighten `confirmProductBatch()` product/recipe lookups with `company_id: '1'` scope
- Update service tests: assert company-scoped lookups in both `create` and `confirmProductBatch` paths; add test for recipe-product mismatch

## Test plan

- [x] All 13 unit tests pass (`production-batch.service.spec.ts`)
- [x] Server build succeeds (`npm run build:server`)
- [x] Prisma validate: pre-existing Prisma v7 config issue (unrelated to this PR)
- [ ] Migration preflight: verify no NULL/orphan rows in production before deploying