### PR TITLE
fix: GAP-101 disable direct material batch creation

### DIFF
--- a/client/src/api/warehouse.ts
+++ b/client/src/api/warehouse.ts
@@ -145,10 +145,6 @@ export const batchApi = {
     return request.get<MaterialBatch>(`/warehouse/batches/${id}`);
   },
 
-  create(payload: Partial<MaterialBatch>) {
-    return request.post<MaterialBatch>('/warehouse/batches', payload);
-  },
-
   update(id: string, payload: Partial<MaterialBatch>) {
     return request.put<MaterialBatch>(`/warehouse/batches/${id}`, payload);
   },

--- a/server/src/modules/warehouse/batch.controller.spec.ts
+++ b/server/src/modules/warehouse/batch.controller.spec.ts
@@ -1,0 +1,56 @@
+import { GoneException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BatchController } from './batch.controller';
+import { BatchService } from './batch.service';
+
+describe('BatchController', () => {
+  let controller: BatchController;
+  let service: BatchService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BatchController],
+      providers: [
+        {
+          provide: BatchService,
+          useValue: {
+            create: jest.fn(),
+            findAll: jest.fn(),
+            getFIFO: jest.fn(),
+            findOne: jest.fn(),
+            update: jest.fn(),
+            lock: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(BatchController);
+    service = module.get(BatchService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the BatchService GoneException for direct manual create', async () => {
+    const dto = {
+      batchNumber: 'BATCH-20260215-001',
+      materialId: 'material-001',
+      productionDate: new Date('2026-01-01'),
+      expiryDate: new Date('2026-07-01'),
+      quantity: 100,
+    };
+
+    jest
+      .spyOn(service, 'create')
+      .mockRejectedValue(
+        new GoneException(
+          'Direct material batch creation is disabled. Complete a MaterialInbound to create MaterialBatch.',
+        ),
+      );
+
+    await expect(controller.create(dto)).rejects.toThrow(GoneException);
+    expect(service.create).toHaveBeenCalledWith(dto);
+  });
+});

--- a/server/src/modules/warehouse/batch.service.spec.ts
+++ b/server/src/modules/warehouse/batch.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from '../../prisma/prisma.service';
 import { BatchService } from './batch.service';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, GoneException, NotFoundException } from '@nestjs/common';
 import { SupplierAccessService } from './services/supplier-access.service';
 import * as dayjs from 'dayjs';
 
