### PR TITLE
feat: GAP-201 restore BatchMixingAggregation as many-to-many bridge

### DIFF
--- a/client/src/views/batch-trace/BatchDetail.vue
+++ b/client/src/views/batch-trace/BatchDetail.vue
@@ -75,6 +75,11 @@
           <div><strong>配料执行号：</strong>{{ agg.mixingExecution?.executionNo }}</div>
           <div><strong>配料区：</strong>{{ agg.mixingExecution?.area?.name }}</div>
           <div><strong>实际配料重量：</strong>{{ agg.mixingExecution?.actual_weight }}</div>
+          <div v-if="isSharedMixingExecution(agg)">
+            <strong>归集方式：</strong>
+            <el-tag type="warning" size="small">共用配料执行</el-tag>
+            <span style="margin-left: 8px">{{ linkedBatchNumbers(agg) }}</span>
+          </div>
           <div><strong>状态：</strong>{{ agg.status }}</div>
         </div>
       </div>
@@ -170,6 +175,19 @@ const confirmingAggregation = ref(false);
 const hasDraftAggregations = computed(() =>
   batch.value?.aggregations?.some((a: any) => a.status === 'draft') ?? false,
 );
+
+const linkedProductionBatches = (agg: any) =>
+  agg?.mixingExecution?.aggregations
+    ?.map((item: any) => item.productionBatch)
+    ?.filter(Boolean) ?? [];
+
+const isSharedMixingExecution = (agg: any) =>
+  linkedProductionBatches(agg).length > 1;
+
+const linkedBatchNumbers = (agg: any) =>
+  linkedProductionBatches(agg)
+    .map((batch: any) => batch.batchNumber || batch.id)
+    .join('、');
 
 const submitAggregationDraft = async () => {
   if (!selectedExecutions.value.length) {

--- a/server/src/modules/batch-trace/services/batch-mixing-aggregation.service.spec.ts
+++ b/server/src/modules/batch-trace/services/batch-mixing-aggregation.service.spec.ts
@@ -53,7 +53,7 @@ describe('BatchMixingAggregationService', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('rejects when an execution is already aggregated to a different product batch', async () => {
+    it('allows one confirmed execution to be aggregated to another matching product batch', async () => {
       prisma.productionBatch.findUnique.mockResolvedValue({
         id: 'pb-new',
         productId: 'product-1',
@@ -62,16 +62,55 @@ describe('BatchMixingAggregationService', () => {
       prisma.mixingExecution.findMany.mockResolvedValue([
         { id: 'mix-1', productId: 'product-1', recipeId: 'recipe-1', status: 'confirmed' },
       ]);
-      prisma.batchMixingAggregation.findMany.mockResolvedValue([
-        { mixingExecutionId: 'mix-1', productionBatchId: 'pb-other' },
-      ]);
+      prisma.$transaction.mockResolvedValue([{ id: 'agg-new', productionBatchId: 'pb-new', mixingExecutionId: 'mix-1' }]);
 
-      await expect(
-        service.create({
-          productionBatchId: 'pb-new',
-          mixingExecutionIds: ['mix-1'],
+      const result = await service.create({
+        productionBatchId: 'pb-new',
+        mixingExecutionIds: ['mix-1'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(prisma.batchMixingAggregation.findMany).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ mixingExecutionId: expect.anything() }),
         }),
-      ).rejects.toThrow(BadRequestException);
+      );
+    });
+
+    it('upserts the same production batch and execution pair instead of creating duplicates', async () => {
+      prisma.productionBatch.findUnique.mockResolvedValue({
+        id: 'pb-1',
+        productId: 'product-1',
+        recipeId: 'recipe-1',
+      });
+      prisma.mixingExecution.findMany.mockResolvedValue([
+        { id: 'mix-1', productId: 'product-1', recipeId: 'recipe-1', status: 'confirmed' },
+      ]);
+      prisma.$transaction.mockResolvedValue([{ id: 'agg-existing', productionBatchId: 'pb-1', mixingExecutionId: 'mix-1' }]);
+
+      await service.create({
+        productionBatchId: 'pb-1',
+        mixingExecutionIds: ['mix-1'],
+        note: 'reuse same pair',
+      });
+
+      expect(prisma.batchMixingAggregation.upsert).toHaveBeenCalledWith({
+        where: {
+          productionBatchId_mixingExecutionId: {
+            productionBatchId: 'pb-1',
+            mixingExecutionId: 'mix-1',
+          },
+        },
+        create: {
+          productionBatchId: 'pb-1',
+          mixingExecutionId: 'mix-1',
+          status: 'draft',
+          note: 'reuse same pair',
+        },
+        update: {
+          note: 'reuse same pair',
+        },
+      });
     });
 
     it('throws when execution product or recipe does not match batch', async () => {

--- a/server/src/modules/batch-trace/services/batch-mixing-aggregation.service.ts
+++ b/server/src/modules/batch-trace/services/batch-mixing-aggregation.service.ts
@@ -41,23 +41,10 @@ export class BatchMixingAggregationService {
       throw new BadRequestException('配料执行与产品批次的产品或配方不一致');
     }
 
-    // BatchMixingAggregation has no quantity-split field, so an execution must
-    // belong to at most one product batch — otherwise a single set of material
-    // usages would be double-counted across two batches in traceability and
-    // material balance. Reject any execution already linked elsewhere.
-    const existingLinks = await this.prisma.batchMixingAggregation.findMany({
-      where: { mixingExecutionId: { in: dto.mixingExecutionIds } },
-      select: { mixingExecutionId: true, productionBatchId: true },
-    });
-    const conflicting = existingLinks.find(
-      (link) => link.productionBatchId !== dto.productionBatchId,
-    );
-    if (conflicting) {
-      throw new BadRequestException(
-        `配料执行 ${conflicting.mixingExecutionId} 已归集到其它产品批次`,
-      );
-    }
-
+    // GAP-201: BatchMixingAggregation is a many-to-many bridge. The composite
+    // unique key keeps one production batch from linking the same execution
+    // twice, while allowing another production batch to share the same input
+    // pool for cross-day packaging traceability.
     const upsertOps = dto.mixingExecutionIds.map((mixingExecutionId) =>
       this.prisma.batchMixingAggregation.upsert({
         where: {

--- a/server/src/modules/batch-trace/services/production-batch.service.ts
+++ b/server/src/modules/batch-trace/services/production-batch.service.ts
@@ -101,6 +101,14 @@ export class ProductionBatchService {
           include: {
             mixingExecution: {
               include: {
+                aggregations: {
+                  include: {
+                    productionBatch: {
+                      select: { id: true, batchNumber: true },
+                    },
+                  },
+                  orderBy: { createdAt: 'asc' },
+                },
                 lines: {
                   include: {
                     materialBatch: true,

--- a/server/src/modules/batch-trace/services/traceability.service.spec.ts
+++ b/server/src/modules/batch-trace/services/traceability.service.spec.ts
@@ -168,6 +168,10 @@ describe('TraceabilityService', () => {
               id: 'mix-1',
               executionNo: 'MIX-20260430-0001',
               area: null,
+              aggregations: [
+                { productionBatch: { id: 'pb-1', batchNumber: 'PB-001' } },
+                { productionBatch: { id: 'pb-2', batchNumber: 'PB-002' } },
+              ],
               lines: [
                 {
                   material: { name: '面粉' },
@@ -186,6 +190,11 @@ describe('TraceabilityService', () => {
       expect(result.nodes.some((node) => node.label.includes('MF20260401'))).toBe(true);
       expect(result.nodes.some((node) => node.type === 'productionBatch')).toBe(true);
       expect(result.nodes.some((node) => node.type === 'mixingExecution')).toBe(true);
+      expect(result.edges).toContainEqual({
+        source: 'pb-1',
+        target: 'mix-1',
+        relation: 'sharedAggregation',
+      });
     });
 
     it('throws NotFoundException if production batch not found', async () => {

--- a/server/src/modules/batch-trace/services/traceability.service.ts
+++ b/server/src/modules/batch-trace/services/traceability.service.ts
@@ -63,6 +63,14 @@ export class TraceabilityService {
             mixingExecution: {
               include: {
                 area: true,
+                aggregations: {
+                  include: {
+                    productionBatch: {
+                      select: { id: true, batchNumber: true },
+                    },
+                  },
+                  orderBy: { createdAt: 'asc' },
+                },
                 lines: {
                   include: {
                     material: true,
@@ -100,10 +108,12 @@ export class TraceabilityService {
         label: execution.executionNo ?? execution.id,
       });
 
+      const linkedBatchCount = execution.aggregations?.length ?? 0;
+
       edges.push({
         source: productionBatch.id,
         target: execution.id,
-        relation: 'aggregation',
+        relation: linkedBatchCount > 1 ? 'sharedAggregation' : 'aggregation',
       });
 
       for (const line of execution.lines ?? []) {

--- a/server/src/prisma/migrations/20260501000300_batch_mixing_aggregation_many_to_many/migration.sql
+++ b/server/src/prisma/migrations/20260501000300_batch_mixing_aggregation_many_to_many/migration.sql
@@ -1,0 +1,8 @@
+-- Restore BatchMixingAggregation as a true many-to-many bridge.
+-- Keep productionBatchId + mixingExecutionId unique, but allow the same
+-- mixing execution to be linked to multiple product batches.
+
+DROP INDEX IF EXISTS "agg_exec_unique";
+
+CREATE INDEX IF NOT EXISTS "batch_mixing_aggregations_mixingExecutionId_idx"
+  ON "batch_mixing_aggregations" ("mixingExecutionId");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1301,7 +1301,7 @@ model BatchMixingAggregation {
   updatedAt         DateTime                     @updatedAt
 
   @@unique([productionBatchId, mixingExecutionId])
-  @@unique([mixingExecutionId], map: "agg_exec_unique")
+  @@index([mixingExecutionId])
   @@map("batch_mixing_aggregations")
 }
 


### PR DESCRIPTION
## Summary

- **Schema**: Remove `agg_exec_unique` (single-column unique on `mixingExecutionId`); keep composite unique `[productionBatchId, mixingExecutionId]`; add regular index on `mixingExecutionId`
- **Migration**: `20260501000300_batch_mixing_aggregation_many_to_many` — DROP INDEX + CREATE INDEX
- **Service**: Remove cross-batch conflict check from `BatchMixingAggregationService.create`; shared mixing executions are now allowed per GAP-201 design
- **Backend reads**: Include sibling `aggregations` metadata in `ProductionBatchService.findOne` and `TraceabilityService.traceProductionBatch`; emit `sharedAggregation` edge when a mixing execution is linked to >1 production batch
- **Frontend**: `BatchDetail.vue` shows "共用配料执行" tag with linked batch numbers when a mixing execution is shared

## Test plan

- [x] `BatchMixingAggregationService` — 9 tests pass (replaced rejection test with allow-shared + idempotency tests)
- [x] `TraceabilityService` — 9 tests pass (sharedAggregation edge assertion added)
- [x] Prisma schema valid (`npx prisma validate`)
- [x] `check-module-usage-docs.mjs` — all 80 GAPs pass
- [x] `jq empty module-usage.manifest.json` — valid JSON
- [x] `git diff --check` — no whitespace errors

## Scope

GAP-201 only. Does NOT touch GAP-202, GAP-203, GAP-204, GAP-206, `MaterialBalanceService`, or `warehouse/` module.