### PR TITLE
test: lock production batch product snapshot source [GAP-007]

### DIFF
--- a/server/src/modules/batch-trace/services/production-batch.service.spec.ts
+++ b/server/src/modules/batch-trace/services/production-batch.service.spec.ts
@@ -88,7 +88,8 @@ describe('ProductionBatchService', () => {
         recipeId: 'r1',
         plannedQuantity: 100,
         productionDate: new Date('2026-04-29T00:00:00.000Z'),
-      });
+        productName: '前端伪造产品名',
+      } as any);
 
       expect(mockPrisma.productionBatch.create).toHaveBeenCalledWith({
         data: {
@@ -248,7 +249,10 @@ describe('ProductionBatchService', () => {
       };
       mockPrisma.productionBatch.create.mockResolvedValue(mockBatch);
 
-      const result = await service.confirmProductBatch(validDto);
+      const result = await service.confirmProductBatch({
+        ...validDto,
+        productName: '包装端伪造产品名',
+      } as any);
 
       expect(result).toEqual(mockBatch);
       expect(mockPrisma.product.findFirst).toHaveBeenCalledWith({

--- a/server/src/modules/batch-trace/services/production-batch.service.ts
+++ b/server/src/modules/batch-trace/services/production-batch.service.ts
@@ -39,6 +39,7 @@ export class ProductionBatchService {
         batchNumber,
         productId: product.id,
         recipeId: recipe.id,
+        // GAP-007: productName is a historical snapshot from Product, never caller input.
         productName: product.name,
         recipeName: `v${recipe.version}`,
         plannedQuantity: createDto.plannedQuantity,
@@ -147,6 +148,7 @@ export class ProductionBatchService {
         data: {
           batchNumber: dto.batchNumber,
           productId: dto.productId,
+          // GAP-007: productName is a historical snapshot from Product, never caller input.
           productName: product.name,
           recipeId: dto.recipeId,
           recipeName: recipe.version_note ?? `v${recipe.version}`,


### PR DESCRIPTION
## Summary

- Adds hostile-input regression tests to `production-batch.service.spec.ts` proving that `ProductionBatch.productName` is always written from `Product.name`, even when a caller passes an extra `productName` field at runtime
- Covers both `create()` and `confirmProductBatch()` snapshot write paths
- Adds `// GAP-007:` guard comments at both write points in `production-batch.service.ts`

## Related

- Issue: fc05b643-9da9-45c3-b463-fee825d6d43f (MYL-32)
- GAP: GAP-007
- Plan: `docs/superpowers/plans/2026-05-01-gap-007-production-batch-product-snapshot-implementation.md`

## Test plan

- [x] `npm run test --workspace server -- production-batch.service --runInBand` → 13 passed, 0 failed
- [x] `git diff --check` → no whitespace errors