### PR TITLE
fix(GAP-106): prevent negative material batch stock on requisition completion

### DIFF
--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -27,6 +27,7 @@ describe('RequisitionService', () => {
               createMany: jest.fn(),
             },
             materialBatch: {
+              findUnique: jest.fn(),
               update: jest.fn(),
             },
             stagingAreaStock: {
@@ -116,6 +117,43 @@ describe('RequisitionService', () => {
   });
 
   describe('complete', () => {
+    it('should reject completion when requested quantity exceeds batch stock', async () => {
+      const mockRequisition = {
+        id: 'req-001',
+        status: 'approved',
+        items: [
+          {
+            batchId: 'batch-001',
+            quantity: 50,
+          },
+        ],
+      };
+
+      jest.spyOn(prisma.materialRequisition, 'findUnique').mockResolvedValue(mockRequisition as any);
+
+      const txClient = {
+        materialBatch: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'batch-001',
+            batchNumber: 'MB-001',
+            quantity: 10,
+          }),
+          update: jest.fn(),
+        },
+        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
+        stockRecord: { create: jest.fn() },
+        materialRequisition: { update: jest.fn() },
+        materialRequisitionItem: { findMany: jest.fn().mockResolvedValue(mockRequisition.items) },
+      };
+
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      await expect(service.complete('req-001', 'user-001')).rejects.toThrow(BadRequestException);
+      expect(txClient.materialBatch.update).not.toHaveBeenCalled();
+      expect(txClient.stockRecord.create).not.toHaveBeenCalled();
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).not.toHaveBeenCalled();
+    });
+
     it('should complete requisition and update inventory', async () => {
       const mockRequisition = {
         id: 'req-001',
@@ -132,7 +170,14 @@ describe('RequisitionService', () => {
       jest.spyOn(inventoryMovementLedger, 'recordMaterialBatchMovement').mockResolvedValue({} as any);
 
       const txClient = {
-        materialBatch: { update: jest.fn() },
+        materialBatch: {
+          findUnique: jest.fn().mockResolvedValue({
+            id: 'batch-001',
+            batchNumber: 'MB-001',
+            quantity: 100,
+          }),
+          update: jest.fn(),
+        },
         stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
         stockRecord: { create: jest.fn() },
         materialRequisition: { update: jest.fn().mockResolvedValue({ ...mockRequisition, status: 'completed' }) },

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -28,7 +28,7 @@ describe('RequisitionService', () => {
             },
             materialBatch: {
               findUnique: jest.fn(),
-              update: jest.fn(),
+              updateMany: jest.fn(),
             },
             stagingAreaStock: {
               upsert: jest.fn(),
@@ -117,28 +117,19 @@ describe('RequisitionService', () => {
   });
 
   describe('complete', () => {
-    it('should reject completion when requested quantity exceeds batch stock', async () => {
+    it('should reject completion when requested quantity exceeds batch stock (atomic updateMany returns count=0)', async () => {
       const mockRequisition = {
         id: 'req-001',
         status: 'approved',
-        items: [
-          {
-            batchId: 'batch-001',
-            quantity: 50,
-          },
-        ],
+        items: [{ batchId: 'batch-001', quantity: 50 }],
       };
 
       jest.spyOn(prisma.materialRequisition, 'findUnique').mockResolvedValue(mockRequisition as any);
 
       const txClient = {
         materialBatch: {
-          findUnique: jest.fn().mockResolvedValue({
-            id: 'batch-001',
-            batchNumber: 'MB-001',
-            quantity: 10,
-          }),
-          update: jest.fn(),
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          findUnique: jest.fn().mockResolvedValue({ batchNumber: 'MB-001' }),
         },
         stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
         stockRecord: { create: jest.fn() },
@@ -149,7 +140,35 @@ describe('RequisitionService', () => {
       jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
 
       await expect(service.complete('req-001', 'user-001')).rejects.toThrow(BadRequestException);
-      expect(txClient.materialBatch.update).not.toHaveBeenCalled();
+      expect(txClient.stockRecord.create).not.toHaveBeenCalled();
+      expect(txClient.stagingAreaStock.create).not.toHaveBeenCalled();
+      expect(txClient.stagingAreaStock.update).not.toHaveBeenCalled();
+      expect(inventoryMovementLedger.recordMaterialBatchMovement).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException and stop side effects when batch does not exist (updateMany count=0, findUnique null)', async () => {
+      const mockRequisition = {
+        id: 'req-001',
+        status: 'approved',
+        items: [{ batchId: 'batch-nonexistent', quantity: 10 }],
+      };
+
+      jest.spyOn(prisma.materialRequisition, 'findUnique').mockResolvedValue(mockRequisition as any);
+
+      const txClient = {
+        materialBatch: {
+          updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+          findUnique: jest.fn().mockResolvedValue(null),
+        },
+        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
+        stockRecord: { create: jest.fn() },
+        materialRequisition: { update: jest.fn() },
+        materialRequisitionItem: { findMany: jest.fn().mockResolvedValue(mockRequisition.items) },
+      };
+
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      await expect(service.complete('req-001', 'user-001')).rejects.toThrow(BadRequestException);
       expect(txClient.stockRecord.create).not.toHaveBeenCalled();
       expect(inventoryMovementLedger.recordMaterialBatchMovement).not.toHaveBeenCalled();
     });
@@ -171,14 +190,10 @@ describe('RequisitionService', () => {
 
       const txClient = {
         materialBatch: {
-          findUnique: jest.fn().mockResolvedValue({
-            id: 'batch-001',
-            batchNumber: 'MB-001',
-            quantity: 100,
-          }),
-          update: jest.fn(),
+          updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+          findUnique: jest.fn(),
         },
-        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
+        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn().mockResolvedValue(null), update: jest.fn(), create: jest.fn() },
         stockRecord: { create: jest.fn() },
         materialRequisition: { update: jest.fn().mockResolvedValue({ ...mockRequisition, status: 'completed' }) },
         materialRequisitionItem: { findMany: jest.fn().mockResolvedValue(mockRequisition.items) },

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -42,6 +42,15 @@ export class RequisitionService {
     });
   }
 
+  private toNumber(value: unknown): number {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string') return Number(value);
+    if (value && typeof (value as { toNumber?: () => number }).toNumber === 'function') {
+      return (value as { toNumber: () => number }).toNumber();
+    }
+    return Number(value);
+  }
+
   private generateRequisitionNo(): string {
     const today = dayjs().format('YYYYMMDD');
     const seq = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
@@ -139,6 +148,21 @@ export class RequisitionService {
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of requisition.items) {
+        const batch = await tx.materialBatch.findUnique({
+          where: { id: item.batchId },
+          select: { id: true, batchNumber: true, quantity: true },
+        });
+
+        if (!batch) {
+          throw new BadRequestException(`物料批次不存在：${item.batchId}`);
+        }
+
+        const availableQty = this.toNumber(batch.quantity);
+        const requestedQty = this.toNumber(item.quantity);
+        if (availableQty < requestedQty) {
+          throw new BadRequestException(`物料批次库存不足：${batch.batchNumber ?? item.batchId}`);
+        }
+
         await tx.materialBatch.update({
           where: { id: item.batchId },
           data: { quantity: { decrement: item.quantity } },

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -148,25 +148,22 @@ export class RequisitionService {
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of requisition.items) {
-        const batch = await tx.materialBatch.findUnique({
-          where: { id: item.batchId },
-          select: { id: true, batchNumber: true, quantity: true },
+        const requestedQty = this.toNumber(item.quantity);
+        const { count } = await tx.materialBatch.updateMany({
+          where: { id: item.batchId, quantity: { gte: requestedQty } },
+          data: { quantity: { decrement: requestedQty } },
         });
 
-        if (!batch) {
-          throw new BadRequestException(`物料批次不存在：${item.batchId}`);
-        }
-
-        const availableQty = this.toNumber(batch.quantity);
-        const requestedQty = this.toNumber(item.quantity);
-        if (availableQty < requestedQty) {
+        if (count === 0) {
+          const batch = await tx.materialBatch.findUnique({
+            where: { id: item.batchId },
+            select: { batchNumber: true },
+          });
+          if (!batch) {
+            throw new BadRequestException(`物料批次不存在：${item.batchId}`);
+          }
           throw new BadRequestException(`物料批次库存不足：${batch.batchNumber ?? item.batchId}`);
         }
-
-        await tx.materialBatch.update({
-          where: { id: item.batchId },
-          data: { quantity: { decrement: item.quantity } },
-        });
 
         const existingStock = await tx.stagingAreaStock.findFirst({
           where: {


### PR DESCRIPTION
## Summary

- Add transaction-local stock check in `RequisitionService.complete()` before decrement
- Throw `BadRequestException` when requested quantity exceeds available batch stock
- Add `toNumber()` helper to handle Prisma `Decimal` type values

## Related

- GAP: GAP-106
- Issue: MYL-36 (ca9407cb-3e56-43bb-af71-c8e26433e1c2)
- Plan: `docs/superpowers/plans/2026-05-01-gap-106-requisition-stock-nonnegative-implementation.md`

## Files Modified

- `server/src/modules/warehouse/requisition.service.ts`
- `server/src/modules/warehouse/requisition.service.spec.ts`

## Test Plan

- [x] Unit test: `should reject completion when requested quantity exceeds batch stock` — verifies `BadRequestException` thrown, no decrement/stockRecord/inventoryMovement called
- [x] Unit test: `should complete requisition and update inventory` — verifies happy path still works with sufficient stock (quantity 100 ≥ requested 50)
- [x] All 5 tests pass: `npm run test --workspace server -- requisition.service --runInBand`