### PR TITLE
fix: GAP-300 require batch link for EnvironmentRecord

### DIFF
--- a/client/src/api/environment-record.ts
+++ b/client/src/api/environment-record.ts
@@ -9,7 +9,7 @@ export type RecordType = 'temperature_humidity' | 'pressure_differential' | 'oth
 export interface EnvironmentRecord {
   id: string;
   company_id: string;
-  production_batch_id: string | null;
+  production_batch_id: string;
   location: string;
   record_type: RecordType;
   temperature: number | null;
@@ -30,7 +30,7 @@ export interface CreateEnvironmentRecordPayload {
   pressure_diff?: number;
   is_within_spec: boolean;
   abnormal_action?: string;
-  production_batch_id?: string;
+  production_batch_id: string;
 }
 
 // =========================================================================

--- a/client/src/views/environment-record/EnvironmentRecordList.vue
+++ b/client/src/views/environment-record/EnvironmentRecordList.vue
@@ -130,8 +130,8 @@
             placeholder="超标时请填写处理措施"
           />
         </el-form-item>
-        <el-form-item label="生产批次号">
-          <el-input v-model="createForm.production_batch_id" placeholder="可选" />
+        <el-form-item label="生产批次" prop="production_batch_id">
+          <ProductionBatchSelect v-model="createForm.production_batch_id" />
         </el-form-item>
       </el-form>
       <template #footer>
@@ -146,6 +146,7 @@
 import { ref, reactive, onMounted } from 'vue';
 import { ElMessage } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
+import ProductionBatchSelect from '@/components/master-data/ProductionBatchSelect.vue';
 import type { FormInstance, FormRules } from 'element-plus';
 import environmentRecordApi, {
   type EnvironmentRecord,
@@ -180,6 +181,7 @@ const createRules: FormRules = {
   location: [{ required: true, message: '请输入监测位置', trigger: 'blur' }],
   record_type: [{ required: true, message: '请选择记录类型', trigger: 'change' }],
   is_within_spec: [{ required: true, message: '请选择是否达标', trigger: 'change' }],
+  production_batch_id: [{ required: true, message: '请选择生产批次', trigger: 'change' }],
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -236,7 +238,7 @@ async function handleCreate() {
       pressure_diff: createForm.pressure_diff,
       is_within_spec: createForm.is_within_spec,
       abnormal_action: createForm.abnormal_action || undefined,
-      production_batch_id: createForm.production_batch_id || undefined,
+      production_batch_id: createForm.production_batch_id,
     });
     ElMessage.success('新建成功');
     createDialogVisible.value = false;

--- a/server/src/modules/environment-record/dto/create-environment-record.dto.ts
+++ b/server/src/modules/environment-record/dto/create-environment-record.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsBoolean, IsNumber } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsNumber, IsNotEmpty } from 'class-validator';
 
 export class CreateEnvironmentRecordDto {
   @IsString()
@@ -26,7 +26,7 @@ export class CreateEnvironmentRecordDto {
   @IsString()
   abnormal_action?: string;
 
-  @IsOptional()
   @IsString()
-  production_batch_id?: string;
+  @IsNotEmpty()
+  production_batch_id: string;
 }

--- a/server/src/modules/environment-record/environment-record.service.spec.ts
+++ b/server/src/modules/environment-record/environment-record.service.spec.ts
@@ -1,0 +1,74 @@
+import { BadRequestException } from '@nestjs/common';
+import { EnvironmentRecordService } from './environment-record.service';
+
+describe('EnvironmentRecordService', () => {
+  it('rejects creation when the production batch does not exist', async () => {
+    const prisma: any = {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      environmentRecord: {
+        create: jest.fn(),
+      },
+    };
+    const service = new EnvironmentRecordService(prisma);
+
+    await expect(
+      service.create(
+        {
+          location: '生产车间A区',
+          record_type: 'temperature_humidity',
+          temperature: 25.5,
+          humidity: 61,
+          is_within_spec: true,
+          production_batch_id: 'missing-batch',
+        },
+        'user-1',
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true },
+    });
+    expect(prisma.environmentRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an environment record linked to an existing production batch', async () => {
+    const prisma: any = {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1' }),
+      },
+      environmentRecord: {
+        create: jest.fn().mockResolvedValue({ id: 'er-1' }),
+      },
+    };
+    const service = new EnvironmentRecordService(prisma);
+
+    await service.create(
+      {
+        location: '生产车间A区',
+        record_type: 'temperature_humidity',
+        temperature: 25.5,
+        humidity: 61,
+        is_within_spec: true,
+        production_batch_id: 'batch-1',
+      },
+      'user-1',
+    );
+
+    expect(prisma.environmentRecord.create).toHaveBeenCalledWith({
+      data: {
+        location: '生产车间A区',
+        record_type: 'temperature_humidity',
+        temperature: 25.5,
+        humidity: 61,
+        is_within_spec: true,
+        production_batch_id: 'batch-1',
+        company_id: '1',
+        operator_id: 'user-1',
+        measured_at: expect.any(Date),
+      },
+    });
+  });
+});

