### PR TITLE
fix: GAP-306 register traceability sub-services in TraceabilityModule

### DIFF
--- a/server/src/modules/traceability/traceability.module.spec.ts
+++ b/server/src/modules/traceability/traceability.module.spec.ts
@@ -1,0 +1,26 @@
+import { Test } from '@nestjs/testing';
+import { TraceabilityModule } from './traceability.module';
+import { TraceabilityQueryService } from './traceability-query.service';
+import { TraceabilityLinkageService } from './traceability-linkage.service';
+import { TraceabilityExportService } from './traceability-export.service';
+import { TraceabilityBalanceService } from './traceability-balance.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ModelLandingService } from '../model-landing/model-landing.service';
+
+describe('TraceabilityModule', () => {
+  it('registers traceability sub-services for DI', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [TraceabilityModule],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({})
+      .overrideProvider(ModelLandingService)
+      .useValue({})
+      .compile();
+
+    expect(moduleRef.get(TraceabilityQueryService)).toBeInstanceOf(TraceabilityQueryService);
+    expect(moduleRef.get(TraceabilityLinkageService)).toBeInstanceOf(TraceabilityLinkageService);
+    expect(moduleRef.get(TraceabilityExportService)).toBeInstanceOf(TraceabilityExportService);
+    expect(moduleRef.get(TraceabilityBalanceService)).toBeInstanceOf(TraceabilityBalanceService);
+  });
+});

--- a/server/src/modules/traceability/traceability.module.ts
+++ b/server/src/modules/traceability/traceability.module.ts
@@ -1,10 +1,28 @@
 import { Module } from '@nestjs/common';
 import { TraceabilityController } from './traceability.controller';
 import { TraceabilityService } from './traceability.service';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { ModelLandingModule } from '../model-landing/model-landing.module';
+import { TraceabilityQueryService } from './traceability-query.service';
+import { TraceabilityLinkageService } from './traceability-linkage.service';
+import { TraceabilityExportService } from './traceability-export.service';
+import { TraceabilityBalanceService } from './traceability-balance.service';
 
 @Module({
+  imports: [PrismaModule, ModelLandingModule],
   controllers: [TraceabilityController],
-  providers: [TraceabilityService],
-  exports: [TraceabilityService],
+  providers: [
+    TraceabilityService,
+    TraceabilityQueryService,
+    TraceabilityLinkageService,
+    TraceabilityExportService,
+    TraceabilityBalanceService,
+  ],
+  exports: [
+    TraceabilityService,
+    TraceabilityQueryService,
+    TraceabilityExportService,
+    TraceabilityBalanceService,
+  ],
 })
 export class TraceabilityModule {}


### PR DESCRIPTION
## Summary

- Registers `TraceabilityQueryService`, `TraceabilityLinkageService`, `TraceabilityExportService`, and `TraceabilityBalanceService` in `TraceabilityModule`
- Imports `PrismaModule` and `ModelLandingModule` to satisfy sub-service DI dependencies
- Exports `TraceabilityQueryService`, `TraceabilityExportService`, and `TraceabilityBalanceService` for cross-module use (`TraceabilityLinkageService` not exported as no cross-module consumer identified)
- Adds `traceability.module.spec.ts` verifying all four sub-services are resolvable via DI

## References

- GAP: **GAP-306**
- Issue: [MYL-35](mention://issue/ac506cac-41a2-4dc3-86ad-778885ea1fad)
- Plan: `docs/superpowers/plans/2026-05-01-gap-306-traceability-module-service-registration-implementation.md`

## Test plan

- [x] `traceability.module.spec.ts` — RED before, GREEN after module wiring fix
- [x] Full `--testPathPattern traceability` suite: 21 tests pass across 7 suites
- [x] 2 pre-existing failures confirmed unrelated (TS errors in `batch-trace` legacy service + E2E requiring live server)
- [x] `git diff --check` clean — only 2 target files modified

## Schema / migration changes

None.

## Remaining risks

- `TraceabilityLinkageService` not exported; if a future module needs it, add to `exports` in a follow-up
- GAP-307 will implement the full query chain; this PR only fixes DI wiring