### PR TITLE
noidear GAP-501 auth profile method

### DIFF
--- a/server/src/modules/auth/auth.controller.spec.ts
+++ b/server/src/modules/auth/auth.controller.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            login: jest.fn(),
+            changePassword: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<AuthController>(AuthController);
+  });
+
+  it('returns the authenticated user profile', async () => {
+    const user = {
+      userId: 'user-1',
+      id: 'user-1',
+      username: 'admin',
+      role: 'admin',
+      companyId: '1',
+    };
+
+    await expect(controller.getProfile({ user } as any)).resolves.toBe(user);
+  });
+});

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body, UseGuards, Request, Patch } from '@nestjs/common';
+import { Controller, Post, Get, Body, UseGuards, Request, Patch } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDTO } from './dto/login.dto';
 import { ChangePasswordDTO } from './dto/change-password.dto';
@@ -15,7 +15,7 @@ export class AuthController {
   }
 
   @UseGuards(JwtAuthGuard)
-  @Post('profile')
+  @Get('profile')
   async getProfile(@Request() req: AuthenticatedRequest) {
     return req.user;
   }


### PR DESCRIPTION
## Summary

- Changed `@Post('profile')` to `@Get('profile')` in `AuthController` to align with the frontend contract
- Added `server/src/modules/auth/auth.controller.spec.ts` with a unit test for `getProfile()`
- No frontend changes needed — `client/src/stores/user.ts` already uses `request.get('/auth/profile')`

## Verification

```
$ cd server && node_modules/.bin/jest auth.controller --runInBand

PASS src/modules/auth/auth.controller.spec.ts (60.93 s)
  AuthController
    ✓ returns the authenticated user profile (58 ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

```
$ rg -n "auth/profile|Post('profile')|Get('profile')" client/src/stores/user.ts server/src/modules/auth/auth.controller.ts

server/src/modules/auth/auth.controller.ts:18:  @Get('profile')
client/src/stores/user.ts:45:        const user = await request.get<User>('/auth/profile');
```

## Test plan

- [x] Unit test for `getProfile()` passes
- [x] Frontend contract unchanged — no frontend changes required
- [x] No schema/migration changes