--- a/server/src/modules/environment-record/environment-record.service.ts
+++ b/server/src/modules/environment-record/environment-record.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateEnvironmentRecordDto } from './dto/create-environment-record.dto';
 
@@ -7,6 +7,15 @@ export class EnvironmentRecordService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateEnvironmentRecordDto, userId: string) {
+    const productionBatch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.production_batch_id },
+      select: { id: true },
+    });
+
+    if (!productionBatch) {
+      throw new BadRequestException('生产批次不存在');
+    }
+
     return this.prisma.environmentRecord.create({
       data: {
         ...dto,

--- a/server/src/prisma/migrations/20260501093000_require_environment_record_batch_id/migration.sql
+++ b/server/src/prisma/migrations/20260501093000_require_environment_record_batch_id/migration.sql
@@ -1,0 +1,29 @@
+-- Require every EnvironmentRecord in the quality release chain to link to a ProductionBatch.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "EnvironmentRecord" WHERE "production_batch_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require EnvironmentRecord.production_batch_id: legacy rows with NULL production_batch_id exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "EnvironmentRecord" er
+    LEFT JOIN "production_batches" pb ON pb."id" = er."production_batch_id"
+    WHERE pb."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add EnvironmentRecord.production_batch_id FK: orphan production_batch_id rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "EnvironmentRecord" DROP CONSTRAINT IF EXISTS "EnvironmentRecord_production_batch_id_fkey";
+ALTER TABLE "EnvironmentRecord" ALTER COLUMN "production_batch_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "EnvironmentRecord_production_batch_id_idx"
+  ON "EnvironmentRecord"("production_batch_id");
+
+ALTER TABLE "EnvironmentRecord"
+  ADD CONSTRAINT "EnvironmentRecord_production_batch_id_fkey"
+  FOREIGN KEY ("production_batch_id") REFERENCES "production_batches"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1521,6 +1521,7 @@ model ProductionBatch {
   // Task 15b: 过程监控
   process_monitor_records ProcessMonitorRecord[]
   metal_detection_logs    MetalDetectionLog[]
+  environment_records     EnvironmentRecord[]
 
   production_run_id String?
   production_run    ProductionRun? @relation(fields: [production_run_id], references: [id], onDelete: SetNull)
@@ -3171,19 +3172,22 @@ model CalibrationRecord {
 // ─── 过程监控 ─────────────────────────────────────
 
 model EnvironmentRecord {
-  id                  String    @id @default(cuid())
+  id                  String          @id @default(cuid())
   company_id          String
-  production_batch_id String?
+  production_batch_id String
+  production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
   location            String
-  record_type         String    // 'temperature_humidity'|'pressure_differential'|'other'
-  temperature         Decimal?  @db.Decimal(8,2)
-  humidity            Decimal?  @db.Decimal(8,2)
-  pressure_diff       Decimal?  @db.Decimal(8,2)
+  record_type         String          // 'temperature_humidity'|'pressure_differential'|'other'
+  temperature         Decimal?        @db.Decimal(8,2)
+  humidity            Decimal?        @db.Decimal(8,2)
+  pressure_diff       Decimal?        @db.Decimal(8,2)
   is_within_spec      Boolean
   abnormal_action     String?
   measured_at         DateTime
   operator_id         String?
-  created_at          DateTime  @default(now())
+  created_at          DateTime        @default(now())
+
+  @@index([production_batch_id])
 }
 
 model ProcessMonitorRecord {


### PR DESCRIPTION
## Summary

- `EnvironmentRecord.production_batch_id` made non-null with FK to `ProductionBatch` (Prisma schema + guarded migration)
- Guarded migration: preflight checks abort if NULL or orphan rows exist — no auto-backfill
- `EnvironmentRecordService.create()` validates batch existence before write; throws `BadRequestException('生产批次不存在')` on miss
- `CreateEnvironmentRecordDto.production_batch_id` changed from optional to required (`@IsNotEmpty`)
- Frontend: replaced free-text batch input with `ProductionBatchSelect` selector, added required form rule
- Added focused Jest spec covering reject-on-missing-batch and happy-path creation

## Verification

| Check | Result |
|-------|--------|
| `npx prisma validate` | ✅ PASS |
| `npm test -- environment-record.service.spec.ts --runInBand` | ✅ 2 tests pass |
| `npm run build:client` | ✅ PASS |
| `pnpm test:e2e --grep GAP-300` | ℹ️ No test:e2e script in repo; replaced by above checks |

## Test plan

- [ ] Create a new EnvironmentRecord with a valid `production_batch_id` → success
- [ ] Create a new EnvironmentRecord with a missing `production_batch_id` → 400 "生产批次不存在"
- [ ] Create a new EnvironmentRecord without `production_batch_id` → DTO 400 validation error
- [ ] Run migration against DB with no NULL rows → succeeds
- [ ] Run migration against DB with NULL rows → migration aborts with RAISE EXCEPTION

## Scope

Only files listed in docs/superpowers/plans/2026-05-01-gap-300-environment-record-batch-fk-implementation.md were modified. No changes to `fragile-item-inspection`, `ccp`, `non-conformance`, or unrelated modules.