### PR TITLE
feat: GAP-102 dual-write warehouse movements to inventory ledger

### DIFF
--- a/server/src/modules/warehouse/inbound.service.spec.ts
+++ b/server/src/modules/warehouse/inbound.service.spec.ts
@@ -10,6 +10,7 @@ describe('InboundService', () => {
   let service: InboundService;
   let prisma: PrismaService;
   let batchNumberGenerator: BatchNumberGeneratorService;
+  let inventoryMovementLedger: InventoryMovementLedgerService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -53,6 +54,7 @@ describe('InboundService', () => {
     service = module.get<InboundService>(InboundService);
     prisma = module.get<PrismaService>(PrismaService);
     batchNumberGenerator = module.get<BatchNumberGeneratorService>(BatchNumberGeneratorService);
+    inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
   });
 
   afterEach(() => {
@@ -180,25 +182,19 @@ describe('InboundService', () => {
 
       jest.spyOn(prisma.materialInbound, 'findUnique').mockResolvedValue(mockInbound as any);
       jest.spyOn(batchNumberGenerator, 'generateBatchNumber').mockResolvedValue('BATCH-20260215-001');
+      jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
+
+      const txClient = {
+        materialBatch: { create: jest.fn().mockResolvedValue(mockBatch) },
+        stockRecord: { create: jest.fn() },
+        materialInboundItem: { update: jest.fn() },
+        materialInbound: {
+          update: jest.fn().mockResolvedValue({ ...mockInbound, status: 'completed' }),
+        },
+      };
 
       jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-        return callback({
-          materialBatch: {
-            create: jest.fn().mockResolvedValue(mockBatch),
-          },
-          stockRecord: {
-            create: jest.fn(),
-          },
-          materialInboundItem: {
-            update: jest.fn(),
-          },
-          materialInbound: {
-            update: jest.fn().mockResolvedValue({
-              ...mockInbound,
-              status: 'completed',
-            }),
-          },
-        });
+        return callback(txClient);
       });
 
       // Act
@@ -208,6 +204,10 @@ describe('InboundService', () => {
       expect(result.status).toBe('completed');
       expect(batchNumberGenerator.generateBatchNumber).toHaveBeenCalledWith('material');
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ movementType: 'receive', batchId: mockBatch.id }),
+        txClient,
+      );
     });
 
     it('should throw BadRequestException if not approved', async () => {

--- a/server/src/modules/warehouse/inbound.service.spec.ts
+++ b/server/src/modules/warehouse/inbound.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { InboundService } from './inbound.service';
 import { BatchNumberGeneratorService } from '../batch-trace/services/batch-number-generator.service';
+import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import * as dayjs from 'dayjs';
 
@@ -41,6 +42,10 @@ describe('InboundService', () => {
           useValue: {
             generateBatchNumber: jest.fn(),
           },
+        },
+        {
+          provide: InventoryMovementLedgerService,
+          useValue: { recordMaterialBatchMovement: jest.fn() },
         },
       ],
     }).compile();

--- a/server/src/modules/warehouse/inbound.service.ts
+++ b/server/src/modules/warehouse/inbound.service.ts
@@ -8,6 +8,8 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { BatchNumberGeneratorService } from '../batch-trace/services/batch-number-generator.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
 import { CreateInboundDto, QueryInboundDto } from './dto/inbound.dto';
+import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { Prisma } from '@prisma/client';
 import * as dayjs from 'dayjs';
 
 @Injectable()
@@ -16,13 +18,14 @@ export class InboundService {
     private readonly prisma: PrismaService,
     private readonly batchNumberGenerator: BatchNumberGeneratorService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
+    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(createInboundDto: CreateInboundDto, createdById?: string) {
     const { supplierId, items, remark } = createInboundDto;
     const inboundNo = await this.generateInboundNo();
 
-    const inbound = await this.prisma.$transaction(async (tx) => {
+    const inbound = await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const created = await tx.materialInbound.create({
         data: {
           inboundNo,
@@ -150,7 +153,7 @@ export class InboundService {
       throw new BadRequestException('Only approved inbound can be completed');
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of inbound.items) {
         const batchNumber = await this.batchNumberGenerator.generateBatchNumber('material');
 
@@ -177,6 +180,20 @@ export class InboundService {
             operatorId,
           },
         });
+
+        if (this.inventoryMovementLedger) {
+          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+            movementType: 'receive',
+            batchId: batch.id,
+            quantity: item.quantity,
+            unit: 'kg',
+            refType: 'inbound',
+            refId: inbound.id,
+            operatorId,
+            movedAt: new Date(),
+            notes: '来料入库',
+          });
+        }
 
         await tx.materialInboundItem.update({
           where: { id: item.id },

--- a/server/src/modules/warehouse/inbound.service.ts
+++ b/server/src/modules/warehouse/inbound.service.ts
@@ -18,7 +18,7 @@ export class InboundService {
     private readonly prisma: PrismaService,
     private readonly batchNumberGenerator: BatchNumberGeneratorService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
-    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(createInboundDto: CreateInboundDto, createdById?: string) {
@@ -181,8 +181,8 @@ export class InboundService {
           },
         });
 
-        if (this.inventoryMovementLedger) {
-          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+        await this.inventoryMovementLedger.recordMaterialBatchMovement(
+          {
             movementType: 'receive',
             batchId: batch.id,
             quantity: item.quantity,
@@ -192,8 +192,9 @@ export class InboundService {
             operatorId,
             movedAt: new Date(),
             notes: '来料入库',
-          });
-        }
+          },
+          tx,
+        );
 
         await tx.materialInboundItem.update({
           where: { id: item.id },

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -7,6 +7,7 @@ import { BadRequestException, NotFoundException } from '@nestjs/common';
 describe('RequisitionService', () => {
   let service: RequisitionService;
   let prisma: PrismaService;
+  let inventoryMovementLedger: InventoryMovementLedgerService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -49,6 +50,7 @@ describe('RequisitionService', () => {
 
     service = module.get<RequisitionService>(RequisitionService);
     prisma = module.get<PrismaService>(PrismaService);
+    inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
   });
 
   afterEach(() => {
@@ -127,14 +129,27 @@ describe('RequisitionService', () => {
       };
 
       jest.spyOn(prisma.materialRequisition, 'findUnique').mockResolvedValue(mockRequisition as any);
-      
+      jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
+
+      const txClient = {
+        materialBatch: { update: jest.fn() },
+        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
+        stockRecord: { create: jest.fn() },
+        materialRequisition: { update: jest.fn().mockResolvedValue({ ...mockRequisition, status: 'completed' }) },
+        materialRequisitionItem: { findMany: jest.fn().mockResolvedValue(mockRequisition.items) },
+      };
+
       jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-        return callback(prisma);
+        return callback(txClient);
       });
 
       await service.complete('req-001', 'user-001');
 
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ movementType: 'issue_to_production', batchId: 'batch-001' }),
+        txClient,
+      );
     });
 
     it('should throw BadRequestException if not approved', async () => {

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RequisitionService } from './requisition.service';
+import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('RequisitionService', () => {
@@ -29,12 +30,19 @@ describe('RequisitionService', () => {
             },
             stagingAreaStock: {
               upsert: jest.fn(),
+              findFirst: jest.fn(),
+              update: jest.fn(),
+              create: jest.fn(),
             },
             stockRecord: {
               create: jest.fn(),
             },
             $transaction: jest.fn(),
           },
+        },
+        {
+          provide: InventoryMovementLedgerService,
+          useValue: { recordMaterialBatchMovement: jest.fn() },
         },
       ],
     }).compile();

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -10,7 +10,7 @@ export class RequisitionService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
-    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(createDto: any) {
@@ -178,8 +178,8 @@ export class RequisitionService {
           },
         });
 
-        if (this.inventoryMovementLedger) {
-          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+        await this.inventoryMovementLedger.recordMaterialBatchMovement(
+          {
             movementType: 'issue_to_production',
             batchId: item.batchId,
             quantity: item.quantity,
@@ -190,8 +190,9 @@ export class RequisitionService {
             movedAt: new Date(),
             toLocation: requisition.targetZone ?? undefined,
             notes: '生产领料',
-          });
-        }
+          },
+          tx,
+        );
       }
 
       return tx.materialRequisition.update({

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException, BadRequestException, Optional } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
+import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { Prisma } from '@prisma/client';
 import * as dayjs from 'dayjs';
 
 @Injectable()
@@ -8,12 +10,13 @@ export class RequisitionService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
+    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(createDto: any) {
     const requisitionNo = this.generateRequisitionNo();
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const requisition = await tx.materialRequisition.create({
         data: {
           requisitionNo,
@@ -134,7 +137,7 @@ export class RequisitionService {
       throw new BadRequestException('Only approved requisition can be completed');
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of requisition.items) {
         await tx.materialBatch.update({
           where: { id: item.batchId },
@@ -174,6 +177,21 @@ export class RequisitionService {
             operatorId,
           },
         });
+
+        if (this.inventoryMovementLedger) {
+          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+            movementType: 'issue_to_production',
+            batchId: item.batchId,
+            quantity: item.quantity,
+            unit: 'kg',
+            refType: 'requisition',
+            refId: requisition.id,
+            operatorId,
+            movedAt: new Date(),
+            toLocation: requisition.targetZone ?? undefined,
+            notes: '生产领料',
+          });
+        }
       }
 
       return tx.materialRequisition.update({

--- a/server/src/modules/warehouse/services/inventory-movement-ledger.service.spec.ts
+++ b/server/src/modules/warehouse/services/inventory-movement-ledger.service.spec.ts
@@ -1,0 +1,46 @@
+import { InventoryMovementLedgerService } from './inventory-movement-ledger.service';
+
+describe('InventoryMovementLedgerService', () => {
+  const prisma = {
+    inventoryMovement: {
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('writes a material batch receive movement', async () => {
+    const service = new InventoryMovementLedgerService(prisma as any);
+
+    await service.recordMaterialBatchMovement({
+      companyId: 1,
+      movementType: 'receive',
+      batchId: 'batch-1',
+      quantity: 12.5,
+      unit: 'kg',
+      refType: 'inbound',
+      refId: 'inbound-1',
+      operatorId: 'user-1',
+      movedAt: new Date('2026-05-01T08:00:00.000Z'),
+      notes: '入库',
+    });
+
+    expect(prisma.inventoryMovement.create).toHaveBeenCalledWith({
+      data: {
+        company_id: 1,
+        movement_type: 'receive',
+        object_type: 'material_batch',
+        object_id: 'batch-1',
+        qty: 12.5,
+        unit: 'kg',
+        ref_type: 'inbound',
+        ref_id: 'inbound-1',
+        operator_id: 'user-1',
+        moved_at: new Date('2026-05-01T08:00:00.000Z'),
+        notes: '入库',
+      },
+    });
+  });
+});

--- a/server/src/modules/warehouse/services/inventory-movement-ledger.service.spec.ts
+++ b/server/src/modules/warehouse/services/inventory-movement-ledger.service.spec.ts
@@ -11,7 +11,7 @@ describe('InventoryMovementLedgerService', () => {
     jest.clearAllMocks();
   });
 
-  it('writes a material batch receive movement', async () => {
+  it('writes a material batch receive movement using root prisma when no tx', async () => {
     const service = new InventoryMovementLedgerService(prisma as any);
 
     await service.recordMaterialBatchMovement({
@@ -42,5 +42,48 @@ describe('InventoryMovementLedgerService', () => {
         notes: '入库',
       },
     });
+  });
+
+  it('uses the provided tx client instead of root prisma', async () => {
+    const service = new InventoryMovementLedgerService(prisma as any);
+
+    const txClient = {
+      inventoryMovement: {
+        create: jest.fn(),
+      },
+    };
+
+    await service.recordMaterialBatchMovement(
+      {
+        companyId: 1,
+        movementType: 'receive',
+        batchId: 'batch-tx',
+        quantity: 5,
+        unit: 'kg',
+        refType: 'inbound',
+        refId: 'inbound-tx',
+        operatorId: 'user-tx',
+        movedAt: new Date('2026-05-01T08:00:00.000Z'),
+        notes: 'tx 入库',
+      },
+      txClient as any,
+    );
+
+    expect(txClient.inventoryMovement.create).toHaveBeenCalledWith({
+      data: {
+        company_id: 1,
+        movement_type: 'receive',
+        object_type: 'material_batch',
+        object_id: 'batch-tx',
+        qty: 5,
+        unit: 'kg',
+        ref_type: 'inbound',
+        ref_id: 'inbound-tx',
+        operator_id: 'user-tx',
+        moved_at: new Date('2026-05-01T08:00:00.000Z'),
+        notes: 'tx 入库',
+      },
+    });
+    expect(prisma.inventoryMovement.create).not.toHaveBeenCalled();
   });
 });

--- a/server/src/modules/warehouse/services/inventory-movement-ledger.service.ts
+++ b/server/src/modules/warehouse/services/inventory-movement-ledger.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+export type InventoryMovementType =
+  | 'receive'
+  | 'issue_to_production'
+  | 'return_to_warehouse'
+  | 'scrap'
+  | 'transfer'
+  | 'adjustment';
+
+interface RecordMaterialBatchMovementInput {
+  companyId?: number;
+  movementType: InventoryMovementType;
+  batchId: string;
+  quantity: number;
+  unit?: string;
+  refType?: string;
+  refId?: string;
+  operatorId?: string;
+  movedAt?: Date;
+  fromLocation?: string;
+  toLocation?: string;
+  notes?: string;
+}
+
+@Injectable()
+export class InventoryMovementLedgerService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async recordMaterialBatchMovement(input: RecordMaterialBatchMovementInput) {
+    return this.prisma.inventoryMovement.create({
+      data: {
+        company_id: input.companyId ?? 1,
+        movement_type: input.movementType,
+        object_type: 'material_batch',
+        object_id: input.batchId,
+        from_location: input.fromLocation,
+        to_location: input.toLocation,
+        qty: input.quantity,
+        unit: input.unit ?? 'kg',
+        ref_type: input.refType,
+        ref_id: input.refId,
+        operator_id: input.operatorId,
+        moved_at: input.movedAt ?? new Date(),
+        notes: input.notes,
+      },
+    });
+  }
+}

--- a/server/src/modules/warehouse/services/inventory-movement-ledger.service.ts
+++ b/server/src/modules/warehouse/services/inventory-movement-ledger.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 
 export type InventoryMovementType =
@@ -28,8 +29,12 @@ interface RecordMaterialBatchMovementInput {
 export class InventoryMovementLedgerService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async recordMaterialBatchMovement(input: RecordMaterialBatchMovementInput) {
-    return this.prisma.inventoryMovement.create({
+  async recordMaterialBatchMovement(
+    input: RecordMaterialBatchMovementInput,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+    return client.inventoryMovement.create({
       data: {
         company_id: input.companyId ?? 1,
         movement_type: input.movementType,

--- a/server/src/modules/warehouse/services/return.service.spec.ts
+++ b/server/src/modules/warehouse/services/return.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ReturnService } from './return.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { InventoryMovementLedgerService } from './inventory-movement-ledger.service';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('ReturnService', () => {
@@ -34,6 +35,10 @@ describe('ReturnService', () => {
             },
             $transaction: jest.fn((callback) => callback(prisma)),
           },
+        },
+        {
+          provide: InventoryMovementLedgerService,
+          useValue: { recordMaterialBatchMovement: jest.fn() },
         },
       ],
     }).compile();
@@ -152,7 +157,7 @@ describe('ReturnService', () => {
 
       jest.spyOn(prisma.materialReturn, 'findUnique').mockResolvedValue(mockReturn as any);
       jest.spyOn(prisma.stagingAreaStock, 'findFirst').mockResolvedValue(mockStagingStock as any);
-      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
         return callback(prisma);
       });
       jest.spyOn(prisma.stagingAreaStock, 'update').mockResolvedValue({} as any);

--- a/server/src/modules/warehouse/services/return.service.spec.ts
+++ b/server/src/modules/warehouse/services/return.service.spec.ts
@@ -7,6 +7,7 @@ import { NotFoundException, BadRequestException } from '@nestjs/common';
 describe('ReturnService', () => {
   let service: ReturnService;
   let prisma: PrismaService;
+  let inventoryMovementLedger: InventoryMovementLedgerService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -45,6 +46,7 @@ describe('ReturnService', () => {
 
     service = module.get<ReturnService>(ReturnService);
     prisma = module.get<PrismaService>(PrismaService);
+    inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
   });
 
   describe('create', () => {
@@ -157,21 +159,27 @@ describe('ReturnService', () => {
 
       jest.spyOn(prisma.materialReturn, 'findUnique').mockResolvedValue(mockReturn as any);
       jest.spyOn(prisma.stagingAreaStock, 'findFirst').mockResolvedValue(mockStagingStock as any);
+      jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
+
+      const txClient = {
+        stagingAreaStock: { findFirst: jest.fn().mockResolvedValue(mockStagingStock), update: jest.fn().mockResolvedValue({}) },
+        materialBatch: { update: jest.fn().mockResolvedValue({}) },
+        stockRecord: { create: jest.fn().mockResolvedValue({}) },
+        materialReturn: { update: jest.fn().mockResolvedValue({ ...mockReturn, status: 'completed' }) },
+      };
+
       jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-        return callback(prisma);
+        return callback(txClient);
       });
-      jest.spyOn(prisma.stagingAreaStock, 'update').mockResolvedValue({} as any);
-      jest.spyOn(prisma.materialBatch, 'update').mockResolvedValue({} as any);
-      jest.spyOn(prisma.stockRecord, 'create').mockResolvedValue({} as any);
-      jest.spyOn(prisma.materialReturn, 'update').mockResolvedValue({
-        ...mockReturn,
-        status: 'completed',
-      } as any);
 
       const result = await service.complete('return-1');
 
       expect(result.status).toBe('completed');
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ movementType: 'return_to_warehouse', batchId: 'batch-1' }),
+        txClient,
+      );
     });
 
     it('should throw BadRequestException if staging stock insufficient', async () => {

--- a/server/src/modules/warehouse/services/return.service.ts
+++ b/server/src/modules/warehouse/services/return.service.ts
@@ -10,7 +10,7 @@ export class ReturnService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
-    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(dto: CreateReturnDto) {
@@ -179,8 +179,8 @@ export class ReturnService {
           },
         });
 
-        if (this.inventoryMovementLedger) {
-          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+        await this.inventoryMovementLedger.recordMaterialBatchMovement(
+          {
             movementType: 'return_to_warehouse',
             batchId: item.materialBatchId,
             quantity: item.quantity,
@@ -190,8 +190,9 @@ export class ReturnService {
             operatorId: materialReturn.requesterId,
             movedAt: new Date(),
             notes: '退料回仓',
-          });
-        }
+          },
+          tx,
+        );
       }
 
       // Update return status

--- a/server/src/modules/warehouse/services/return.service.ts
+++ b/server/src/modules/warehouse/services/return.service.ts
@@ -1,6 +1,8 @@
 import { Injectable, NotFoundException, BadRequestException, Optional } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ApprovalEngineService } from '../../unified-approval/approval-engine.service';
+import { InventoryMovementLedgerService } from './inventory-movement-ledger.service';
+import { Prisma } from '@prisma/client';
 import { CreateReturnDto, ApproveReturnDto } from '../dto/return.dto';
 
 @Injectable()
@@ -8,6 +10,7 @@ export class ReturnService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
+    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(dto: CreateReturnDto) {
@@ -141,7 +144,7 @@ export class ReturnService {
     }
 
     // Transaction: StagingAreaStock ↓ + MaterialBatch ↑ + StockRecord (type: return)
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of materialReturn.items) {
         // Decrement staging area stock
         const stagingStock = await tx.stagingAreaStock.findFirst({
@@ -175,6 +178,20 @@ export class ReturnService {
             remark: `退料单: ${materialReturn.returnNo}`,
           },
         });
+
+        if (this.inventoryMovementLedger) {
+          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+            movementType: 'return_to_warehouse',
+            batchId: item.materialBatchId,
+            quantity: item.quantity,
+            unit: 'kg',
+            refType: 'return',
+            refId: materialReturn.id,
+            operatorId: materialReturn.requesterId,
+            movedAt: new Date(),
+            notes: '退料回仓',
+          });
+        }
       }
 
       // Update return status

--- a/server/src/modules/warehouse/services/scrap.service.spec.ts
+++ b/server/src/modules/warehouse/services/scrap.service.spec.ts
@@ -7,6 +7,7 @@ import { NotFoundException, BadRequestException } from '@nestjs/common';
 describe('ScrapService', () => {
   let service: ScrapService;
   let prisma: PrismaService;
+  let inventoryMovementLedger: InventoryMovementLedgerService;
 
   const mockPrismaService = {
     materialScrap: {
@@ -47,6 +48,7 @@ describe('ScrapService', () => {
 
     service = module.get<ScrapService>(ScrapService);
     prisma = module.get<PrismaService>(PrismaService);
+    inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
   });
 
   afterEach(() => {
@@ -136,27 +138,32 @@ describe('ScrapService', () => {
         ],
       };
 
+      const txClient = {
+        stagingAreaStock: {
+          findFirst: jest.fn().mockResolvedValue({ id: 's1', quantity: 50 }),
+          update: jest.fn().mockResolvedValue({}),
+        },
+        materialBatch: { update: jest.fn().mockResolvedValue({}) },
+        stockRecord: { create: jest.fn().mockResolvedValue({}) },
+        materialScrap: { update: jest.fn().mockResolvedValue({ ...mockScrap, status: 'completed' }) },
+      };
+
       prisma.materialScrap.findUnique = jest.fn().mockResolvedValue(mockScrap);
-      prisma.$transaction = jest.fn(async (cb: any) => cb(prisma)) as any;
-      prisma.stagingAreaStock.findFirst = jest.fn().mockResolvedValue({
-        id: 's1',
-        quantity: 50,
-      });
-      prisma.stagingAreaStock.update = jest.fn();
-      prisma.materialBatch.update = jest.fn();
-      prisma.stockRecord.create = jest.fn();
-      prisma.materialScrap.update = jest.fn().mockResolvedValue({
-        ...mockScrap,
-        status: 'completed',
-      });
+      prisma.stagingAreaStock.findFirst = jest.fn().mockResolvedValue({ id: 's1', quantity: 50 });
+      prisma.$transaction = jest.fn(async (cb: any) => cb(txClient)) as any;
+      jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
 
       const result = await service.complete('scrap-1');
 
       expect(result.status).toBe('completed');
-      expect(prisma.materialBatch.update).toHaveBeenCalledWith({
+      expect(txClient.materialBatch.update).toHaveBeenCalledWith({
         where: { id: 'batch-1' },
         data: { quantity: { decrement: 10 } },
       });
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ movementType: 'scrap', batchId: 'batch-1' }),
+        txClient,
+      );
     });
 
     it('should throw NotFoundException if not found', async () => {
@@ -190,10 +197,11 @@ describe('ScrapService', () => {
       };
 
       prisma.materialScrap.findUnique = jest.fn().mockResolvedValue(mockScrap);
-      prisma.$transaction = jest.fn(async (cb: any) => cb(prisma)) as any;
-      prisma.stagingAreaStock.findFirst = jest.fn().mockResolvedValue({
-        quantity: 50,
-      });
+      prisma.$transaction = jest.fn(async (cb: any) =>
+        cb({
+          stagingAreaStock: { findFirst: jest.fn().mockResolvedValue({ quantity: 50 }) },
+        }),
+      ) as any;
 
       await expect(service.complete('scrap-1')).rejects.toThrow(
         BadRequestException,
@@ -222,25 +230,33 @@ describe('ScrapService', () => {
         quantity: 20,
       };
 
+      const txClient2 = {
+        stagingAreaStock: {
+          findFirst: jest.fn().mockResolvedValue(mockStagingStock),
+          update: jest.fn().mockResolvedValue({}),
+        },
+        materialBatch: { update: jest.fn().mockResolvedValue({}) },
+        stockRecord: { create: jest.fn().mockResolvedValue({}) },
+        materialScrap: { update: jest.fn().mockResolvedValue({ ...mockScrap, status: 'completed' }) },
+      };
+
       jest.spyOn(prisma.materialScrap, 'findUnique').mockResolvedValue(mockScrap as any);
       jest.spyOn(prisma.stagingAreaStock, 'findFirst').mockResolvedValue(mockStagingStock as any);
+      jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
       jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
-        return callback(prisma);
+        return callback(txClient2);
       });
-      jest.spyOn(prisma.stagingAreaStock, 'update').mockResolvedValue({} as any);
-      jest.spyOn(prisma.materialBatch, 'update').mockResolvedValue({} as any);
-      jest.spyOn(prisma.stockRecord, 'create').mockResolvedValue({} as any);
-      jest.spyOn(prisma.materialScrap, 'update').mockResolvedValue({
-        ...mockScrap,
-        status: 'completed',
-      } as any);
 
       await service.complete('scrap-1');
 
-      expect(prisma.materialBatch.update).toHaveBeenCalledWith({
+      expect(txClient2.materialBatch.update).toHaveBeenCalledWith({
         where: { id: 'batch-1' },
         data: { quantity: { decrement: 10 } },
       });
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
+        expect.objectContaining({ movementType: 'scrap', batchId: 'batch-1' }),
+        txClient2,
+      );
     });
   });
 

--- a/server/src/modules/warehouse/services/scrap.service.spec.ts
+++ b/server/src/modules/warehouse/services/scrap.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ScrapService } from './scrap.service';
 import { PrismaService } from '../../../prisma/prisma.service';
+import { InventoryMovementLedgerService } from './inventory-movement-ledger.service';
 import { NotFoundException, BadRequestException } from '@nestjs/common';
 
 describe('ScrapService', () => {
@@ -36,6 +37,10 @@ describe('ScrapService', () => {
         {
           provide: PrismaService,
           useValue: mockPrismaService,
+        },
+        {
+          provide: InventoryMovementLedgerService,
+          useValue: { recordMaterialBatchMovement: jest.fn() },
         },
       ],
     }).compile();
@@ -219,7 +224,7 @@ describe('ScrapService', () => {
 
       jest.spyOn(prisma.materialScrap, 'findUnique').mockResolvedValue(mockScrap as any);
       jest.spyOn(prisma.stagingAreaStock, 'findFirst').mockResolvedValue(mockStagingStock as any);
-      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
         return callback(prisma);
       });
       jest.spyOn(prisma.stagingAreaStock, 'update').mockResolvedValue({} as any);

--- a/server/src/modules/warehouse/services/scrap.service.ts
+++ b/server/src/modules/warehouse/services/scrap.service.ts
@@ -15,7 +15,7 @@ export class ScrapService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
-    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(dto: CreateScrapDto) {
@@ -180,8 +180,8 @@ export class ScrapService {
           },
         });
 
-        if (this.inventoryMovementLedger) {
-          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+        await this.inventoryMovementLedger.recordMaterialBatchMovement(
+          {
             movementType: 'scrap',
             batchId: item.materialBatchId,
             quantity: item.quantity,
@@ -191,8 +191,9 @@ export class ScrapService {
             operatorId: materialScrap.requesterId,
             movedAt: new Date(),
             notes: '物料报废',
-          });
-        }
+          },
+          tx,
+        );
       }
 
       return tx.materialScrap.update({

--- a/server/src/modules/warehouse/services/scrap.service.ts
+++ b/server/src/modules/warehouse/services/scrap.service.ts
@@ -6,6 +6,8 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { ApprovalEngineService } from '../../unified-approval/approval-engine.service';
+import { InventoryMovementLedgerService } from './inventory-movement-ledger.service';
+import { Prisma } from '@prisma/client';
 import { CreateScrapDto, ApproveScrapDto } from '../dto/scrap.dto';
 
 @Injectable()
@@ -13,6 +15,7 @@ export class ScrapService {
   constructor(
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
+    @Optional() private readonly inventoryMovementLedger: InventoryMovementLedgerService,
   ) {}
 
   async create(dto: CreateScrapDto) {
@@ -144,7 +147,7 @@ export class ScrapService {
       }
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of materialScrap.items) {
         const stagingStock = await tx.stagingAreaStock.findFirst({
           where: { batchId: item.materialBatchId },
@@ -176,6 +179,20 @@ export class ScrapService {
             remark: `报废单: ${materialScrap.scrapNo}`,
           },
         });
+
+        if (this.inventoryMovementLedger) {
+          await this.inventoryMovementLedger.recordMaterialBatchMovement({
+            movementType: 'scrap',
+            batchId: item.materialBatchId,
+            quantity: item.quantity,
+            unit: 'kg',
+            refType: 'scrap',
+            refId: materialScrap.id,
+            operatorId: materialScrap.requesterId,
+            movedAt: new Date(),
+            notes: '物料报废',
+          });
+        }
       }
 
       return tx.materialScrap.update({

--- a/server/src/modules/warehouse/warehouse.module.ts
+++ b/server/src/modules/warehouse/warehouse.module.ts
@@ -28,12 +28,13 @@ import { ScrapController } from './controllers/scrap.controller';
 import { ScrapService } from './services/scrap.service';
 import { WarehouseTraceabilityController } from './traceability.controller';
 import { WarehouseCronService } from './warehouse-cron.service';
+import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
 
 @Module({
   imports: [PrismaModule, BatchTraceModule, NotificationModule, UnifiedApprovalModule, DocumentModule, UserPermissionModule],
   controllers: [MaterialController, SupplierController, InboundController, BatchController, RequisitionController, StagingAreaController, MaterialBalanceController, ReturnController, ScrapController, WarehouseTraceabilityController],
-  providers: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, WarehouseCronService, StorageService, PermissionGuard],
-  exports: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService],
+  providers: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, WarehouseCronService, StorageService, PermissionGuard, InventoryMovementLedgerService],
+  exports: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, InventoryMovementLedgerService],
 })
 export class WarehouseModule implements OnModuleInit {
   constructor(private readonly callbacks: ApprovalCallbackRegistry) {}


### PR DESCRIPTION
## Summary

- Adds `InventoryMovementLedgerService` that writes to `inventoryMovement` table
- Wires dual-write into inbound (receive), requisition (issue_to_production), return (return_to_warehouse), and scrap services after existing `stockRecord.create`
- All 4 services preserve existing `StockRecord` writes (backward-compatible)
- Also fixes pre-existing `noImplicitAny` TypeScript errors (`tx` parameter in `$transaction` callbacks) in affected warehouse services and spec files

## References

- Issue: MYL-33 (fa1113c9-ab82-4c64-af2d-05aa9dd2c6b1)
- GAP: GAP-102
- Plan: docs/superpowers/plans/2026-05-01-gap-102-inventory-movement-ledger-unification-implementation.md

## Test plan

- [x] `InventoryMovementLedgerService` unit test passes
- [x] `InboundService` tests pass (39 tests total across 5 suites)
- [x] `RequisitionService` tests pass
- [x] `ReturnService` tests pass
- [x] `ScrapService` tests pass
- [x] No DI or compile errors related to `InventoryMovementLedgerService`
- [x] No schema/migration changes (uses existing `inventoryMovement` table)