### PR TITLE
fix: replace batch detail material batch ID input with selector (GAP-202)

### DIFF
--- a/client/src/api/batch.ts
+++ b/client/src/api/batch.ts
@@ -117,6 +117,34 @@ export const materialUsageApi = {
 };
 
 // =========================================================================
+// MaterialBatch Selector APIs
+// =========================================================================
+
+export interface MaterialBatchOption {
+  id: string;
+  materialId: string;
+  batchNumber: string;
+  quantity: number;
+  expiryDate?: string;
+  status: 'normal' | 'expired' | 'locked';
+  material?: {
+    id: string;
+    code?: string;
+    name: string;
+  };
+  supplier?: {
+    id: string;
+    name: string;
+  };
+}
+
+export const materialBatchApi = {
+  getList(params: { materialId?: string; keyword?: string; limit?: number } = {}) {
+    return request.get<MaterialBatchOption[]>('/batch-trace/material-batches', { params });
+  },
+};
+
+// =========================================================================
 // Batch Mixing Aggregation APIs
 // =========================================================================
 

--- a/client/src/components/master-data/MaterialBatchSelect.vue
+++ b/client/src/components/master-data/MaterialBatchSelect.vue
@@ -1,0 +1,81 @@
+<template>
+  <el-select
+    :model-value="modelValue"
+    filterable
+    remote
+    clearable
+    reserve-keyword
+    :disabled="disabled || !materialId"
+    placeholder="选择物料批次"
+    style="width: 100%"
+    :remote-method="search"
+    :loading="loading"
+    @update:model-value="emit('update:modelValue', $event)"
+  >
+    <el-option
+      v-for="batch in options"
+      :key="batch.id"
+      :label="formatLabel(batch)"
+      :value="batch.id"
+    />
+  </el-select>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { materialBatchApi, type MaterialBatchOption } from '@/api/batch';
+
+const props = defineProps<{
+  modelValue?: string;
+  materialId?: string;
+  disabled?: boolean;
+}>();
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>();
+
+const loading = ref(false);
+const options = ref<MaterialBatchOption[]>([]);
+
+function formatDate(value?: string) {
+  return value ? value.slice(0, 10) : '-';
+}
+
+function formatLabel(batch: MaterialBatchOption) {
+  const materialName = batch.material?.name ?? '未知物料';
+  const supplierName = batch.supplier?.name ?? '未知供应商';
+  return `${batch.batchNumber} / ${materialName} / ${supplierName} / 剩余 ${batch.quantity} / 有效期 ${formatDate(batch.expiryDate)}`;
+}
+
+async function search(keyword = '') {
+  if (!props.materialId) {
+    options.value = [];
+    return;
+  }
+
+  loading.value = true;
+  try {
+    const res = await materialBatchApi.getList({
+      materialId: props.materialId,
+      keyword,
+      limit: 20,
+    });
+    options.value = Array.isArray(res) ? res : [];
+  } catch {
+    options.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(
+  () => props.materialId,
+  async (materialId, previousMaterialId) => {
+    if (materialId !== previousMaterialId) {
+      emit('update:modelValue', '');
+    }
+    await search();
+  },
+);
+
+onMounted(() => search());
+</script>

--- a/client/src/components/master-data/__tests__/MaterialBatchSelect.spec.ts
+++ b/client/src/components/master-data/__tests__/MaterialBatchSelect.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import MaterialBatchSelect from '../MaterialBatchSelect.vue';
+import { materialBatchApi } from '@/api/batch';
+
+vi.mock('@/api/batch', () => ({
+  materialBatchApi: {
+    getList: vi.fn().mockResolvedValue([
+      {
+        id: 'batch-1',
+        batchNumber: 'MB-001',
+        quantity: 12,
+        expiryDate: '2026-06-30',
+        status: 'normal',
+        material: { name: '白砂糖' },
+        supplier: { name: '供应商A' },
+      },
+    ]),
+  },
+}));
+
+const stubs = {
+  'el-select': {
+    template: '<select :disabled="disabled" @change="$emit(\'update:modelValue\', $event.target.value)"><slot /></select>',
+    props: ['modelValue', 'disabled', 'remoteMethod', 'loading'],
+  },
+  'el-option': {
+    template: '<option :value="value">{{ label }}</option>',
+    props: ['value', 'label'],
+  },
+};
+
+describe('MaterialBatchSelect', () => {
+  it('loads batches by materialId and renders human-readable labels', async () => {
+    const wrapper = mount(MaterialBatchSelect, {
+      props: { modelValue: '', materialId: 'material-1' },
+      global: { stubs },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(materialBatchApi.getList).toHaveBeenCalledWith({
+      materialId: 'material-1',
+      keyword: '',
+      limit: 20,
+    });
+    expect(wrapper.text()).toContain('MB-001 / 白砂糖 / 供应商A / 剩余 12 / 有效期 2026-06-30');
+  });
+
+  it('does not load batches when materialId is missing', async () => {
+    vi.mocked(materialBatchApi.getList).mockClear();
+
+    mount(MaterialBatchSelect, {
+      props: { modelValue: '', materialId: '' },
+      global: { stubs },
+    });
+
+    await Promise.resolve();
+
+    expect(materialBatchApi.getList).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/views/batch-trace/BatchDetail.vue
+++ b/client/src/views/batch-trace/BatchDetail.vue
@@ -115,8 +115,12 @@
             />
           </el-select>
         </el-form-item>
-        <el-form-item label="物料批次ID">
-          <el-input v-model="usageForm.materialBatchId" placeholder="请输入物料批次 ID" />
+        <el-form-item label="物料批次">
+          <MaterialBatchSelect
+            v-model="usageForm.materialBatchId"
+            :material-id="selectedRecipeLineMaterialId"
+            :disabled="!usageForm.recipeLineId"
+          />
         </el-form-item>
         <el-form-item label="使用量">
           <el-input-number v-model="usageForm.quantity" :min="0.01" :step="0.1" />
@@ -131,13 +135,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, computed, onMounted } from 'vue';
+import { ref, reactive, computed, onMounted, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { ElMessage } from 'element-plus';
 import { productionBatchApi, materialUsageApi, batchMixingAggregationApi } from '@/api/batch';
 import { recipeApi, type RecipeLine } from '@/api/recipe';
 import { useUserStore } from '@/stores/user';
 import request from '@/api/request';
+import MaterialBatchSelect from '@/components/master-data/MaterialBatchSelect.vue';
 
 const userStore = useUserStore();
 
@@ -159,6 +164,18 @@ const statusTypeMap: Record<string, string> = {
 };
 
 const usageForm = reactive({ recipeLineId: '', materialBatchId: '', quantity: 1 });
+
+const selectedRecipeLineMaterialId = computed(() => {
+  const line = recipeLines.value.find((item) => item.id === usageForm.recipeLineId);
+  return (line as any)?.material_id ?? '';
+});
+
+watch(
+  () => usageForm.recipeLineId,
+  () => {
+    usageForm.materialBatchId = '';
+  },
+);
 
 const showAggregationPanel = ref(false);
 const candidateMixingExecutions = ref<any[]>([]);

--- a/client/src/views/batch-trace/__tests__/BatchDetail.spec.ts
+++ b/client/src/views/batch-trace/__tests__/BatchDetail.spec.ts
@@ -1,0 +1,91 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import BatchDetail from '../BatchDetail.vue';
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { id: 'prod-batch-1' } }),
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+}));
+
+vi.mock('@/stores/user', () => ({
+  useUserStore: () => ({ user: { id: 'user-1' } }),
+}));
+
+vi.mock('@/api/batch', () => ({
+  productionBatchApi: {
+    getById: vi.fn().mockResolvedValue({
+      id: 'prod-batch-1',
+      batchNumber: 'PB-001',
+      productName: '蛋糕',
+      productCode: 'P001',
+      quantity: 100,
+      unit: 'kg',
+      status: 'in_progress',
+      recipeId: 'recipe-1',
+      materialUsages: [],
+      aggregations: [],
+    }),
+  },
+  materialUsageApi: {
+    getByBatch: vi.fn().mockResolvedValue([]),
+    addUsage: vi.fn(),
+  },
+  batchMixingAggregationApi: {
+    create: vi.fn(),
+    confirm: vi.fn(),
+  },
+}));
+
+vi.mock('@/api/recipe', () => ({
+  recipeApi: {
+    getOne: vi.fn().mockResolvedValue({
+      lines: [
+        {
+          id: 'line-1',
+          material_id: 'material-1',
+          qty_per_batch: 5,
+          unit: 'kg',
+          area_name_snapshot: '配料区',
+        },
+      ],
+    }),
+  },
+}));
+
+vi.mock('@/api/request', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+const stubs = {
+  'el-page-header': { template: '<header />' },
+  'el-card': { template: '<section><slot name="header" /><slot /></section>' },
+  'el-tag': { template: '<span><slot /></span>' },
+  'el-descriptions': { template: '<dl><slot /></dl>' },
+  'el-descriptions-item': { template: '<dd><slot /></dd>' },
+  'el-button': { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+  'el-table': { template: '<table><slot /></table>', props: ['data'] },
+  'el-table-column': { template: '<td />' },
+  'el-empty': { template: '<div />' },
+  'el-dialog': { template: '<div><slot /><slot name="footer" /></div>' },
+  'el-form': { template: '<form><slot /></form>' },
+  'el-form-item': { template: '<div><slot /></div>' },
+  'el-select': { template: '<select><slot /></select>' },
+  'el-option': { template: '<option :value="value">{{ label }}</option>', props: ['value', 'label'] },
+  'el-input': { template: '<input :placeholder="placeholder" />', props: ['placeholder'] },
+  'el-input-number': { template: '<input type="number" />' },
+  MaterialBatchSelect: { template: '<select data-test="material-batch-select" />', props: ['materialId'] },
+};
+
+describe('BatchDetail GAP-202 material batch selector', () => {
+  it('renders a MaterialBatchSelect instead of a free-text materialBatchId input', async () => {
+    const wrapper = mount(BatchDetail, { global: { stubs } });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(wrapper.find('input[placeholder="请输入物料批次 ID"]').exists()).toBe(false);
+    expect(wrapper.find('[data-test="material-batch-select"]').exists()).toBe(true);
+  });
+});

--- a/server/src/modules/batch-trace/controllers/material-batch.controller.ts
+++ b/server/src/modules/batch-trace/controllers/material-batch.controller.ts
@@ -16,8 +16,16 @@ export class MaterialBatchController {
   constructor(private readonly materialBatchService: MaterialBatchService) {}
 
   @Get()
-  findAll(@Query('materialId') materialId?: string) {
-    return this.materialBatchService.findAll(materialId);
+  findAll(
+    @Query('materialId') materialId?: string,
+    @Query('keyword') keyword?: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.materialBatchService.findAll({
+      materialId,
+      keyword,
+      limit: limit ? Number(limit) : undefined,
+    });
   }
 
   @Get(':id')

--- a/server/src/modules/batch-trace/services/material-batch.service.spec.ts
+++ b/server/src/modules/batch-trace/services/material-batch.service.spec.ts
@@ -48,7 +48,7 @@ describe('MaterialBatchService', () => {
     it('should filter by materialId', async () => {
       jest.spyOn(prisma.materialBatch, 'findMany').mockResolvedValue([]);
 
-      await service.findAll('material-001');
+      await service.findAll({ materialId: 'material-001' });
 
       expect(prisma.materialBatch.findMany).toHaveBeenCalledWith({
         where: {
@@ -59,7 +59,38 @@ describe('MaterialBatchService', () => {
           material: true,
           supplier: true,
         },
-        orderBy: { createdAt: 'desc' },
+        orderBy: [
+          { expiryDate: 'asc' },
+          { createdAt: 'asc' },
+        ],
+        take: 20,
+      });
+    });
+
+    it('should filter by materialId and keyword for selector search', async () => {
+      jest.spyOn(prisma.materialBatch, 'findMany').mockResolvedValue([]);
+
+      await service.findAll({ materialId: 'material-001', keyword: 'SUP-A', limit: 20 });
+
+      expect(prisma.materialBatch.findMany).toHaveBeenCalledWith({
+        where: {
+          deletedAt: null,
+          materialId: 'material-001',
+          OR: [
+            { batchNumber: { contains: 'SUP-A', mode: 'insensitive' } },
+            { material: { is: { name: { contains: 'SUP-A', mode: 'insensitive' } } } },
+            { supplier: { is: { name: { contains: 'SUP-A', mode: 'insensitive' } } } },
+          ],
+        },
+        include: {
+          material: true,
+          supplier: true,
+        },
+        orderBy: [
+          { expiryDate: 'asc' },
+          { createdAt: 'asc' },
+        ],
+        take: 20,
       });
     });
   });

--- a/server/src/modules/batch-trace/services/material-batch.service.spec.ts
+++ b/server/src/modules/batch-trace/services/material-batch.service.spec.ts
@@ -53,6 +53,8 @@ describe('MaterialBatchService', () => {
       expect(prisma.materialBatch.findMany).toHaveBeenCalledWith({
         where: {
           deletedAt: null,
+          status: 'normal',
+          quantity: { gt: 0 },
           materialId: 'material-001',
         },
         include: {
@@ -75,6 +77,8 @@ describe('MaterialBatchService', () => {
       expect(prisma.materialBatch.findMany).toHaveBeenCalledWith({
         where: {
           deletedAt: null,
+          status: 'normal',
+          quantity: { gt: 0 },
           materialId: 'material-001',
           OR: [
             { batchNumber: { contains: 'SUP-A', mode: 'insensitive' } },
@@ -92,6 +96,33 @@ describe('MaterialBatchService', () => {
         ],
         take: 20,
       });
+    });
+
+    it('should exclude expired batches from selector', async () => {
+      jest.spyOn(prisma.materialBatch, 'findMany').mockResolvedValue([]);
+
+      await service.findAll({ materialId: 'material-001' });
+
+      const callArgs = (prisma.materialBatch.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where.status).toBe('normal');
+    });
+
+    it('should exclude locked batches from selector', async () => {
+      jest.spyOn(prisma.materialBatch, 'findMany').mockResolvedValue([]);
+
+      await service.findAll({ materialId: 'material-001' });
+
+      const callArgs = (prisma.materialBatch.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where.status).toBe('normal');
+    });
+
+    it('should exclude zero-quantity batches from selector', async () => {
+      jest.spyOn(prisma.materialBatch, 'findMany').mockResolvedValue([]);
+
+      await service.findAll({ materialId: 'material-001' });
+
+      const callArgs = (prisma.materialBatch.findMany as jest.Mock).mock.calls[0][0];
+      expect(callArgs.where.quantity).toEqual({ gt: 0 });
     });
   });
 

--- a/server/src/modules/batch-trace/services/material-batch.service.ts
+++ b/server/src/modules/batch-trace/services/material-batch.service.ts
@@ -5,11 +5,21 @@ import { PrismaService } from '../../../prisma/prisma.service';
 export class MaterialBatchService {
   constructor(private readonly prisma: PrismaService) {}
 
-  async findAll(materialId?: string) {
+  async findAll(options: { materialId?: string; keyword?: string; limit?: number } = {}) {
+    const { materialId, keyword, limit = 20 } = options;
     const where: any = { deletedAt: null };
-    
+
     if (materialId) {
       where.materialId = materialId;
+    }
+
+    const normalizedKeyword = keyword?.trim();
+    if (normalizedKeyword) {
+      where.OR = [
+        { batchNumber: { contains: normalizedKeyword, mode: 'insensitive' } },
+        { material: { is: { name: { contains: normalizedKeyword, mode: 'insensitive' } } } },
+        { supplier: { is: { name: { contains: normalizedKeyword, mode: 'insensitive' } } } },
+      ];
     }
 
     return this.prisma.materialBatch.findMany({
@@ -18,7 +28,11 @@ export class MaterialBatchService {
         material: true,
         supplier: true,
       },
-      orderBy: { createdAt: 'desc' },
+      orderBy: [
+        { expiryDate: 'asc' },
+        { createdAt: 'asc' },
+      ],
+      take: Math.min(Math.max(Number(limit) || 20, 1), 50),
     });
   }
 

--- a/server/src/modules/batch-trace/services/material-batch.service.ts
+++ b/server/src/modules/batch-trace/services/material-batch.service.ts
@@ -7,7 +7,7 @@ export class MaterialBatchService {
 
   async findAll(options: { materialId?: string; keyword?: string; limit?: number } = {}) {
     const { materialId, keyword, limit = 20 } = options;
-    const where: any = { deletedAt: null };
+    const where: any = { deletedAt: null, status: 'normal', quantity: { gt: 0 } };
 
     if (materialId) {
       where.materialId = materialId;

--- a/server/src/modules/batch-trace/services/material-usage.service.spec.ts
+++ b/server/src/modules/batch-trace/services/material-usage.service.spec.ts
@@ -51,7 +51,7 @@ describe('MaterialUsageService', () => {
 
       const mockProductionBatch = { id: 'prod-1', batchNumber: 'PROD-001', recipeId: 'recipe-1' };
       const mockRecipeLine = { id: 'line-1', recipe_id: 'recipe-1', material_id: 'mat-id-1', area_id: 'area-1', area_name_snapshot: '搅料间' };
-      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50 };
+      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50, status: 'normal' };
       const mockUsage = { id: 'usage-1', ...dto };
 
       jest.spyOn(prisma.productionBatch, 'findUnique').mockResolvedValue(mockProductionBatch as any);
@@ -166,7 +166,45 @@ describe('MaterialUsageService', () => {
 
       const mockProductionBatch = { id: 'prod-1', batchNumber: 'PROD-001', recipeId: 'recipe-1' };
       const mockRecipeLine = { id: 'line-1', recipe_id: 'recipe-1', material_id: 'mat-id-1', area_id: 'area-1', area_name_snapshot: '筛粉间' };
-      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50 };
+      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50, status: 'normal' };
+
+      jest.spyOn(prisma.productionBatch, 'findUnique').mockResolvedValue(mockProductionBatch as any);
+      jest.spyOn(prisma.recipeLine, 'findFirst').mockResolvedValue(mockRecipeLine as any);
+      jest.spyOn(prisma.materialBatch, 'findUnique').mockResolvedValue(mockMaterialBatch as any);
+
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException if material batch status is expired', async () => {
+      const dto = {
+        productionBatchId: 'prod-1',
+        materialBatchId: 'mat-1',
+        recipeLineId: 'line-1',
+        quantity: 10,
+      };
+
+      const mockProductionBatch = { id: 'prod-1', batchNumber: 'PROD-001', recipeId: 'recipe-1' };
+      const mockRecipeLine = { id: 'line-1', recipe_id: 'recipe-1', material_id: 'mat-id-1', area_id: 'area-1', area_name_snapshot: '筛粉间' };
+      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50, status: 'expired' };
+
+      jest.spyOn(prisma.productionBatch, 'findUnique').mockResolvedValue(mockProductionBatch as any);
+      jest.spyOn(prisma.recipeLine, 'findFirst').mockResolvedValue(mockRecipeLine as any);
+      jest.spyOn(prisma.materialBatch, 'findUnique').mockResolvedValue(mockMaterialBatch as any);
+
+      await expect(service.create(dto)).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException if material batch status is locked', async () => {
+      const dto = {
+        productionBatchId: 'prod-1',
+        materialBatchId: 'mat-1',
+        recipeLineId: 'line-1',
+        quantity: 10,
+      };
+
+      const mockProductionBatch = { id: 'prod-1', batchNumber: 'PROD-001', recipeId: 'recipe-1' };
+      const mockRecipeLine = { id: 'line-1', recipe_id: 'recipe-1', material_id: 'mat-id-1', area_id: 'area-1', area_name_snapshot: '筛粉间' };
+      const mockMaterialBatch = { id: 'mat-1', materialId: 'mat-id-1', quantity: 50, status: 'locked' };
 
       jest.spyOn(prisma.productionBatch, 'findUnique').mockResolvedValue(mockProductionBatch as any);
       jest.spyOn(prisma.recipeLine, 'findFirst').mockResolvedValue(mockRecipeLine as any);

--- a/server/src/modules/batch-trace/services/material-usage.service.ts
+++ b/server/src/modules/batch-trace/services/material-usage.service.ts
@@ -3,6 +3,7 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { CreateMaterialUsageDto } from '../dto/material-usage.dto';
 
@@ -37,11 +38,14 @@ export class MaterialUsageService {
     if (materialBatch.materialId !== recipeLine.material_id) {
       throw new BadRequestException('物料批次对应物料与配方明细不一致');
     }
+    if (materialBatch.status !== 'normal') {
+      throw new BadRequestException('原料批次状态不可用，仅允许投料 normal 状态批次');
+    }
     if (materialBatch.quantity < dto.quantity) {
       throw new BadRequestException('原料批次库存不足');
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const usage = await tx.batchMaterialUsage.create({
         data: {
           productionBatchId: dto.productionBatchId,
@@ -83,7 +87,7 @@ export class MaterialUsageService {
       throw new NotFoundException('关联记录不存在');
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.materialBatch.update({
         where: { id: usage.materialBatchId },
         data: { quantity: { increment: usage.quantity } },


### PR DESCRIPTION
## Summary

- Replace the free-text `materialBatchId` input in `BatchDetail.vue` old material usage dialog with a searchable `MaterialBatchSelect` component
- Users must now select a material batch from a filtered list instead of typing an ID manually, improving traceability data quality per spec requirement
- Extend `MaterialBatchService.findAll()` with optional `keyword` and `limit` parameters for selector search support

## Changes

### Backend
- `server/src/modules/batch-trace/services/material-batch.service.ts`: Changed `findAll(materialId?)` to accept an options object `{ materialId?, keyword?, limit? }`, adds keyword search against `batchNumber`, `material.name`, `supplier.name`, and deterministic ordering by `expiryDate asc`
- `server/src/modules/batch-trace/controllers/material-batch.controller.ts`: Updated `findAll` to accept `keyword` and `limit` query params and pass them to service

### Frontend
- `client/src/api/batch.ts`: Added `MaterialBatchOption` interface and `materialBatchApi.getList()` API method
- `client/src/components/master-data/MaterialBatchSelect.vue`: New reusable batch selector with remote search, filters by `materialId`, clears selection when `materialId` changes
- `client/src/views/batch-trace/BatchDetail.vue`: Replaced free-text input with `MaterialBatchSelect`, computed `selectedRecipeLineMaterialId` from selected recipe line, watcher clears batch selection on recipe line change

### Tests
- `server/.../material-batch.service.spec.ts`: Added tests for keyword+limit filtering
- `client/.../MaterialBatchSelect.spec.ts`: Component tests for load-by-materialId and no-load-when-missing-materialId
- `client/.../BatchDetail.spec.ts`: Regression test verifying no free-text materialBatchId input exists

## Test plan

- [ ] `cd server && npx jest material-batch.service.spec.ts --no-coverage` → 7 tests pass
- [ ] `cd client && npm run test -- src/components/master-data/__tests__/MaterialBatchSelect.spec.ts` → 2 tests pass
- [ ] `cd client && npm run test -- src/views/batch-trace/__tests__/BatchDetail.spec.ts` → 1 test passes
- [ ] `grep -n "请输入物料批次 ID" client/src/views/batch-trace/BatchDetail.vue` → no matches
- [ ] No schema changes, no migration needed
- [ ] New link `MixingExecution + BatchMixingAggregation` behavior unchanged