### PR TITLE
fix: GAP-100 use material batch selector for incoming inspections

### DIFF
--- a/client/src/views/incoming-inspection/IncomingInspectionList.vue
+++ b/client/src/views/incoming-inspection/IncomingInspectionList.vue
@@ -88,8 +88,25 @@
         :rules="createRules"
         label-width="110px"
       >
-        <el-form-item label="物料批次ID" prop="material_batch_id">
-          <el-input v-model="createForm.material_batch_id" placeholder="请输入物料批次 ID" />
+        <el-form-item label="物料批次" prop="material_batch_id">
+          <el-select
+            v-model="createForm.material_batch_id"
+            filterable
+            remote
+            clearable
+            reserve-keyword
+            :remote-method="loadBatchOptions"
+            :loading="batchLoading"
+            placeholder="请选择物料批次"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="batch in batchOptions"
+              :key="batch.id"
+              :label="formatBatchOptionLabel(batch)"
+              :value="batch.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="总体结论" prop="overall_result">
           <el-select v-model="createForm.overall_result" placeholder="请选择" style="width: 100%">
@@ -217,6 +234,7 @@ import incomingInspectionApi, {
   getOverallResultText,
   getOverallResultTagType,
 } from '@/api/incoming-inspection';
+import { batchApi, type MaterialBatch } from '@/api/warehouse';
 import filePreviewApi from '@/api/file-preview';
 
 // ── State ─────────────────────────────────────────────────────────────────────
@@ -236,6 +254,9 @@ const createDialogVisible = ref(false);
 const submitting = ref(false);
 const createFormRef = ref<FormInstance>();
 
+const batchOptions = ref<MaterialBatch[]>([]);
+const batchLoading = ref(false);
+
 function defaultResultRow(): InspectionResult {
   return { item_name: '', actual_value: '', is_pass: true };
 }
@@ -251,7 +272,7 @@ const createForm = reactive({
 });
 
 const createRules: FormRules = {
-  material_batch_id: [{ required: true, message: '请输入物料批次 ID', trigger: 'blur' }],
+  material_batch_id: [{ required: true, message: '请选择物料批次', trigger: 'change' }],
   overall_result: [{ required: true, message: '请选择总体结论', trigger: 'change' }],
 };
 
@@ -274,6 +295,32 @@ function calcPassRate(results: InspectionResult[]): string {
   return `${passed} / ${results.length}`;
 }
 