@@ -45,8 +45,7 @@ describe('BatchService', () => {
   });
 
   describe('create', () => {
-    it('should create batch successfully', async () => {
-      // Arrange
+    it('rejects direct manual batch creation with GoneException', async () => {
       const createDto = {
         batchNumber: 'BATCH-20260215-001',
         materialId: 'material-001',
@@ -57,44 +56,27 @@ describe('BatchService', () => {
         supplierBatchNo: 'SUP-001',
       };
 
-      const mockBatch = {
-        id: 'batch-001',
-        ...createDto,
-        status: 'normal',
-        createdAt: new Date(),
-      };
-
-      jest.spyOn(prisma.materialBatch, 'create').mockResolvedValue(mockBatch as any);
-
-      // Act
-      const result = await service.create(createDto);
-
-      // Assert
-      expect(result).toEqual(mockBatch);
-      expect(supplierAccess.assertSupplierUsable).toHaveBeenCalledWith('supplier-001', '创建物料批次');
-    });
-
-    it('should reject batch creation when supplier is not usable', async () => {
-      const createDto = {
-        batchNumber: 'BATCH-20260215-001',
-        materialId: 'material-001',
-        productionDate: new Date('2026-01-01'),
-        expiryDate: new Date('2026-07-01'),
-        quantity: 100,
-        supplierId: 'supplier-001',
-        supplierBatchNo: 'SUP-001',
-      };
-
-      jest
-        .spyOn(supplierAccess, 'assertSupplierUsable')
-        .mockRejectedValue(new BadRequestException('供应商已淘汰'));
-
-      await expect(service.create(createDto as any)).rejects.toThrow(BadRequestException);
+      await expect(service.create(createDto)).rejects.toThrow(GoneException);
       expect(prisma.materialBatch.create).not.toHaveBeenCalled();
     });
 
-    it('should throw BadRequestException if batch number exists', async () => {
-      // Arrange
+    it('rejects direct manual batch creation regardless of supplier status', async () => {
+      const createDto = {
+        batchNumber: 'BATCH-20260215-001',
+        materialId: 'material-001',
+        productionDate: new Date('2026-01-01'),
+        expiryDate: new Date('2026-07-01'),
+        quantity: 100,
+        supplierId: 'supplier-001',
+        supplierBatchNo: 'SUP-001',
+      };
+
+      await expect(service.create(createDto as any)).rejects.toThrow(GoneException);
+      expect(prisma.materialBatch.create).not.toHaveBeenCalled();
+      expect(supplierAccess.assertSupplierUsable).not.toHaveBeenCalled();
+    });
+
+    it('does not attempt Prisma create even when batch number would duplicate', async () => {
       const createDto = {
         batchNumber: 'BATCH-20260215-001',
         materialId: 'material-001',
@@ -103,13 +85,8 @@ describe('BatchService', () => {
         quantity: 100,
       };
 
-      jest.spyOn(prisma.materialBatch, 'create').mockRejectedValue({
-        code: 'P2002',
-        meta: { target: ['batchNumber'] },
-      });
-
-      // Act & Assert
-      await expect(service.create(createDto as any)).rejects.toThrow(BadRequestException);
+      await expect(service.create(createDto as any)).rejects.toThrow(GoneException);
+      expect(prisma.materialBatch.create).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/modules/warehouse/batch.service.ts
+++ b/server/src/modules/warehouse/batch.service.ts
@@ -3,6 +3,7 @@ import {
   Logger,
   NotFoundException,
   BadRequestException,
+  GoneException,
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -18,20 +19,10 @@ export class BatchService {
     private readonly supplierAccess: SupplierAccessService,
   ) {}
 
-  async create(createBatchDto: CreateBatchDto) {
-    if (createBatchDto.supplierId) {
-      await this.supplierAccess.assertSupplierUsable(createBatchDto.supplierId, '创建物料批次');
-    }
-    try {
-      return await this.prisma.materialBatch.create({
-        data: createBatchDto,
-      });
-    } catch (error) {
-      if (error.code === 'P2002') {
-        throw new BadRequestException('Batch number already exists (BR-241)');
-      }
-      throw error;
-    }
+  async create(_createBatchDto: CreateBatchDto) {
+    throw new GoneException(
+      'Direct material batch creation is disabled. Complete a MaterialInbound to create MaterialBatch.',
+    );
   }
 
   async findAll(query: QueryBatchDto) {

--- a/server/src/modules/warehouse/inbound.service.spec.ts
+++ b/server/src/modules/warehouse/inbound.service.spec.ts
@@ -237,6 +237,32 @@ describe('InboundService', () => {
       expect(result.status).toBe('completed');
       expect(batchNumberGenerator.generateBatchNumber).toHaveBeenCalledWith('material');
       expect(prisma.$transaction).toHaveBeenCalled();
+      expect(txClient.materialBatch.create).toHaveBeenCalledWith({
+        data: {
+          batchNumber: 'BATCH-20260215-001',
+          materialId: 'material-001',
+          supplierBatchNo: 'SUP-001',
+          supplierId: 'supplier-001',
+          productionDate: new Date('2026-01-01'),
+          expiryDate: new Date('2026-07-01'),
+          quantity: 100,
+          status: 'normal',
+        },
+      });
+      expect(txClient.stockRecord.create).toHaveBeenCalledWith({
+        data: {
+          batchId: 'batch-001',
+          recordType: 'in',
+          quantity: 100,
+          relatedId: 'inbound-001',
+          relatedType: 'inbound',
+          operatorId: 'user-001',
+        },
+      });
+      expect(txClient.materialInboundItem.update).toHaveBeenCalledWith({
+        where: { id: 'item-001' },
+        data: { createdBatchId: 'batch-001' },
+      });
       expect(inventoryMovementLedger.recordMaterialBatchMovement).toHaveBeenCalledWith(
         expect.objectContaining({ movementType: 'receive', batchId: mockBatch.id }),
         txClient,


### PR DESCRIPTION
## Summary

- `BatchService.create()` now throws `GoneException` (410) for any direct call, blocking manual `POST /warehouse/batches` without a `MaterialInbound` source
- Removed `batchApi.create()` from `client/src/api/warehouse.ts` to prevent new frontend code from accessing the deprecated path
- `InboundService.complete()` is unchanged — it remains the only authorized `MaterialBatch` creation path

## Changes

- `server/src/modules/warehouse/batch.service.ts` — `create()` returns `GoneException`
- `server/src/modules/warehouse/batch.service.spec.ts` — updated create tests to assert `GoneException`
- `server/src/modules/warehouse/batch.controller.spec.ts` — new controller-level test for 410 response
- `server/src/modules/warehouse/inbound.service.spec.ts` — added assertions verifying `InboundService.complete()` still creates `MaterialBatch`, `StockRecord(in)`, and updates `MaterialInboundItem.createdBatchId`
- `client/src/api/warehouse.ts` — removed `batchApi.create()`

## Test plan

- [ ] `npm test --workspace server -- --runTestsByPath src/modules/warehouse/batch.service.spec.ts` passes (14 tests)
- [ ] `npm test --workspace server -- --runTestsByPath src/modules/warehouse/batch.controller.spec.ts` passes (1 test)
- [ ] `npm test --workspace server -- --runTestsByPath src/modules/warehouse/inbound.service.spec.ts` passes (10 tests)
- [ ] `npm run build:client` exits 0
- [ ] No schema or migration changes
- [ ] `rg "batchApi\.create" client/src` returns no results