### PR TITLE
fix: GAP-303 filter missing CCPs by batch product/recipe

### DIFF
--- a/server/src/modules/ccp/ccp.service.spec.ts
+++ b/server/src/modules/ccp/ccp.service.spec.ts
@@ -27,16 +27,75 @@ describe('CcpService', () => {
     );
   });
 
-  it('finds missing CCPs only from current company records and points', async () => {
-    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'b1' });
-    prisma.cCPRecord.findMany.mockResolvedValue([{ ccp_point_id: 'p1' }]);
-    prisma.cCPPoint.findMany.mockResolvedValue([{ id: 'p1' }, { id: 'p2' }]);
+  it('finds missing CCPs only from the batch product or recipe', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({
+      id: 'b1',
+      productId: 'prod-1',
+      recipeId: 'recipe-1',
+    });
+    prisma.cCPRecord.findMany.mockResolvedValue([{ ccp_point_id: 'p-product-filled' }]);
+    prisma.cCPPoint.findMany.mockResolvedValue([
+      { id: 'p-product-filled', ccp_no: 'CCP-1' },
+      { id: 'p-recipe-missing', ccp_no: 'CCP-2' },
+    ]);
 
-    await expect(service.findMissingCCPs('b1', '2')).resolves.toEqual([{ id: 'p2' }]);
+    await expect(service.findMissingCCPs('b1', '2')).resolves.toEqual([
+      { id: 'p-recipe-missing', ccp_no: 'CCP-2' },
+    ]);
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'b1' },
+      select: { id: true, productId: true, recipeId: true },
+    });
     expect(prisma.cCPRecord.findMany).toHaveBeenCalledWith({
       where: { production_batch_id: 'b1', company_id: '2' },
       select: { ccp_point_id: true },
     });
-    expect(prisma.cCPPoint.findMany).toHaveBeenCalledWith({ where: { company_id: '2' } });
+    expect(prisma.cCPPoint.findMany).toHaveBeenCalledWith({
+      where: {
+        company_id: '2',
+        deleted_at: null,
+        process_step: {
+          company_id: '2',
+          deleted_at: null,
+          OR: [{ product_id: 'prod-1' }, { recipe_id: 'recipe-1' }],
+        },
+      },
+      orderBy: [{ ccp_no: 'asc' }, { created_at: 'asc' }],
+    });
+  });
+
+  it('returns an empty list when the production batch does not exist', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue(null);
+
+    await expect(service.findMissingCCPs('missing-batch', '2')).resolves.toEqual([]);
+
+    expect(prisma.cCPRecord.findMany).not.toHaveBeenCalled();
+    expect(prisma.cCPPoint.findMany).not.toHaveBeenCalled();
+  });
+
+  it('keeps the company boundary in both recorded and expected CCP queries', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({
+      id: 'b2',
+      productId: 'prod-2',
+      recipeId: 'recipe-2',
+    });
+    prisma.cCPRecord.findMany.mockResolvedValue([]);
+    prisma.cCPPoint.findMany.mockResolvedValue([{ id: 'p-company-2' }]);
+
+    await service.findMissingCCPs('b2', 'company-2');
+
+    expect(prisma.cCPRecord.findMany).toHaveBeenCalledWith({
+      where: { production_batch_id: 'b2', company_id: 'company-2' },
+      select: { ccp_point_id: true },
+    });
+    expect(prisma.cCPPoint.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          company_id: 'company-2',
+          process_step: expect.objectContaining({ company_id: 'company-2' }),
+        }),
+      }),
+    );
   });
 });

--- a/server/src/modules/ccp/ccp.service.ts
+++ b/server/src/modules/ccp/ccp.service.ts
@@ -34,6 +34,7 @@ export class CcpService {
   async findMissingCCPs(productionBatchId: string, companyId: string) {
     const batch = await this.prisma.productionBatch.findUnique({
       where: { id: productionBatchId },
+      select: { id: true, productId: true, recipeId: true },
     });
     if (!batch) return [];
 
@@ -43,10 +44,19 @@ export class CcpService {
     });
     const filledIds = new Set(records.map((r) => r.ccp_point_id));
 
-    const allCCPs = await this.prisma.cCPPoint.findMany({
-      where: { company_id: companyId },
+    const expectedCCPs = await this.prisma.cCPPoint.findMany({
+      where: {
+        company_id: companyId,
+        deleted_at: null,
+        process_step: {
+          company_id: companyId,
+          deleted_at: null,
+          OR: [{ product_id: batch.productId }, { recipe_id: batch.recipeId }],
+        },
+      },
+      orderBy: [{ ccp_no: 'asc' }, { created_at: 'asc' }],
     });
 
-    return allCCPs.filter((c) => !filledIds.has(c.id));
+    return expectedCCPs.filter((ccp) => !filledIds.has(ccp.id));
   }
 }


### PR DESCRIPTION
## Summary
- Fixes GAP-303: `findMissingCCPs()` now filters expected CCP points by the production batch's `productId` / `recipeId` via the `ProcessStep` relation
- Adds `select: { id, productId, recipeId }` to the `productionBatch.findUnique` call
- Replaces the full-company CCP scan with a product/recipe-scoped query using `process_step.product_id OR process_step.recipe_id`
- Adds `deleted_at: null` guards on both `CCPPoint` and `ProcessStep`
- Expands focused unit test coverage to 4 cases: product/recipe filter, batch-not-found early return, company boundary

## Files changed
- `server/src/modules/ccp/ccp.service.ts` — `findMissingCCPs()` implementation
- `server/src/modules/ccp/ccp.service.spec.ts` — focused unit tests

## No schema or migration changes

## Pre-existing unrelated failures (not introduced by this PR)
- `test/task.e2e-spec.ts`, `test/document.e2e-spec.ts`, `test/role.e2e-spec.ts`, `test/training.e2e-spec.ts`, `test/training-service.e2e-spec.ts`, `test/deviation.e2e-spec.ts`, `test/monitoring.e2e-spec.ts`
- `src/modules/document/services/record-form-landing.service.spec.ts`, `test/document-version.service.spec.ts`

## Test plan
- [x] `CcpService` focused unit test: 4 tests pass (`ccp.service.spec.ts --runInBand`)
- [ ] No GAP-303 E2E script exists in this repo (recorded per plan Task 4 Step 2)