### PR TITLE
fix(GAP-103): gate warehouse flows by supplier status

### DIFF
--- a/server/src/modules/warehouse/batch.fifo.spec.ts
+++ b/server/src/modules/warehouse/batch.fifo.spec.ts
@@ -14,6 +14,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { BatchService } from './batch.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 
 // ---------------------------------------------------------------------------
 // 辅助类型
@@ -97,6 +98,13 @@ describe('MaterialBatch FIFO 自动关联逻辑 (BR-307/308)', () => {
               update: jest.fn(),
               count: jest.fn(),
             },
+          },
+        },
+        {
+          provide: SupplierAccessService,
+          useValue: {
+            assertSupplierUsable: jest.fn(),
+            assertBatchSupplierUsable: jest.fn(),
           },
         },
       ],

--- a/server/src/modules/warehouse/batch.service.spec.ts
+++ b/server/src/modules/warehouse/batch.service.spec.ts
@@ -2,11 +2,13 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { BatchService } from './batch.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { SupplierAccessService } from './services/supplier-access.service';
 import * as dayjs from 'dayjs';
 
 describe('BatchService', () => {
   let service: BatchService;
   let prisma: PrismaService;
+  let supplierAccess: SupplierAccessService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -24,11 +26,18 @@ describe('BatchService', () => {
             },
           },
         },
+        {
+          provide: SupplierAccessService,
+          useValue: {
+            assertSupplierUsable: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<BatchService>(BatchService);
     prisma = module.get<PrismaService>(PrismaService);
+    supplierAccess = module.get<SupplierAccessService>(SupplierAccessService);
   });
 
   afterEach(() => {
@@ -62,6 +71,26 @@ describe('BatchService', () => {
 
       // Assert
       expect(result).toEqual(mockBatch);
+      expect(supplierAccess.assertSupplierUsable).toHaveBeenCalledWith('supplier-001', '创建物料批次');
+    });
+
+    it('should reject batch creation when supplier is not usable', async () => {
+      const createDto = {
+        batchNumber: 'BATCH-20260215-001',
+        materialId: 'material-001',
+        productionDate: new Date('2026-01-01'),
+        expiryDate: new Date('2026-07-01'),
+        quantity: 100,
+        supplierId: 'supplier-001',
+        supplierBatchNo: 'SUP-001',
+      };
+
+      jest
+        .spyOn(supplierAccess, 'assertSupplierUsable')
+        .mockRejectedValue(new BadRequestException('供应商已淘汰'));
+
+      await expect(service.create(createDto as any)).rejects.toThrow(BadRequestException);
+      expect(prisma.materialBatch.create).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException if batch number exists', async () => {

--- a/server/src/modules/warehouse/batch.service.ts
+++ b/server/src/modules/warehouse/batch.service.ts
@@ -7,14 +7,21 @@ import {
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateBatchDto, UpdateBatchDto, QueryBatchDto } from './dto/batch.dto';
+import { SupplierAccessService } from './services/supplier-access.service';
 
 @Injectable()
 export class BatchService {
   private readonly logger = new Logger(BatchService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly supplierAccess: SupplierAccessService,
+  ) {}
 
   async create(createBatchDto: CreateBatchDto) {
+    if (createBatchDto.supplierId) {
+      await this.supplierAccess.assertSupplierUsable(createBatchDto.supplierId, '创建物料批次');
+    }
     try {
       return await this.prisma.materialBatch.create({
         data: createBatchDto,

--- a/server/src/modules/warehouse/inbound.service.spec.ts
+++ b/server/src/modules/warehouse/inbound.service.spec.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { InboundService } from './inbound.service';
 import { BatchNumberGeneratorService } from '../batch-trace/services/batch-number-generator.service';
 import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import * as dayjs from 'dayjs';
 
@@ -11,6 +12,7 @@ describe('InboundService', () => {
   let prisma: PrismaService;
   let batchNumberGenerator: BatchNumberGeneratorService;
   let inventoryMovementLedger: InventoryMovementLedgerService;
+  let supplierAccess: SupplierAccessService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -48,6 +50,12 @@ describe('InboundService', () => {
           provide: InventoryMovementLedgerService,
           useValue: { recordMaterialBatchMovement: jest.fn() },
         },
+        {
+          provide: SupplierAccessService,
+          useValue: {
+            assertSupplierUsable: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -55,6 +63,7 @@ describe('InboundService', () => {
     prisma = module.get<PrismaService>(PrismaService);
     batchNumberGenerator = module.get<BatchNumberGeneratorService>(BatchNumberGeneratorService);
     inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
+    supplierAccess = module.get<SupplierAccessService>(SupplierAccessService);
   });
 
   afterEach(() => {
@@ -103,6 +112,30 @@ describe('InboundService', () => {
       // Assert
       expect(result.inboundNo).toContain('IN-');
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(supplierAccess.assertSupplierUsable).toHaveBeenCalledWith('supplier-001', '创建来料单');
+    });
+
+    it('should reject inbound creation when supplier is not usable', async () => {
+      const createDto = {
+        supplierId: 'supplier-001',
+        items: [
+          {
+            materialId: 'material-001',
+            quantity: 100,
+            supplierBatchNo: 'SUP-BATCH-001',
+            productionDate: new Date('2026-01-01'),
+            expiryDate: new Date('2026-07-01'),
+          },
+        ],
+        remark: '测试入库',
+      };
+
+      jest
+        .spyOn(supplierAccess, 'assertSupplierUsable')
+        .mockRejectedValue(new BadRequestException('供应商已淘汰'));
+
+      await expect(service.create(createDto)).rejects.toThrow(BadRequestException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/modules/warehouse/inbound.service.ts
+++ b/server/src/modules/warehouse/inbound.service.ts
@@ -9,6 +9,7 @@ import { BatchNumberGeneratorService } from '../batch-trace/services/batch-numbe
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
 import { CreateInboundDto, QueryInboundDto } from './dto/inbound.dto';
 import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 import { Prisma } from '@prisma/client';
 import * as dayjs from 'dayjs';
 
@@ -19,10 +20,12 @@ export class InboundService {
     private readonly batchNumberGenerator: BatchNumberGeneratorService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
     private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly supplierAccess: SupplierAccessService,
   ) {}
 
   async create(createInboundDto: CreateInboundDto, createdById?: string) {
     const { supplierId, items, remark } = createInboundDto;
+    await this.supplierAccess.assertSupplierUsable(supplierId, '创建来料单');
     const inboundNo = await this.generateInboundNo();
 
     const inbound = await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -2,12 +2,14 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { RequisitionService } from './requisition.service';
 import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
 describe('RequisitionService', () => {
   let service: RequisitionService;
   let prisma: PrismaService;
   let inventoryMovementLedger: InventoryMovementLedgerService;
+  let supplierAccess: SupplierAccessService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -46,12 +48,19 @@ describe('RequisitionService', () => {
           provide: InventoryMovementLedgerService,
           useValue: { recordMaterialBatchMovement: jest.fn() },
         },
+        {
+          provide: SupplierAccessService,
+          useValue: {
+            assertBatchSupplierUsable: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<RequisitionService>(RequisitionService);
     prisma = module.get<PrismaService>(PrismaService);
     inventoryMovementLedger = module.get<InventoryMovementLedgerService>(InventoryMovementLedgerService);
+    supplierAccess = module.get<SupplierAccessService>(SupplierAccessService);
   });
 
   afterEach(() => {
@@ -206,10 +215,44 @@ describe('RequisitionService', () => {
       await service.complete('req-001', 'user-001');
 
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(supplierAccess.assertBatchSupplierUsable).toHaveBeenCalledWith('batch-001', '完成领料');
       expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
         expect.objectContaining({ movementType: 'issue_to_production', batchId: 'batch-001' }),
         txClient,
       );
+    });
+
+    it('should reject requisition completion when batch supplier is not usable', async () => {
+      const mockRequisition = {
+        id: 'req-001',
+        status: 'approved',
+        items: [
+          {
+            batchId: 'batch-001',
+            quantity: 50,
+          },
+        ],
+      };
+
+      jest.spyOn(prisma.materialRequisition, 'findUnique').mockResolvedValue(mockRequisition as any);
+      jest
+        .spyOn(supplierAccess, 'assertBatchSupplierUsable')
+        .mockRejectedValue(new BadRequestException('供应商已淘汰'));
+
+      const txClient = {
+        materialBatch: { update: jest.fn() },
+        stagingAreaStock: { upsert: jest.fn(), findFirst: jest.fn(), update: jest.fn(), create: jest.fn() },
+        stockRecord: { create: jest.fn() },
+        materialRequisition: { update: jest.fn() },
+        materialRequisitionItem: { findMany: jest.fn().mockResolvedValue(mockRequisition.items) },
+      };
+
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => {
+        return callback(txClient);
+      });
+
+      await expect(service.complete('req-001', 'user-001')).rejects.toThrow(BadRequestException);
+      expect(txClient.materialBatch.update).not.toHaveBeenCalled();
     });
 
     it('should throw BadRequestException if not approved', async () => {

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException, BadRequestException, Optional } from '@n
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
 import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 import { Prisma } from '@prisma/client';
 import * as dayjs from 'dayjs';
 
@@ -11,6 +12,7 @@ export class RequisitionService {
     private readonly prisma: PrismaService,
     @Optional() private readonly approvalEngine: ApprovalEngineService,
     private readonly inventoryMovementLedger: InventoryMovementLedgerService,
+    private readonly supplierAccess: SupplierAccessService,
   ) {}
 
   async create(createDto: any) {
@@ -148,6 +150,7 @@ export class RequisitionService {
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       for (const item of requisition.items) {
+        await this.supplierAccess.assertBatchSupplierUsable(item.batchId, '完成领料');
         const requestedQty = this.toNumber(item.quantity);
         const { count } = await tx.materialBatch.updateMany({
           where: { id: item.batchId, quantity: { gte: requestedQty } },

--- a/server/src/modules/warehouse/services/supplier-access.service.spec.ts
+++ b/server/src/modules/warehouse/services/supplier-access.service.spec.ts
@@ -1,0 +1,129 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../../../prisma/prisma.service';
+import { SupplierAccessService } from './supplier-access.service';
+
+describe('SupplierAccessService', () => {
+  let service: SupplierAccessService;
+  let prisma: PrismaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SupplierAccessService,
+        {
+          provide: PrismaService,
+          useValue: {
+            supplier: {
+              findUnique: jest.fn(),
+            },
+            materialBatch: {
+              findUnique: jest.fn(),
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(SupplierAccessService);
+    prisma = module.get(PrismaService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('assertSupplierUsable', () => {
+    it('passes approved active suppliers', async () => {
+      jest.spyOn(prisma.supplier, 'findUnique').mockResolvedValue({
+        id: 'supplier-1',
+        name: '合格供应商',
+        status: 'active',
+        supplier_status: 'approved',
+        deletedAt: null,
+      } as any);
+
+      await expect(service.assertSupplierUsable('supplier-1', '创建来料单')).resolves.toBeUndefined();
+    });
+
+    it('rejects disabled suppliers', async () => {
+      jest.spyOn(prisma.supplier, 'findUnique').mockResolvedValue({
+        id: 'supplier-1',
+        name: '停用供应商',
+        status: 'disabled',
+        supplier_status: 'approved',
+        deletedAt: null,
+      } as any);
+
+      await expect(service.assertSupplierUsable('supplier-1', '创建来料单')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects eliminated suppliers', async () => {
+      jest.spyOn(prisma.supplier, 'findUnique').mockResolvedValue({
+        id: 'supplier-1',
+        name: '淘汰供应商',
+        status: 'active',
+        supplier_status: 'eliminated',
+        deletedAt: null,
+      } as any);
+
+      await expect(service.assertSupplierUsable('supplier-1', '创建来料单')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('does not reject suspended suppliers in GAP-103', async () => {
+      jest.spyOn(prisma.supplier, 'findUnique').mockResolvedValue({
+        id: 'supplier-1',
+        name: '暂停供应商',
+        status: 'active',
+        supplier_status: 'suspended',
+        deletedAt: null,
+      } as any);
+
+      await expect(service.assertSupplierUsable('supplier-1', '创建来料单')).resolves.toBeUndefined();
+    });
+
+    it('rejects missing suppliers', async () => {
+      jest.spyOn(prisma.supplier, 'findUnique').mockResolvedValue(null);
+
+      await expect(service.assertSupplierUsable('missing', '创建来料单')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('assertBatchSupplierUsable', () => {
+    it('passes batches without supplier for legacy data', async () => {
+      jest.spyOn(prisma.materialBatch, 'findUnique').mockResolvedValue({
+        id: 'batch-1',
+        deletedAt: null,
+        supplierId: null,
+        supplier: null,
+      } as any);
+
+      await expect(service.assertBatchSupplierUsable('batch-1', '完成领料')).resolves.toBeUndefined();
+    });
+
+    it('rejects batches from eliminated suppliers', async () => {
+      jest.spyOn(prisma.materialBatch, 'findUnique').mockResolvedValue({
+        id: 'batch-1',
+        deletedAt: null,
+        supplierId: 'supplier-1',
+        supplier: {
+          id: 'supplier-1',
+          name: '淘汰供应商',
+          status: 'active',
+          supplier_status: 'eliminated',
+          deletedAt: null,
+        },
+      } as any);
+
+      await expect(service.assertBatchSupplierUsable('batch-1', '完成领料')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+});

--- a/server/src/modules/warehouse/services/supplier-access.service.ts
+++ b/server/src/modules/warehouse/services/supplier-access.service.ts
@@ -1,0 +1,76 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../../prisma/prisma.service';
+
+type SupplierLike = {
+  id: string;
+  name?: string | null;
+  status?: string | null;
+  supplier_status?: string | null;
+  deletedAt?: Date | null;
+};
+
+@Injectable()
+export class SupplierAccessService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async assertSupplierUsable(supplierId: string, actionLabel: string): Promise<void> {
+    const supplier = await this.prisma.supplier.findUnique({
+      where: { id: supplierId },
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        supplier_status: true,
+        deletedAt: true,
+      },
+    });
+
+    this.assertUsableSupplier(supplier, actionLabel);
+  }
+
+  async assertBatchSupplierUsable(batchId: string, actionLabel: string): Promise<void> {
+    const batch = await this.prisma.materialBatch.findUnique({
+      where: { id: batchId },
+      select: {
+        id: true,
+        deletedAt: true,
+        supplierId: true,
+        supplier: {
+          select: {
+            id: true,
+            name: true,
+            status: true,
+            supplier_status: true,
+            deletedAt: true,
+          },
+        },
+      },
+    });
+
+    if (!batch || batch.deletedAt) {
+      throw new NotFoundException(`物料批次不存在：${batchId}`);
+    }
+
+    if (!batch.supplierId) {
+      return;
+    }
+
+    this.assertUsableSupplier(batch.supplier, actionLabel);
+  }
+
+  private assertUsableSupplier(supplier: SupplierLike | null, actionLabel: string): void {
+    if (!supplier || supplier.deletedAt) {
+      throw new NotFoundException('供应商不存在');
+    }
+
+    const displayName = supplier.name || supplier.id;
+
+    if (supplier.status === 'disabled') {
+      throw new BadRequestException(`供应商 ${displayName} 已停用，不能${actionLabel}`);
+    }
+
+    if (supplier.supplier_status === 'eliminated') {
+      throw new BadRequestException(`供应商 ${displayName} 已淘汰，不能${actionLabel}`);
+    }
+  }
+}

--- a/server/src/modules/warehouse/warehouse.module.ts
+++ b/server/src/modules/warehouse/warehouse.module.ts
@@ -29,12 +29,13 @@ import { ScrapService } from './services/scrap.service';
 import { WarehouseTraceabilityController } from './traceability.controller';
 import { WarehouseCronService } from './warehouse-cron.service';
 import { InventoryMovementLedgerService } from './services/inventory-movement-ledger.service';
+import { SupplierAccessService } from './services/supplier-access.service';
 
 @Module({
   imports: [PrismaModule, BatchTraceModule, NotificationModule, UnifiedApprovalModule, DocumentModule, UserPermissionModule],
   controllers: [MaterialController, SupplierController, InboundController, BatchController, RequisitionController, StagingAreaController, MaterialBalanceController, ReturnController, ScrapController, WarehouseTraceabilityController],
-  providers: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, WarehouseCronService, StorageService, PermissionGuard, InventoryMovementLedgerService],
-  exports: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, InventoryMovementLedgerService],
+  providers: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, WarehouseCronService, StorageService, PermissionGuard, InventoryMovementLedgerService, SupplierAccessService],
+  exports: [MaterialService, SupplierService, InboundService, BatchService, RequisitionService, StagingAreaService, MaterialBalanceService, ReturnService, ScrapService, InventoryMovementLedgerService, SupplierAccessService],
 })
 export class WarehouseModule implements OnModuleInit {
   constructor(private readonly callbacks: ApprovalCallbackRegistry) {}


### PR DESCRIPTION
## Summary

Implements GAP-103: Supplier Status Gate for warehouse flows.

- Adds `SupplierAccessService` as single usability gate (new file: `warehouse/services/supplier-access.service.ts`)
- Gates `InboundService.create()` — blocks disabled/eliminated suppliers before creating inbound order
- Gates `BatchService.create()` — blocks disabled/eliminated suppliers when `supplierId` is provided
- Gates `RequisitionService.complete()` — checks batch supplier before decrementing inventory

Execution followed `docs/superpowers/plans/2026-05-01-gap-103-supplier-status-gate-implementation.md` using `superpowers:executing-plans`.

**No schema/migration changes.** Only blocks `status=disabled` and `supplier_status=eliminated`. `suspended` and `pending` are not blocked per spec.

## Test plan

- [x] `SupplierAccessService` unit tests: 7 tests pass
- [x] `InboundService` tests: 10 tests pass (includes blocked supplier test)
- [x] `BatchService` tests: 14 tests pass (includes blocked supplier test)  
- [x] `RequisitionService` tests: 7 tests pass (includes blocked batch supplier test)
- [x] No TypeScript errors in modified files
- [x] `git diff --check` passes (no whitespace issues)