### PR TITLE
fix(GAP-107): include returns and scraps in material balance

### DIFF
--- a/server/src/modules/warehouse/material-balance.service.spec.ts
+++ b/server/src/modules/warehouse/material-balance.service.spec.ts
@@ -69,6 +69,38 @@ describe('MaterialBalanceService', () => {
       expect(result.difference).toBe(0);
     });
 
+    it('includes return as inbound and scrap as outbound in balance calculation', async () => {
+      const prismaSimple = {
+        stockRecord: { findMany: jest.fn() },
+        batchMaterialUsage: { findMany: jest.fn() },
+        materialBatch: { findMany: jest.fn() },
+      };
+      const simpleService = new MaterialBalanceService(prismaSimple as any);
+      prismaSimple.stockRecord.findMany.mockResolvedValue([
+        { recordType: 'in', quantity: 100 },
+        { recordType: 'return', quantity: 10 },
+        { recordType: 'out', quantity: 20 },
+        { recordType: 'scrap', quantity: 5 },
+      ]);
+      prismaSimple.batchMaterialUsage.findMany.mockResolvedValue([
+        { quantity: 30 },
+      ]);
+      prismaSimple.materialBatch.findMany.mockResolvedValue([
+        { id: 'batch-1', quantity: 55 },
+      ]);
+
+      const result = await simpleService.checkBalance('batch-1');
+
+      expect(result.totalIn).toBe(110);
+      expect(result.totalOut).toBe(25);
+      expect(result.returnedToWarehouse).toBe(10);
+      expect(result.scrapped).toBe(5);
+      expect(result.usedInProduction).toBe(30);
+      expect(result.calculated).toBe(55);
+      expect(result.currentStock).toBe(55);
+      expect(result.isBalanced).toBe(true);
+    });
+
     it('should detect imbalance', async () => {
       const batchId = 'batch-1';
 

--- a/server/src/modules/warehouse/material-balance.service.ts
+++ b/server/src/modules/warehouse/material-balance.service.ts
@@ -5,6 +5,15 @@ import { PrismaService } from '../../prisma/prisma.service';
 export class MaterialBalanceService {
   constructor(private readonly prisma: PrismaService) {}
 
+  private toNumber(value: unknown): number {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string') return Number(value);
+    if (value && typeof (value as { toNumber?: () => number }).toNumber === 'function') {
+      return (value as { toNumber: () => number }).toNumber();
+    }
+    return Number(value);
+  }
+
   async checkBalance(batchId: string) {
     const [stockRecords, usages, batches] = await Promise.all([
       this.prisma.stockRecord.findMany({
@@ -18,18 +27,28 @@ export class MaterialBalanceService {
       }),
     ]);
 
-    const totalIn = stockRecords
+    const received = stockRecords
       .filter((r) => r.recordType === 'in')
-      .reduce((sum, r) => sum + r.quantity, 0);
+      .reduce((sum: number, r) => sum + this.toNumber(r.quantity), 0);
 
-    const totalOut = stockRecords
+    const returnedToWarehouse = stockRecords
+      .filter((r) => r.recordType === 'return')
+      .reduce((sum: number, r) => sum + this.toNumber(r.quantity), 0);
+
+    const issuedToProduction = stockRecords
       .filter((r) => r.recordType === 'out')
-      .reduce((sum, r) => sum + r.quantity, 0);
+      .reduce((sum: number, r) => sum + this.toNumber(r.quantity), 0);
 
-    const usedInProduction = usages.reduce((sum, u) => sum + u.quantity, 0);
+    const scrapped = stockRecords
+      .filter((r) => r.recordType === 'scrap')
+      .reduce((sum: number, r) => sum + this.toNumber(r.quantity), 0);
 
+    const totalIn = received + returnedToWarehouse;
+    const totalOut = issuedToProduction + scrapped;
+    const usedInProduction = usages.reduce((sum: number, u) => sum + this.toNumber(u.quantity), 0);
+
+    const currentStock = this.toNumber(batches[0]?.quantity ?? 0);
     const calculated = totalIn - totalOut - usedInProduction;
-    const currentStock = batches[0]?.quantity || 0;
     const difference = Math.abs(calculated - currentStock);
     const isBalanced = difference < 0.01;
 
@@ -42,6 +61,10 @@ export class MaterialBalanceService {
       currentStock,
       difference,
       isBalanced,
+      received,
+      returnedToWarehouse,
+      issuedToProduction,
+      scrapped,
     };
   }
 


### PR DESCRIPTION
## Summary

- Extends `MaterialBalanceService.checkBalance()` to classify `return` stock records as inbound and `scrap` records as outbound
- Adds `toNumber()` helper to safely handle Prisma Decimal/Float values
- Preserves all existing response fields; adds `received`, `returnedToWarehouse`, `issuedToProduction`, `scrapped`
- Also regenerated Prisma client to fix pre-existing `noImplicitAny` TS compilation errors

## References

- Issue: MYL-37 (c27a16b0-6882-4c26-9795-799ac1690537)
- GAP: GAP-107
- Plan: `docs/superpowers/plans/2026-05-01-gap-107-material-balance-scrap-return-implementation.md`

## Files Changed

- `server/src/modules/warehouse/material-balance.service.ts` — formula updated, `toNumber()` added, new fields in response
- `server/src/modules/warehouse/material-balance.service.spec.ts` — new test case for return+scrap balance

## Test Plan

- [x] `npm run test --workspace server -- --testPathPatterns="material-balance.service" --runInBand` → 4 passed
- [x] `npm run test --workspace server -- --testPathPatterns="material-balance.service|requisition.service|return.service|scrap.service" --runInBand` → 33 passed