### PR TITLE
feat: link process instances to existing products (GAP-001/GAP-006)

### DIFF
--- a/client/src/api/process.ts
+++ b/client/src/api/process.ts
@@ -72,8 +72,8 @@ export const processApi = {
   getInstance: (id: string) =>
     request.get<ProcessInstance & { stepDataList?: ProcessStepData[] }>(`/process/instances/${id}`),
 
-  createInstance: (templateId: string, productName?: string) =>
-    request.post<ProcessInstance>('/process/instances', { templateId, productName }),
+  createInstance: (templateId: string, productName?: string, productId?: string) =>
+    request.post<ProcessInstance>('/process/instances', { templateId, productName, productId }),
 
   deleteInstance: (id: string) =>
     request.delete(`/process/instances/${id}`),

--- a/client/src/views/process/Step1.vue
+++ b/client/src/views/process/Step1.vue
@@ -11,6 +11,23 @@
         <el-form-item label="申请日期">
           <el-input :model-value="form.requestDate" disabled />
         </el-form-item>
+        <el-form-item label="关联已有产品">
+          <el-select
+            v-model="form.productId"
+            filterable
+            clearable
+            placeholder="不选择则按新产品研发"
+            style="width: 100%"
+            @change="handleProductChange"
+          >
+            <el-option
+              v-for="product in products"
+              :key="product.id"
+              :label="`${product.code} ${product.name}`"
+              :value="product.id"
+            />
+          </el-select>
+        </el-form-item>
         <el-form-item label="开发产品名称" prop="productName" :rules="[{ required: true, message: '请填写产品名称' }]">
           <el-input v-model="form.productName" placeholder="如：海盐芝士味蛋糕" />
         </el-form-item>
@@ -75,6 +92,7 @@ import { ElMessage } from 'element-plus';
 import type { FormInstance } from 'element-plus';
 import dayjs from 'dayjs';
 import ApprovalTaskPanel from '@/components/approval/ApprovalTaskPanel.vue';
+import { productApi, type Product } from '@/api/product';
 
 const props = defineProps<{
   instanceId: string;
@@ -91,9 +109,11 @@ const emit = defineEmits<{
 }>();
 
 const formRef = ref<FormInstance>();
+const products = ref<Product[]>([]);
 
 const form = reactive({
   requestDate: dayjs().format('YYYY-MM-DD'),
+  productId: '',
   productName: '',
   developmentQuantity: '',
   processRequirement: '',
@@ -105,7 +125,14 @@ const form = reactive({
   applicationConclusion: '',
 });
 
-onMounted(() => {
+onMounted(async () => {
+  try {
+    const res = await productApi.getList();
+    products.value = (res as any)?.data ?? (Array.isArray(res) ? res : []);
+  } catch {
+    products.value = [];
+  }
+
   if (props.modelValue) {
     const mv = props.modelValue as typeof form;
     Object.keys(form).forEach((k) => {
@@ -126,6 +153,13 @@ const handleSubmit = async () => {
     return;
   }
   emit('submitted', { ...form });
+};
+
+const handleProductChange = (productId: string) => {
+  const product = products.value.find((p) => p.id === productId);
+  if (product) {
+    form.productName = product.name;
+  }
 };
 </script>
 

--- a/server/src/modules/process/process-approval.callbacks.ts
+++ b/server/src/modules/process/process-approval.callbacks.ts
@@ -32,8 +32,21 @@ export async function applyProcessStepApproved(
   };
 
   if (stepNumber === 1) {
+    const productId = typeof data.productId === 'string' && data.productId.trim()
+      ? data.productId.trim()
+      : undefined;
     const productName = data.productName as string | undefined;
-    if (productName && !instance.productId) {
+
+    if (productId) {
+      const product = await tx.product.findFirst({
+        where: { id: productId, deleted_at: null },
+      });
+      if (!product) {
+        throw new Error('产品不存在或已删除');
+      }
+      instanceUpdate.productId = product.id;
+      instanceUpdate.productName = product.name;
+    } else if (productName && !instance.productId) {
       const product = await tx.product.create({
         data: {
           company_id: '1',
@@ -44,6 +57,8 @@ export async function applyProcessStepApproved(
       });
       instanceUpdate.productName = productName;
       instanceUpdate.productId = product.id;
+    } else if (productName) {
+      instanceUpdate.productName = productName;
     }
   }
 

--- a/server/src/modules/process/process-instance.controller.ts
+++ b/server/src/modules/process/process-instance.controller.ts
@@ -61,10 +61,25 @@ export class ProcessInstanceController {
   @ApiOperation({ summary: '创建流程实例' })
   async create(@Body() data: any, @Request() req: any) {
     const userId = req.user?.sub || req.user?.id;
+
+    const productId = typeof data.productId === 'string' && data.productId.trim()
+      ? data.productId.trim()
+      : undefined;
+    const product = productId
+      ? await this.prisma.product.findFirst({
+          where: { id: productId, deleted_at: null },
+        })
+      : null;
+
+    if (productId && !product) {
+      throw new BadRequestException('产品不存在或已删除');
+    }
+
     const instance = await this.prisma.processInstance.create({
       data: {
         templateId: data.templateId,
-        productName: data.productName || '',
+        productId: product?.id,
+        productName: product?.name ?? data.productName ?? '',
         createdById: userId,
         status: 'DRAFT',
         currentStep: 1,

--- a/server/src/modules/process/process-product-link.spec.ts
+++ b/server/src/modules/process/process-product-link.spec.ts
@@ -1,0 +1,77 @@
+import { applyProcessStepApproved } from './process-approval.callbacks';
+
+describe('process product link approval callback', () => {
+  const createTx = (stepData: any, instanceOverrides: any = {}) => ({
+    processInstance: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'pi-1',
+        productId: null,
+        productName: '',
+        template: { steps: [{ stepNumber: 1 }] },
+        ...instanceOverrides,
+      }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    processStepData: {
+      findUnique: jest.fn().mockResolvedValue({
+        instanceId: 'pi-1',
+        stepNumber: 1,
+        status: 'SUBMITTED',
+        data: stepData,
+      }),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    product: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+  });
+
+  it('links an existing product without creating a duplicate product', async () => {
+    const tx = createTx({ productId: 'prod-1', productName: '前端文本名' });
+    tx.product.findFirst.mockResolvedValue({ id: 'prod-1', name: '主数据产品名' });
+
+    await applyProcessStepApproved({} as any, {
+      tx,
+      resourceId: 'pi-1',
+      resourceStep: 'step:1',
+      actorId: 'user-1',
+    } as any);
+
+    expect(tx.product.create).not.toHaveBeenCalled();
+    expect(tx.processInstance.update).toHaveBeenCalledWith({
+      where: { id: 'pi-1' },
+      data: expect.objectContaining({
+        productId: 'prod-1',
+        productName: '主数据产品名',
+      }),
+    });
+  });
+
+  it('keeps the new-product path when no productId is supplied', async () => {
+    const tx = createTx({ productName: '新产品A' });
+    tx.product.create.mockResolvedValue({ id: 'created-prod-1' });
+
+    await applyProcessStepApproved({} as any, {
+      tx,
+      resourceId: 'pi-1',
+      resourceStep: 'step:1',
+      actorId: 'user-1',
+    } as any);
+
+    expect(tx.product.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        name: '新产品A',
+        status: 'draft',
+      }),
+    });
+    expect(tx.processInstance.update).toHaveBeenCalledWith({
+      where: { id: 'pi-1' },
+      data: expect.objectContaining({
+        productId: 'created-prod-1',
+        productName: '新产品A',
+      }),
+    });
+  });
+});

--- a/server/src/modules/process/process-step-approval.service.ts
+++ b/server/src/modules/process/process-step-approval.service.ts
@@ -157,8 +157,21 @@ export class ProcessStepApprovalService {
     };
 
     if (stepNumber === 1) {
+      const productId = typeof data.productId === 'string' && data.productId.trim()
+        ? data.productId.trim()
+        : undefined;
       const productName = data.productName;
-      if (productName && !instance.productId) {
+
+      if (productId) {
+        const product = await tx.product.findFirst({
+          where: { id: productId, deleted_at: null },
+        });
+        if (!product) {
+          throw new BadRequestException('产品不存在或已删除');
+        }
+        instanceUpdate.productId = product.id;
+        instanceUpdate.productName = product.name;
+      } else if (productName && !instance.productId) {
         const product = await tx.product.create({
           data: { company_id: '1', code: `RD-${Date.now()}`, name: productName, status: 'draft' },
         });


### PR DESCRIPTION
## Summary

- Allow R&D process instances to bind an existing `Product.id` at creation time and during Step1 approval
- Preserve the new-product auto-creation path when no `productId` is supplied
- Add a searchable product selector in Step1.vue that prefills `productName` from master data

## Changes

| File | Change |
|------|--------|
| `client/src/api/process.ts` | `createInstance` now accepts optional `productId` |
| `client/src/views/process/Step1.vue` | Adds product selector above product name field |
| `server/src/modules/process/process-instance.controller.ts` | Validates and binds existing product on create |
| `server/src/modules/process/process-approval.callbacks.ts` | Step1 approval prefers existing product over creating duplicate |
| `server/src/modules/process/process-step-approval.service.ts` | Legacy approval path aligned with same logic |
| `server/src/modules/process/process-product-link.spec.ts` | New focused tests for both paths |

## Test plan

- [x] `process-product-link.spec.ts` — 2 tests PASS (existing product binding, new product creation path)
- [x] Server build succeeds (`npm run build:server`)
- [x] Client build succeeds (`npm run build:client`)
- [x] Schema unchanged (`git diff -- server/src/prisma/schema.prisma` → no diff)
- [ ] Manual: create a process instance with an existing `productId` — verify no duplicate Product is created
- [ ] Manual: create a process instance without `productId` — verify new Product is created on Step1 approval