### PR TITLE
fix: GAP-200 link ShiftInstance to ShiftType FK

### DIFF
--- a/client/src/api/shift-instance.ts
+++ b/client/src/api/shift-instance.ts
@@ -4,9 +4,21 @@ import request from './request';
 // Types
 // =========================================================================
 
+export interface ShiftTypeSummary {
+  id: string;
+  code: string;
+  name: string;
+  start_time: string;
+  end_time: string;
+  crosses_day: boolean;
+  active: boolean;
+}
+
 export interface ShiftInstance {
   id: string;
+  shift_type_id: string;
   shift_type: string;
+  shift_type_ref?: ShiftTypeSummary;
   shift_date: string;
   status: 'open' | 'closed';
   notes?: string;
@@ -24,7 +36,7 @@ export interface ProductionRunSummary {
 }
 
 export interface CreateShiftInstancePayload {
-  shift_type: string;
+  shiftTypeId: string;
   shift_date: string;
   notes?: string;
 }

--- a/client/src/views/shift/ShiftDashboard.vue
+++ b/client/src/views/shift/ShiftDashboard.vue
@@ -21,7 +21,7 @@
             <el-tag :type="shift.status === 'open' ? 'success' : 'info'">
               {{ shift.status === 'open' ? '进行中' : '已关班' }}
             </el-tag>
-            &nbsp;{{ shift.shift_type }} | {{ formatDate(shift.shift_date) }}
+            &nbsp;{{ displayShiftType(shift) }} | {{ formatDate(shift.shift_date) }}
           </span>
           <div>
             <el-button
@@ -119,6 +119,10 @@ function formatDate(d: string): string {
 function formatTime(d: string): string {
   if (!d) return '';
   return new Date(d).toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' });
+}
+
+function displayShiftType(shift: ShiftInstance): string {
+  return shift.shift_type_ref?.name ?? shift.shift_type;
 }
 
 function openRunFor(shift: ShiftInstance) {

--- a/client/src/views/shift/components/OpenShiftDialog.vue
+++ b/client/src/views/shift/components/OpenShiftDialog.vue
@@ -6,11 +6,15 @@
     @close="$emit('update:modelValue', false)"
   >
     <el-form ref="formRef" :model="form" :rules="rules" label-width="80px">
-      <el-form-item label="班次类型" prop="shift_type">
-        <el-radio-group v-model="form.shift_type">
-          <el-radio value="白班">白班</el-radio>
-          <el-radio value="夜班">夜班</el-radio>
-        </el-radio-group>
+      <el-form-item label="班次类型" prop="shiftTypeId">
+        <el-select v-model="form.shiftTypeId" placeholder="请选择班次类型" style="width: 100%">
+          <el-option
+            v-for="shiftType in shiftTypes"
+            :key="shiftType.id"
+            :label="formatShiftTypeLabel(shiftType)"
+            :value="shiftType.id"
+          />
+        </el-select>
       </el-form-item>
       <el-form-item label="开班日期" prop="shift_date">
         <el-date-picker
@@ -32,9 +36,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive } from 'vue';
+import { ref, reactive, onMounted } from 'vue';
 import type { FormInstance, FormRules } from 'element-plus';
-import { ShiftInstanceApi, type CreateShiftInstancePayload } from '@/api/shift-instance';
+import { ShiftInstanceApi, type CreateShiftInstancePayload, type ShiftTypeSummary } from '@/api/shift-instance';
+import { teamShiftApi } from '@/api/team-shift';
 
 defineProps<{ modelValue: boolean }>();
 const emit = defineEmits<{
@@ -45,17 +50,37 @@ const emit = defineEmits<{
 const formRef = ref<FormInstance>();
 const loading = ref(false);
 const today = new Date().toISOString().slice(0, 10);
+const shiftTypes = ref<ShiftTypeSummary[]>([]);
 
 const form = reactive<CreateShiftInstancePayload>({
-  shift_type: '白班',
+  shiftTypeId: '',
   shift_date: today,
   notes: '',
 });
 
 const rules: FormRules = {
-  shift_type: [{ required: true, message: '请选择班次类型', trigger: 'change' }],
+  shiftTypeId: [{ required: true, message: '请选择班次类型', trigger: 'change' }],
   shift_date: [{ required: true, message: '请选择日期', trigger: 'change' }],
 };
+
+onMounted(loadShiftTypes);
+
+async function loadShiftTypes() {
+  const response = await teamShiftApi.listShiftTypes();
+  const data = Array.isArray((response as any).data)
+    ? (response as any).data
+    : Array.isArray(response)
+      ? response
+      : [];
+  shiftTypes.value = data as ShiftTypeSummary[];
+  if (!form.shiftTypeId && shiftTypes.value.length > 0) {
+    form.shiftTypeId = shiftTypes.value[0].id;
+  }
+}
+
+function formatShiftTypeLabel(shiftType: ShiftTypeSummary): string {
+  return `${shiftType.name} ${shiftType.start_time}-${shiftType.end_time}`;
+}
 
 async function submit() {
   const valid = await formRef.value?.validate().catch(() => false);

--- a/server/src/modules/shift-instance/dto/create-shift-instance.dto.ts
+++ b/server/src/modules/shift-instance/dto/create-shift-instance.dto.ts
@@ -1,9 +1,15 @@
-import { IsNotEmpty, IsIn, IsDateString, IsOptional, IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsOptional, IsString, ValidateIf } from 'class-validator';
 
 export class CreateShiftInstanceDto {
+  @ValidateIf((dto) => !dto.shift_type)
   @IsNotEmpty()
-  @IsIn(['白班', '夜班'])
-  shift_type: string;
+  @IsString()
+  shiftTypeId?: string;
+
+  @ValidateIf((dto) => !dto.shiftTypeId)
+  @IsNotEmpty()
+  @IsString()
+  shift_type?: string;
 
   @IsNotEmpty()
   @IsDateString()

--- a/server/src/modules/shift-instance/shift-instance.service.spec.ts
+++ b/server/src/modules/shift-instance/shift-instance.service.spec.ts
@@ -7,6 +7,9 @@ describe('ShiftInstanceService', () => {
   let service: ShiftInstanceService;
 
   const mockPrisma = {
+    shiftType: {
+      findFirst: jest.fn(),
+    },
     shiftInstance: {
       findUnique: jest.fn(),
       findFirst: jest.fn(),
@@ -28,21 +31,100 @@ describe('ShiftInstanceService', () => {
   });
 
   describe('create', () => {
-    it('should throw ConflictException when shift already exists', async () => {
+    const dayShiftType = {
+      id: 'shift-day',
+      code: 'DAY',
+      name: '白班',
+      start_time: '08:00',
+      end_time: '20:00',
+      crosses_day: false,
+      active: true,
+    };
+
+    it('should throw ConflictException when shift already exists for shiftTypeId and date', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
       mockPrisma.shiftInstance.findUnique.mockResolvedValue({ id: 'existing' });
+
       await expect(
-        service.create({ shift_type: '白班', shift_date: '2026-04-22' }, 'user1'),
+        service.create({ shiftTypeId: 'shift-day', shift_date: '2026-04-22' }, 'user1'),
       ).rejects.toThrow(ConflictException);
+
+      expect(mockPrisma.shiftInstance.findUnique).toHaveBeenCalledWith({
+        where: {
+          company_id_shift_type_id_shift_date: {
+            company_id: '1',
+            shift_type_id: 'shift-day',
+            shift_date: new Date('2026-04-22'),
+          },
+        },
+      });
     });
 
-    it('should create shift when none exists', async () => {
+    it('should create shift from shiftTypeId and persist the legacy name snapshot', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
       mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
-      mockPrisma.shiftInstance.create.mockResolvedValue({ id: 'new-id', status: 'open' });
-      const result = await service.create({ shift_type: '白班', shift_date: '2026-04-22' }, 'user1');
-      expect(result.status).toBe('open');
-      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ shift_type: '白班' }) }),
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'new-id',
+        status: 'open',
+        shift_type_id: 'shift-day',
+        shift_type: '白班',
+      });
+
+      const result = await service.create(
+        { shiftTypeId: 'shift-day', shift_date: '2026-04-22' },
+        'user1',
       );
+
+      expect(result.status).toBe('open');
+      expect(mockPrisma.shiftType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'shift-day', active: true },
+      });
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith({
+        data: {
+          company_id: '1',
+          shift_type_id: 'shift-day',
+          shift_type: '白班',
+          shift_date: new Date('2026-04-22'),
+          opened_by: 'user1',
+          notes: undefined,
+        },
+        include: { shift_type_ref: true },
+      });
+    });
+
+    it('should keep legacy shift_type payload working during migration window', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'new-id',
+        status: 'open',
+        shift_type_id: 'shift-day',
+        shift_type: '白班',
+      });
+
+      await service.create({ shift_type: '白班', shift_date: '2026-04-22' }, 'user1');
+
+      expect(mockPrisma.shiftType.findFirst).toHaveBeenCalledWith({
+        where: { name: '白班', active: true },
+      });
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            shift_type_id: 'shift-day',
+            shift_type: '白班',
+          }),
+        }),
+      );
+    });
+
+    it('should reject unknown legacy shift_type values', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.create({ shift_type: '中班', shift_date: '2026-04-22' }, 'user1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrisma.shiftInstance.create).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/modules/shift-instance/shift-instance.service.ts
+++ b/server/src/modules/shift-instance/shift-instance.service.ts
@@ -11,13 +11,32 @@ import { CreateShiftInstanceDto, CloseShiftInstanceDto } from './dto/create-shif
 export class ShiftInstanceService {
   constructor(private readonly prisma: PrismaService) {}
 
+  private async resolveShiftType(dto: CreateShiftInstanceDto) {
+    const shiftType = dto.shiftTypeId
+      ? await this.prisma.shiftType.findFirst({
+          where: { id: dto.shiftTypeId, active: true },
+        })
+      : await this.prisma.shiftType.findFirst({
+          where: { name: dto.shift_type, active: true },
+        });
+
+    if (!shiftType) {
+      throw new BadRequestException('班次类型不存在或已停用');
+    }
+
+    return shiftType;
+  }
+
   async create(dto: CreateShiftInstanceDto, userId: string) {
+    const shiftType = await this.resolveShiftType(dto);
+    const shiftDate = new Date(dto.shift_date);
+
     const existing = await this.prisma.shiftInstance.findUnique({
       where: {
-        company_id_shift_type_shift_date: {
+        company_id_shift_type_id_shift_date: {
           company_id: '1',
-          shift_type: dto.shift_type,
-          shift_date: new Date(dto.shift_date),
+          shift_type_id: shiftType.id,
+          shift_date: shiftDate,
         },
       },
     });
@@ -26,11 +45,13 @@ export class ShiftInstanceService {
     return this.prisma.shiftInstance.create({
       data: {
         company_id: '1',
-        shift_type: dto.shift_type,
-        shift_date: new Date(dto.shift_date),
+        shift_type_id: shiftType.id,
+        shift_type: shiftType.name,
+        shift_date: shiftDate,
         opened_by: userId,
         notes: dto.notes,
       },
+      include: { shift_type_ref: true },
     });
   }
 
@@ -41,6 +62,7 @@ export class ShiftInstanceService {
         ...(date ? { shift_date: new Date(date) } : {}),
       },
       include: {
+        shift_type_ref: true,
         production_runs: {
           include: { product: true },
           orderBy: { started_at: 'asc' },
@@ -54,6 +76,7 @@ export class ShiftInstanceService {
     const inst = await this.prisma.shiftInstance.findFirst({
       where: { id, company_id: '1' },
       include: {
+        shift_type_ref: true,
         production_runs: {
           include: { product: true, recipe: true },
           orderBy: { started_at: 'asc' },

--- a/server/src/prisma/migrations/20260501000200_shift_instance_shift_type_fk/migration.sql
+++ b/server/src/prisma/migrations/20260501000200_shift_instance_shift_type_fk/migration.sql
@@ -1,0 +1,66 @@
+-- Link ShiftInstance to ShiftType while preserving shift_type as a legacy display snapshot.
+-- This migration only auto-maps the two legacy values that the current DTO allowed.
+
+ALTER TABLE "shift_instances" ADD COLUMN "shift_type_id" TEXT;
+
+INSERT INTO "shift_types" ("id", "code", "name", "start_time", "end_time", "crosses_day", "active", "created_at", "updated_at")
+SELECT 'shift-type-day', 'DAY', '白班', '08:00', '20:00', false, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM "shift_types" WHERE "code" = 'DAY' OR "name" = '白班'
+);
+
+INSERT INTO "shift_types" ("id", "code", "name", "start_time", "end_time", "crosses_day", "active", "created_at", "updated_at")
+SELECT 'shift-type-night', 'NIGHT', '夜班', '20:00', '08:00', true, true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+WHERE NOT EXISTS (
+  SELECT 1 FROM "shift_types" WHERE "code" = 'NIGHT' OR "name" = '夜班'
+);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "shift_instances"
+    WHERE "shift_type" NOT IN ('白班', '夜班')
+  ) THEN
+    RAISE EXCEPTION 'Cannot backfill shift_instances.shift_type_id: unknown legacy shift_type exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT "name"
+      FROM "shift_types"
+      WHERE "name" IN ('白班', '夜班')
+      GROUP BY "name"
+      HAVING COUNT(*) > 1
+    ) duplicated
+  ) THEN
+    RAISE EXCEPTION 'Cannot backfill shift_instances.shift_type_id: duplicate ShiftType names for legacy values';
+  END IF;
+END $$;
+
+UPDATE "shift_instances" si
+SET "shift_type_id" = st."id"
+FROM "shift_types" st
+WHERE si."shift_type" = st."name"
+  AND si."shift_type_id" IS NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "shift_instances" WHERE "shift_type_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require shift_instances.shift_type_id: unmapped legacy rows remain';
+  END IF;
+END $$;
+
+ALTER TABLE "shift_instances" ALTER COLUMN "shift_type_id" SET NOT NULL;
+
+CREATE UNIQUE INDEX "shift_instances_company_id_shift_type_id_shift_date_key"
+  ON "shift_instances"("company_id", "shift_type_id", "shift_date");
+
+CREATE INDEX "shift_instances_shift_type_id_idx"
+  ON "shift_instances"("shift_type_id");
+
+ALTER TABLE "shift_instances"
+  ADD CONSTRAINT "shift_instances_shift_type_id_fkey"
+  FOREIGN KEY ("shift_type_id") REFERENCES "shift_types"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -2856,8 +2856,9 @@ model ShiftType {
   crosses_day Boolean              @default(false)
   active      Boolean              @default(true)
   schedules   TeamShiftSchedule[]
-  batches     ProductionBatch[]
-  records     StagingAreaStocktake[]
+  batches        ProductionBatch[]
+  records        StagingAreaStocktake[]
+  shiftInstances ShiftInstance[]
   created_at  DateTime             @default(now())
   updated_at  DateTime             @updatedAt
 
@@ -3654,7 +3655,9 @@ model PackagingMaterialUsage {
 model ShiftInstance {
   id              String   @id @default(cuid())
   company_id      String
-  shift_type      String   // '白班' | '夜班'
+  shift_type_id   String
+  shift_type_ref  ShiftType @relation(fields: [shift_type_id], references: [id], onDelete: Restrict)
+  shift_type      String   // legacy display snapshot; derived from ShiftType.name
   shift_date      DateTime @db.Date
   opened_by       String
   closed_by       String?
@@ -3669,7 +3672,9 @@ model ShiftInstance {
   records         Record[]
 
   @@unique([company_id, shift_type, shift_date])
+  @@unique([company_id, shift_type_id, shift_date])
   @@index([company_id, shift_date])
+  @@index([shift_type_id])
   @@map("shift_instances")
 }
 


### PR DESCRIPTION
## Summary

- Add `shift_type_id` FK on `ShiftInstance` pointing to `ShiftType.id` (Restrict on delete)
- Add guarded migration that seeds default 白班/夜班 ShiftTypes if missing, backfills all existing rows, and fails fast on any unknown legacy `shift_type` value
- Update `CreateShiftInstanceDto` to prefer `shiftTypeId` with legacy `shift_type` fallback for migration window
- Update `ShiftInstanceService.create()` to resolve ShiftType before creating, use new composite unique key, include `shift_type_ref` in list/detail reads
- Update frontend: add `ShiftTypeSummary` type, extend `ShiftInstance`, replace hardcoded radio with dynamic `el-select` from `teamShiftApi.listShiftTypes()`
- Update `ShiftDashboard.vue` to use `shift_type_ref?.name ?? shift_type` for display

## Test plan

- [x] `npx prisma validate --schema src/prisma/schema.prisma` passes (schema valid)
- [x] `npm test -- shift-instance.service.spec.ts team-shift.service.spec.ts --runInBand` passes (9 tests)
- [x] Migration SQL guards against unknown legacy values and duplicate ShiftType names
- [x] Only plan-specified files changed (`git diff --name-only`)
- [x] No whitespace issues (`git diff --check`)