### PR TITLE
fix: align batch status filter with backend BatchStatus enum (GAP-108)

### DIFF
--- a/client/src/api/warehouse.ts
+++ b/client/src/api/warehouse.ts
@@ -27,7 +27,7 @@ export interface MaterialBatch {
   quantity: number;
   expiryDate?: string;
   supplierId?: string;
-  status: 'available' | 'reserved' | 'consumed' | 'expired';
+  status: 'normal' | 'expired' | 'locked';
   receivedAt: string;
   material?: Material;
   supplier?: Supplier;

--- a/client/src/views/warehouse/BatchManagement.vue
+++ b/client/src/views/warehouse/BatchManagement.vue
@@ -4,10 +4,9 @@
       <el-form :model="filterForm" inline>
         <el-form-item label="状态">
           <el-select v-model="filterForm.status" clearable placeholder="全部">
-            <el-option value="available" label="可用" />
-            <el-option value="reserved" label="已预留" />
-            <el-option value="consumed" label="已消耗" />
+            <el-option value="normal" label="正常" />
             <el-option value="expired" label="已过期" />
+            <el-option value="locked" label="已锁定" />
           </el-select>
         </el-form-item>
         <el-form-item>
@@ -74,8 +73,8 @@ const tableData = ref<any[]>([]);
 const filterForm = reactive({ status: '' });
 const pagination = reactive({ page: 1, limit: 20, total: 0 });
 
-const batchStatusText = (s: string) => ({ available: '可用', reserved: '已预留', consumed: '已消耗', expired: '已过期' }[s] || s);
-const batchStatusType = (s: string) => ({ available: 'success', reserved: 'warning', consumed: 'info', expired: 'danger' }[s] || 'info');
+const batchStatusText = (s: string) => ({ normal: '正常', expired: '已过期', locked: '已锁定' }[s] || s);
+const batchStatusType = (s: string) => ({ normal: 'success', expired: 'danger', locked: 'warning' }[s] || 'info');
 
 const fetchData = async () => {
   loading.value = true;

--- a/client/src/views/warehouse/__tests__/BatchManagement.spec.ts
+++ b/client/src/views/warehouse/__tests__/BatchManagement.spec.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import BatchManagement from '../BatchManagement.vue';
+
+vi.mock('@/api/warehouse', () => ({
+  batchApi: {
+    getList: vi.fn().mockResolvedValue({ list: [], total: 0 }),
+  },
+}));
+
+const stubs = {
+  'el-card': { template: '<div><slot /><slot name="header" /></div>' },
+  'el-form': { template: '<form><slot /></form>' },
+  'el-form-item': { template: '<div><slot /></div>' },
+  'el-select': { template: '<select><slot /></select>', props: ['modelValue'] },
+  'el-option': { template: '<option :value="value">{{ label }}</option>', props: ['value', 'label'] },
+  'el-button': { template: '<button><slot /></button>' },
+  'el-table': { template: '<table><slot /></table>', props: ['data', 'loading', 'stripe'] },
+  'el-table-column': { template: '<td></td>', props: ['prop', 'label', 'width', 'minWidth'] },
+  'el-tag': { template: '<span><slot /></span>', props: ['type', 'size'] },
+  'el-pagination': { template: '<nav />' },
+};
+
+describe('BatchManagement', () => {
+  it('uses backend BatchStatus enum values in the status filter', () => {
+    const wrapper = mount(BatchManagement, { global: { stubs } });
+
+    const optionValues = wrapper.findAll('option').map((option) => option.attributes('value'));
+
+    expect(optionValues).toEqual(['normal', 'expired', 'locked']);
+    expect(optionValues).not.toContain('available');
+    expect(optionValues).not.toContain('reserved');
+    expect(optionValues).not.toContain('consumed');
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces stale frontend batch status values (`available`, `reserved`, `consumed`, `expired`) with the actual backend `BatchStatus` enum: `normal`, `expired`, `locked`
- Updates `MaterialBatch.status` type in `client/src/api/warehouse.ts`
- Replaces filter `<el-option>` elements and display mappers in `BatchManagement.vue`
- Adds a focused Vitest component test that asserts only backend enum values appear as filter options

Closes issue MYL-38 | Implementation plan: `docs/superpowers/plans/2026-05-01-gap-108-batch-status-enum-sync-implementation.md` | GAP-108

## Test plan

- [x] `vitest run BatchManagement` passes (1 test, GREEN)
- [x] `vue-tsc --noEmit` exits 0 (no new type errors)
- [ ] Manual smoke-test: open Batch Management page, verify status filter shows 正常/已过期/已锁定