+function getBatchNumber(batch: MaterialBatch & { lot_number?: string }): string {
+  return batch.batchNumber || batch.lot_number || batch.id;
+}
+
+function formatBatchOptionLabel(batch: MaterialBatch & { lot_number?: string }): string {
+  const materialName = batch.material?.name || '未知物料';
+  const supplierName = batch.supplier?.name || '未知供应商';
+  const quantityText = batch.quantity != null ? `剩余 ${batch.quantity}` : '数量未知';
+  return `${getBatchNumber(batch)} / ${materialName} / ${supplierName} / ${quantityText}`;
+}
+
+function normalizeBatchListResponse(response: unknown): MaterialBatch[] {
+  if (Array.isArray(response)) {
+    return response as MaterialBatch[];
+  }
+
+  const payload = response as { list?: MaterialBatch[]; data?: MaterialBatch[] };
+  if (Array.isArray(payload.list)) {
+    return payload.list;
+  }
+  if (Array.isArray(payload.data)) {
+    return payload.data;
+  }
+  return [];
+}
+
 // ── Result rows ───────────────────────────────────────────────────────────────
 
 function addResultRow() {
@@ -285,6 +332,23 @@ function removeResultRow(index: number) {
 }
 
 // ── Data loading ──────────────────────────────────────────────────────────────
+
+async function loadBatchOptions(search = '') {
+  batchLoading.value = true;
+  try {
+    const response = await batchApi.getList({
+      page: 1,
+      limit: 20,
+      status: 'normal',
+      search: search || undefined,
+    } as Parameters<typeof batchApi.getList>[0] & { search?: string });
+    batchOptions.value = normalizeBatchListResponse(response);
+  } catch {
+    ElMessage.error('加载物料批次失败');
+  } finally {
+    batchLoading.value = false;
+  }
+}
 
 async function loadList() {
   loading.value = true;
@@ -309,6 +373,7 @@ function openCreateDialog() {
   createForm.notes = '';
   createForm.results = [defaultResultRow()];
   createDialogVisible.value = true;
+  void loadBatchOptions();
 }
 
 async function handleCreate() {

--- a/client/src/views/incoming-inspection/__tests__/IncomingInspectionList.spec.ts
+++ b/client/src/views/incoming-inspection/__tests__/IncomingInspectionList.spec.ts
@@ -1,0 +1,117 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import IncomingInspectionList from '../IncomingInspectionList.vue';
+import incomingInspectionApi from '@/api/incoming-inspection';
+import { batchApi } from '@/api/warehouse';
+
+vi.mock('@/api/incoming-inspection', () => ({
+  default: {
+    getList: vi.fn(),
+    create: vi.fn(),
+    getReports: vi.fn(),
+  },
+  getOverallResultText: (value: string) => ({ pass: '合格', fail: '不合格', conditional_pass: '有条件合格' }[value] || value),
+  getOverallResultTagType: (value: string) => (value === 'pass' ? 'success' : value === 'fail' ? 'danger' : 'warning'),
+}));
+
+vi.mock('@/api/warehouse', () => ({
+  batchApi: {
+    getList: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/file-preview', () => ({
+  default: {
+    getPreviewInfo: vi.fn(),
+  },
+}));
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus');
+  return {
+    ...actual,
+    ElMessage: {
+      success: vi.fn(),
+      error: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+});
+
+const batchRows = [
+  {
+    id: 'batch-1',
+    batchNumber: 'MB-2026-001',
+    quantity: 120,
+    status: 'normal',
+    material: { id: 'mat-1', name: '白砂糖', code: 'M-SUGAR', category: 'raw', unit: 'kg', currentStock: 120, status: 'active', createdAt: '', updatedAt: '' },
+    supplier: { id: 'sup-1', name: '合格供应商', code: 'S-001', status: 'active', createdAt: '' },
+  },
+];
+
+const stubs = {
+  'el-card': { template: '<section><slot name="header" /><slot /></section>' },
+  'el-button': { template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>', props: ['type', 'loading', 'disabled'] },
+  'el-icon': { template: '<i><slot /></i>' },
+  'el-table': { template: '<table><slot /></table>', props: ['data', 'loading', 'stripe'] },
+  'el-table-column': { template: '<td><slot name="default" :row="{}" /></td>', props: ['prop', 'label', 'width', 'minWidth', 'showOverflowTooltip', 'fixed'] },
+  'el-tag': { template: '<span><slot /></span>', props: ['type', 'effect', 'size'] },
+  'el-dialog': { template: '<div v-if="modelValue"><slot /><slot name="footer" /></div>', props: ['modelValue', 'title', 'width', 'closeOnClickModal'] },
+  'el-form': { template: '<form><slot /></form>', methods: { validate: () => Promise.resolve(true) }, props: ['model', 'rules', 'labelWidth'] },
+  'el-form-item': { template: '<label><span>{{ label }}</span><slot /></label>', props: ['label', 'prop'] },
+  'el-select': {
+    template: '<select :data-placeholder="placeholder" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+    props: ['modelValue', 'placeholder', 'filterable', 'remote', 'remoteMethod', 'loading', 'clearable', 'reserveKeyword', 'style'],
+  },
+  'el-option': { template: '<option :value="value">{{ label }}</option>', props: ['label', 'value'] },
+  'el-input': { template: '<input :value="modelValue" :placeholder="placeholder" @input="$emit(\'update:modelValue\', $event.target.value)" />', props: ['modelValue', 'placeholder', 'type', 'rows', 'style'] },
+  'el-input-number': { template: '<input type="number" :value="modelValue" @input="$emit(\'update:modelValue\', Number($event.target.value))" />', props: ['modelValue', 'min', 'placeholder', 'style'] },
+  'el-divider': { template: '<hr />', props: ['contentPosition'] },
+};
+
+describe('IncomingInspectionList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(incomingInspectionApi.getList).mockResolvedValue([]);
+    vi.mocked(incomingInspectionApi.create).mockResolvedValue({} as any);
+    vi.mocked(batchApi.getList).mockResolvedValue({ list: batchRows, total: 1, page: 1, limit: 20 } as any);
+  });
+
+  it('uses a searchable material batch selector instead of a free text batch id input', async () => {
+    const wrapper = mount(IncomingInspectionList, { global: { stubs } });
+    await flushPromises();
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+
+    expect(batchApi.getList).toHaveBeenCalledWith({ page: 1, limit: 20, status: 'normal' });
+    expect(wrapper.text()).toContain('物料批次');
+    expect(wrapper.text()).not.toContain('物料批次ID');
+    expect(wrapper.find('input[placeholder="请输入物料批次 ID"]').exists()).toBe(false);
+    expect(wrapper.find('select[data-placeholder="请选择物料批次"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('MB-2026-001 / 白砂糖');
+  });
+
+  it('submits the selected MaterialBatch id as material_batch_id', async () => {
+    const wrapper = mount(IncomingInspectionList, { global: { stubs } });
+    await flushPromises();
+
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+
+    const selects = wrapper.findAll('select');
+    await selects[0].setValue('batch-1');
+    await selects[1].setValue('pass');
+
+    const confirmButtons = wrapper.findAll('button');
+    await confirmButtons[confirmButtons.length - 1].trigger('click');
+    await flushPromises();
+
+    expect(incomingInspectionApi.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        material_batch_id: 'batch-1',
+        overall_result: 'pass',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces free-text `material_batch_id` input in the incoming inspection create form with a remote-search `el-select` backed by `GET /warehouse/batches`
- Defaults to `status: normal` batches; option label shows batch number, material name, supplier, and remaining quantity
- Submit payload field `material_batch_id` is unchanged — no backend DTO changes
- Adds focused Vitest unit test: selector render, `batchApi.getList` call, and `material_batch_id` submit

**Plan:** `docs/superpowers/plans/2026-05-01-gap-100-incoming-inspection-batch-selector-implementation.md`

## Files Changed

- `M client/src/views/incoming-inspection/IncomingInspectionList.vue`
- `A client/src/views/incoming-inspection/__tests__/IncomingInspectionList.spec.ts`

No schema, migration, or backend service changes.

## Test Plan

- [x] `npm run test -w client -- IncomingInspectionList.spec.ts` — 2 tests PASS
- [x] `npm run test -w client -- BatchManagement.spec.ts` — 1 test PASS (batch status enum guard)
- [x] `npm run build:client` — Build PASS, no TypeScript errors
- [ ] `pnpm test:e2e -- --grep GAP-100` — Not available in this environment (no pnpm workspace config, no GAP-100 E2E spec found)