### PR TITLE
noidear GAP-409 training project status endpoints

### DIFF
--- a/server/src/modules/training/training.controller.spec.ts
+++ b/server/src/modules/training/training.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TrainingController } from './training.controller';
+import { TrainingService } from './training.service';
+
+describe('TrainingController status endpoints', () => {
+  let controller: TrainingController;
+  const trainingService = {
+    updateProjectStatus: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TrainingController],
+      providers: [{ provide: TrainingService, useValue: trainingService }],
+    }).compile();
+
+    controller = module.get<TrainingController>(TrainingController);
+  });
+
+  it('starts a project by setting status to ongoing', async () => {
+    trainingService.updateProjectStatus.mockResolvedValue({ id: 'project-1', status: 'ongoing' });
+    await expect(controller.startProject('project-1')).resolves.toEqual({ id: 'project-1', status: 'ongoing' });
+    expect(trainingService.updateProjectStatus).toHaveBeenCalledWith('project-1', 'ongoing');
+  });
+
+  it('completes a project by setting status to completed', async () => {
+    trainingService.updateProjectStatus.mockResolvedValue({ id: 'project-1', status: 'completed' });
+    await expect(controller.completeProject('project-1')).resolves.toEqual({ id: 'project-1', status: 'completed' });
+    expect(trainingService.updateProjectStatus).toHaveBeenCalledWith('project-1', 'completed');
+  });
+
+  it('cancels a project by setting status to cancelled', async () => {
+    trainingService.updateProjectStatus.mockResolvedValue({ id: 'project-1', status: 'cancelled' });
+    await expect(controller.cancelProject('project-1')).resolves.toEqual({ id: 'project-1', status: 'cancelled' });
+    expect(trainingService.updateProjectStatus).toHaveBeenCalledWith('project-1', 'cancelled');
+  });
+});

--- a/server/src/modules/training/training.controller.ts
+++ b/server/src/modules/training/training.controller.ts
@@ -120,4 +120,22 @@ export class TrainingController {
   async updateProjectStatus(@Param('id') id: string, @Body() body: { status: string }) {
     return this.trainingService.updateProjectStatus(id, body.status);
   }
+
+  @Post('projects/:id/start')
+  @ApiOperation({ summary: '启动培训项目' })
+  async startProject(@Param('id') id: string) {
+    return this.trainingService.updateProjectStatus(id, 'ongoing');
+  }
+
+  @Post('projects/:id/complete')
+  @ApiOperation({ summary: '完成培训项目' })
+  async completeProject(@Param('id') id: string) {
+    return this.trainingService.updateProjectStatus(id, 'completed');
+  }
+
+  @Post('projects/:id/cancel')
+  @ApiOperation({ summary: '取消培训项目' })
+  async cancelProject(@Param('id') id: string) {
+    return this.trainingService.updateProjectStatus(id, 'cancelled');
+  }
 }

--- a/server/src/modules/training/training.service.ts
+++ b/server/src/modules/training/training.service.ts
@@ -539,7 +539,7 @@ export class TrainingService {
     const updated = await this.prisma.trainingProject.update({
       where: { id },
       data: {
-        trainees: project.trainees.filter(t => t !== userId),
+        trainees: project.trainees.filter((t: string) => t !== userId),
       },
     });
 
@@ -622,7 +622,7 @@ export class TrainingService {
       throw new BadRequestException('部分培训资料不存在');
     }
 
-    const unpublishedDocs = documents.filter(doc => doc.status !== 'published');
+    const unpublishedDocs = documents.filter((doc: { id: string; status: string }) => doc.status !== 'published');
     if (unpublishedDocs.length > 0) {
       throw new BadRequestException('只能引用已发布的文档作为培训资料');
     }
@@ -634,7 +634,7 @@ export class TrainingService {
       select: { userId: true },
     });
 
-    const existingUserIds = new Set(existingRecords.map(r => r.userId));
+    const existingUserIds = new Set(existingRecords.map((r: { userId: string }) => r.userId));
     const newTrainees = trainees.filter(userId => !existingUserIds.has(userId));
 
     if (newTrainees.length > 0) {
@@ -656,15 +656,15 @@ export class TrainingService {
       where: { projectId },
     });
 
-    const existingUserIds = new Set(existingRecords.map(r => r.userId));
+    const existingUserIds = new Set(existingRecords.map((r: { id: string; userId: string }) => r.userId));
     const newTraineesSet = new Set(newTrainees);
 
     // 删除不在新列表中的学习记录
-    const toDelete = existingRecords.filter(r => !newTraineesSet.has(r.userId));
+    const toDelete = existingRecords.filter((r: { id: string; userId: string }) => !newTraineesSet.has(r.userId));
     if (toDelete.length > 0) {
       await this.prisma.learningRecord.deleteMany({
         where: {
-          id: { in: toDelete.map(r => r.id) },
+          id: { in: toDelete.map((r: { id: string; userId: string }) => r.id) },
         },
       });
     }


### PR DESCRIPTION
## Summary

- Add `POST /training/projects/:id/start` → sets status to `ongoing`
- Add `POST /training/projects/:id/complete` → sets status to `completed`
- Add `POST /training/projects/:id/cancel` → sets status to `cancelled`
- All three endpoints delegate to `TrainingService.updateProjectStatus()` — no state machine logic is duplicated
- Fix pre-existing implicit-any TS errors in `training.service.ts` (lines 542, 625, 637, 659, 663, 667) that prevented any training tests from compiling

## Verification

```
$ cd server && npx jest training.controller --runInBand

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Time:        2.978 s
```

## Test plan

- [ ] `POST /training/projects/:id/start` returns project with status `ongoing`
- [ ] `POST /training/projects/:id/complete` returns project with status `completed`
- [ ] `POST /training/projects/:id/cancel` returns project with status `cancelled`
- [ ] Frontend `startTrainingProject`, `completeTrainingProject`, `cancelTrainingProject` no longer get 404