### PR TITLE
fix: GAP-205 finished goods residual cleanup

### DIFF
--- a/server/src/modules/record-template/dto/create-record-template.dto.spec.ts
+++ b/server/src/modules/record-template/dto/create-record-template.dto.spec.ts
@@ -1,0 +1,30 @@
+import { validate } from 'class-validator';
+import { CreateRecordTemplateDto } from './create-record-template.dto';
+
+describe('CreateRecordTemplateDto', () => {
+  it('rejects finished_goods for new record template batch links', async () => {
+    const dto = Object.assign(new CreateRecordTemplateDto(), {
+      name: '模板',
+      code: 'TPL-001',
+      fieldsJson: { sections: [] },
+      batchLinkType: 'finished_goods',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'batchLinkType')).toBe(true);
+  });
+
+  it('accepts production as batchLinkType', async () => {
+    const dto = Object.assign(new CreateRecordTemplateDto(), {
+      name: '模板',
+      code: 'TPL-001',
+      fieldsJson: { sections: [] },
+      batchLinkType: 'production',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors.some((e) => e.property === 'batchLinkType')).toBe(false);
+  });
+});

--- a/server/src/modules/record-template/dto/create-record-template.dto.ts
+++ b/server/src/modules/record-template/dto/create-record-template.dto.ts
@@ -40,10 +40,9 @@ export class CreateRecordTemplateDto {
   @IsBoolean()
   batchLinkEnabled?: boolean;
 
-  @ApiPropertyOptional({ description: '批次关联类型', example: 'production', enum: ['production', 'finished_goods'] })
+  @ApiPropertyOptional({ description: '批次关联类型', example: 'production', enum: ['production'] })
   @IsOptional()
-  @IsString()
-  @IsIn(['production', 'finished_goods'])
+  @IsIn(['production'])
   batchLinkType?: string;
 
   @ApiPropertyOptional({ description: '批次关联字段名', example: 'batchNumber' })

--- a/server/src/modules/record-template/dto/update-record-template.dto.ts
+++ b/server/src/modules/record-template/dto/update-record-template.dto.ts
@@ -35,10 +35,9 @@ export class UpdateRecordTemplateDto {
   @IsBoolean()
   batchLinkEnabled?: boolean;
 
-  @ApiPropertyOptional({ description: '批次关联类型', example: 'production', enum: ['production', 'finished_goods'] })
+  @ApiPropertyOptional({ description: '批次关联类型', example: 'production', enum: ['production'] })
   @IsOptional()
-  @IsString()
-  @IsIn(['production', 'finished_goods'])
+  @IsIn(['production'])
   batchLinkType?: string;
 
   @ApiPropertyOptional({ description: '批次关联字段名', example: 'batchNumber' })

--- a/server/src/modules/record-template/types/fields-json.types.ts
+++ b/server/src/modules/record-template/types/fields-json.types.ts
@@ -7,6 +7,7 @@ export type FieldType =
   | 'signature'
   | 'entity-link';
 
+// Historical compatibility only. New batch-linked templates should use production_batch.
 export type EntityType =
   | 'shift_instance' | 'production_run' | 'material_lot' | 'supplier'
   | 'production_batch' | 'finished_goods_batch' | 'product' | 'recipe' | 'equipment';

--- a/server/src/modules/record/record.service.ts
+++ b/server/src/modules/record/record.service.ts
@@ -517,6 +517,8 @@ export class RecordService {
     batchNumber: string,
     batchType: string,
   ): Promise<any> {
+    // GAP-205: `finished_goods` is accepted only for historical templates.
+    // New templates must use `production`; both values resolve to ProductionBatch.
     if (batchType === 'production' || batchType === 'finished_goods') {
       const batch = await this.prisma.productionBatch.findUnique({
         where: { batchNumber },

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -788,7 +788,7 @@ model RecordTemplate {
 
   // TASK-169: 批次关联配置
   batchLinkEnabled Boolean @default(false) // 是否启用批次关联
-  batchLinkType    String? // "production" | "finished_goods"
+  batchLinkType    String? // "production"; legacy rows may contain "finished_goods"
   batchLinkField   String? // 哪个字段存储批次号
 
   // 工作流集成字段
@@ -840,7 +840,7 @@ model Record {
   deletedAt      DateTime?
 
   // TASK-169: 批次关联
-  relatedBatchType     String? // "production" | "finished_goods"
+  relatedBatchType     String? // "production"; legacy rows may contain "finished_goods"
   relatedBatchId       String? // 批次 ID
   relatedBatchNumber   String? // 批次号（冗余，加速查询）
   productionBatchId    String?
@@ -2674,7 +2674,7 @@ model IncomingInspectionResult {
 model InventoryMovement {
   id            Int      @id @default(autoincrement())
   company_id    Int
-  movement_type String   // 'receive'|'issue_to_production'|'transfer'|'finished_goods_in'|'finished_goods_out'|'adjustment'
+  movement_type String   // 'receive'|'issue_to_production'|'transfer'|'production_in'|'production_out'|'adjustment'|'return_to_warehouse'|'scrap'
   object_type   String   // 'material_batch'|'production_batch'
   object_id     String
   from_location String?


### PR DESCRIPTION
## Summary

- Restrict `batchLinkType` in `CreateRecordTemplateDto` and `UpdateRecordTemplateDto` to `['production']` only — rejects `finished_goods` on new templates
- Preserve historical compatibility in `RecordService.associateBatch()` — both `production` and `finished_goods` still resolve to `ProductionBatch` for legacy rows, with a GAP-205 comment explaining this
- Add `// Historical compatibility only` comment to `finished_goods_batch` in `EntityType` union
- Update `schema.prisma` comments for `Record.batchLinkType`, `Record.relatedBatchType`, and `InventoryMovement.movement_type` to reflect `ProductionBatch` vocabulary
- Add focused DTO validation test (`create-record-template.dto.spec.ts`) that verifies `finished_goods` is rejected

## References

- Issue: MYL-34
- GAP: GAP-205
- Plan: `docs/superpowers/plans/2026-05-01-gap-205-finished-goods-residual-cleanup-implementation.md`

## Test plan

- [x] `jest "record-template/dto" --runInBand` → 2 tests pass
- [x] `rg "batchLinkType.*finished_goods|IsIn\(\['production', 'finished_goods'\]" server/src/modules` → only match is the rejection test
- [x] `git diff --check` → no trailing whitespace
- [x] No schema migration required — only comments changed in `schema.prisma`
- [x] No destructive DB operations