### PR TITLE
noidear GAP-407 internal audit api prefix

### DIFF
--- a/client/src/api/internal-audit/finding.ts
+++ b/client/src/api/internal-audit/finding.ts
@@ -72,45 +72,45 @@ export interface RejectFindingDto {
 
 // 创建审核发现
 export const createFinding = (data: CreateFindingDto) => {
-  return request.post<AuditFinding>('/api/v1/audit/findings', data);
+  return request.post<AuditFinding>('/audit/findings', data);
 };
 
 // 更新审核发现
 export const updateFinding = (id: string, data: UpdateFindingDto) => {
-  return request.put<AuditFinding>(`/api/v1/audit/findings/${id}`, data);
+  return request.put<AuditFinding>(`/audit/findings/${id}`, data);
 };
 
 // 提交审核报告
 export const submitAuditReport = (planId: string) => {
-  return request.post(`/api/v1/audit/plans/${planId}/submit`);
+  return request.post(`/audit/plans/${planId}/submit`);
 };
 
 // 撤回审核报告
 export const withdrawAuditReport = (planId: string) => {
-  return request.post(`/api/v1/audit/plans/${planId}/withdraw`);
+  return request.post(`/audit/plans/${planId}/withdraw`);
 };
 
 // 获取我的整改任务
 export const getMyRectifications = (params?: { page?: number; limit?: number }) => {
-  return request.get<{ items: AuditFinding[]; total: number }>('/api/v1/audit/findings/my-rectifications', { params });
+  return request.get<{ items: AuditFinding[]; total: number }>('/audit/findings/my-rectifications', { params });
 };
 
 // 提交整改
 export const submitRectification = (id: string, data: SubmitRectificationDto) => {
-  return request.post<AuditFinding>(`/api/v1/audit/findings/${id}/submit-rectification`, data);
+  return request.post<AuditFinding>(`/audit/findings/${id}/submit-rectification`, data);
 };
 
 // 获取待复审任务
 export const getPendingVerifications = (params?: { page?: number; limit?: number }) => {
-  return request.get<{ items: AuditFinding[]; total: number }>('/api/v1/audit/findings/pending-verification', { params });
+  return request.get<{ items: AuditFinding[]; total: number }>('/audit/findings/pending-verification', { params });
 };
 
 // 验证整改（通过）
 export const verifyFinding = (id: string, data?: VerifyFindingDto) => {
-  return request.post<AuditFinding>(`/api/v1/audit/findings/${id}/verify`, data);
+  return request.post<AuditFinding>(`/audit/findings/${id}/verify`, data);
 };
 
 // 驳回整改
 export const rejectFinding = (id: string, data: RejectFindingDto) => {
-  return request.post<AuditFinding>(`/api/v1/audit/findings/${id}/reject`, data);
+  return request.post<AuditFinding>(`/audit/findings/${id}/reject`, data);
 };

--- a/client/src/api/internal-audit/plan.ts
+++ b/client/src/api/internal-audit/plan.ts
@@ -49,43 +49,43 @@ export interface QueryAuditPlanDto {
 
 // 创建审核计划
 export const createAuditPlan = (data: CreateAuditPlanDto) => {
-  return request.post<AuditPlan>('/api/v1/audit/plans', data);
+  return request.post<AuditPlan>('/audit/plans', data);
 };
 
 // 查询审核计划列表
 export const queryAuditPlans = (params: QueryAuditPlanDto) => {
   return request.get<{ items: AuditPlan[]; total: number; page: number; limit: number }>(
-    '/api/v1/audit/plans',
+    '/audit/plans',
     { params }
   );
 };
 
 // 获取审核计划详情
 export const getAuditPlan = (id: string) => {
-  return request.get<AuditPlan>(`/api/v1/audit/plans/${id}`);
+  return request.get<AuditPlan>(`/audit/plans/${id}`);
 };
 
 // 更新审核计划
 export const updateAuditPlan = (id: string, data: UpdateAuditPlanDto) => {
-  return request.put<AuditPlan>(`/api/v1/audit/plans/${id}`, data);
+  return request.put<AuditPlan>(`/audit/plans/${id}`, data);
 };
 
 // 删除审核计划
 export const deleteAuditPlan = (id: string) => {
-  return request.delete(`/api/v1/audit/plans/${id}`);
+  return request.delete(`/audit/plans/${id}`);
 };
 
 // 启动审核计划
 export const startAuditPlan = (id: string) => {
-  return request.post<AuditPlan>(`/api/v1/audit/plans/${id}/start`);
+  return request.post<AuditPlan>(`/audit/plans/${id}/start`);
 };
 
 // 复制审核计划
 export const copyAuditPlan = (id: string) => {
-  return request.post<AuditPlan>(`/api/v1/audit/plans/${id}/copy`);
+  return request.post<AuditPlan>(`/audit/plans/${id}/copy`);
 };
 
 // 获取统计信息
 export const getAuditPlanStats = () => {
-  return request.get('/api/v1/audit/plans/statistics');
+  return request.get('/audit/plans/statistics');
 };

--- a/client/src/api/internal-audit/report.ts
+++ b/client/src/api/internal-audit/report.ts
@@ -27,15 +27,15 @@ export interface QueryReportDto {
 
 // 完成内审计划（生成报告）
 export const completeAuditPlan = (planId: string) => {
-  return request.post<AuditReport>(`/api/v1/audit/plans/${planId}/complete`);
+  return request.post<AuditReport>(`/audit/plans/${planId}/complete`);
 };
 
 // 查询内审报告列表
 export const getReports = (params?: QueryReportDto) => {
-  return request.get<{ items: AuditReport[]; total: number }>('/api/v1/audit/reports', { params });
+  return request.get<{ items: AuditReport[]; total: number }>('/audit/reports', { params });
 };
 
 // 获取内审报告详情
 export const getReport = (id: string) => {
-  return request.get<AuditReport>(`/api/v1/audit/reports/${id}`);
+  return request.get<AuditReport>(`/audit/reports/${id}`);
 };


### PR DESCRIPTION
## Summary

- Remove duplicate `/api/v1` prefix from internal audit frontend API calls
- Keep Axios `baseURL: '/api/v1'` as the single prefix source
- All paths in `plan.ts`, `finding.ts`, `report.ts` now use `/audit/...` relative paths

## Verification

**Duplicate prefix check:**
```
rg -n "/api/v1/audit" client/src/api/internal-audit
# → no output (clean)
```

**Build verification:**
```
npm --prefix client run build
# → ✓ built in 25.16s (PASS)
```

## Files Modified

- `client/src/api/internal-audit/plan.ts`
- `client/src/api/internal-audit/finding.ts`
- `client/src/api/internal-audit/report.ts`