### PR TITLE
GAP-203: require batch FK for PackagingMaterialUsage

### DIFF
--- a/client/src/api/packaging-material-usage.ts
+++ b/client/src/api/packaging-material-usage.ts
@@ -7,7 +7,7 @@ import request from './request';
 export interface PackagingMaterialUsage {
   id: string;
   company_id: string;
-  production_batch_id: string | null;
+  production_batch_id: string;
   material_name: string;
   material_code: string | null;
   used_weight: string | null;
@@ -21,9 +21,8 @@ export interface PackagingMaterialUsage {
 }
 
 export interface CreatePackagingMaterialUsagePayload {
-  material_name: string;
-  material_code?: string;
-  production_batch_id?: string;
+  material_id: string;
+  production_batch_id: string;
   used_weight?: number;
   waste_weight?: number;
   unit?: string;

--- a/client/src/views/packaging-material-usage/PackagingMaterialUsageList.vue
+++ b/client/src/views/packaging-material-usage/PackagingMaterialUsageList.vue
@@ -70,10 +70,10 @@
         :rules="formRules"
         label-width="110px"
       >
-        <el-form-item label="物料" prop="material_name">
+        <el-form-item label="物料" prop="material_id">
           <MaterialSelect v-model="form.material_id" />
         </el-form-item>
-        <el-form-item label="生产批次">
+        <el-form-item label="生产批次" prop="production_batch_id">
           <ProductionBatchSelect v-model="form.production_batch_id" />
         </el-form-item>
         <el-form-item label="用量">
@@ -157,7 +157,8 @@ const form = reactive({
 });
 
 const formRules: FormRules = {
-  material_name: [{ required: true, message: '请选择物料', trigger: 'change' }],
+  material_id: [{ required: true, message: '请选择物料', trigger: 'change' }],
+  production_batch_id: [{ required: true, message: '请选择生产批次', trigger: 'change' }],
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -213,9 +214,8 @@ async function handleCreate() {
   submitting.value = true;
   try {
     await packagingMaterialUsageApi.create({
-      material_name: form.material_name || form.material_id,
-      material_code: form.material_code || undefined,
-      production_batch_id: form.production_batch_id || undefined,
+      material_id: form.material_id,
+      production_batch_id: form.production_batch_id,
       used_weight: form.used_weight,
       waste_weight: form.waste_weight,
       unit: form.unit || undefined,

--- a/server/src/modules/packaging-material-usage/dto/create-packaging-material-usage.dto.ts
+++ b/server/src/modules/packaging-material-usage/dto/create-packaging-material-usage.dto.ts
@@ -14,9 +14,9 @@ export class CreatePackagingMaterialUsageDto {
   @IsString()
   material_code?: string;
 
-  @IsOptional()
   @IsString()
-  production_batch_id?: string;
+  @IsNotEmpty()
+  production_batch_id: string;
 
   @IsOptional()
   @IsNumber()

--- a/server/src/modules/packaging-material-usage/packaging-material-usage.service.spec.ts
+++ b/server/src/modules/packaging-material-usage/packaging-material-usage.service.spec.ts
@@ -1,0 +1,107 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { PackagingMaterialUsageService } from './packaging-material-usage.service';
+
+describe('PackagingMaterialUsageService', () => {
+  const activeMaterial = {
+    id: 'mat-1',
+    name: '包装膜',
+    materialCode: 'PM-001',
+    unit: 'kg',
+  };
+
+  it('rejects creation when production_batch_id is missing', async () => {
+    const prisma: any = {
+      material: {
+        findFirst: jest.fn().mockResolvedValue(activeMaterial),
+      },
+      productionBatch: {
+        findUnique: jest.fn(),
+      },
+      packagingMaterialUsage: {
+        create: jest.fn(),
+      },
+    };
+    const service = new PackagingMaterialUsageService(prisma);
+
+    await expect(
+      service.create({
+        material_id: 'mat-1',
+        used_weight: 12.5,
+      } as any),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.productionBatch.findUnique).not.toHaveBeenCalled();
+    expect(prisma.packagingMaterialUsage.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when the production batch does not exist', async () => {
+    const prisma: any = {
+      material: {
+        findFirst: jest.fn().mockResolvedValue(activeMaterial),
+      },
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      packagingMaterialUsage: {
+        create: jest.fn(),
+      },
+    };
+    const service = new PackagingMaterialUsageService(prisma);
+
+    await expect(
+      service.create({
+        material_id: 'mat-1',
+        production_batch_id: 'missing-batch',
+        used_weight: 12.5,
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true },
+    });
+    expect(prisma.packagingMaterialUsage.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a packaging material usage linked to an existing production batch', async () => {
+    const prisma: any = {
+      material: {
+        findFirst: jest.fn().mockResolvedValue(activeMaterial),
+      },
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1' }),
+      },
+      packagingMaterialUsage: {
+        create: jest.fn().mockResolvedValue({ id: 'pmu-1' }),
+      },
+    };
+    const service = new PackagingMaterialUsageService(prisma);
+
+    await service.create({
+      material_id: 'mat-1',
+      production_batch_id: 'batch-1',
+      used_weight: 12.5,
+      waste_weight: 0.2,
+      unit: 'kg',
+      usage_date: '2026-05-01T08:30:00.000Z',
+      operator_id: 'user-1',
+      notes: '包装线A',
+    });
+
+    expect(prisma.packagingMaterialUsage.create).toHaveBeenCalledWith({
+      data: {
+        company_id: '1',
+        production_batch_id: 'batch-1',
+        material_id: 'mat-1',
+        material_name: '包装膜',
+        material_code: 'PM-001',
+        used_weight: 12.5,
+        waste_weight: 0.2,
+        unit: 'kg',
+        usage_date: new Date('2026-05-01T08:30:00.000Z'),
+        operator_id: 'user-1',
+        notes: '包装线A',
+      },
+    });
+  });
+});

--- a/server/src/modules/packaging-material-usage/packaging-material-usage.service.ts
+++ b/server/src/modules/packaging-material-usage/packaging-material-usage.service.ts
@@ -20,13 +20,15 @@ export class PackagingMaterialUsageService {
     });
     if (!material) throw new BadRequestException('物料不存在或已停用');
 
-    if (dto.production_batch_id) {
-      const batch = await this.prisma.productionBatch.findUnique({
-        where: { id: dto.production_batch_id },
-        select: { id: true },
-      });
-      if (!batch) throw new NotFoundException('生产批次不存在');
+    if (!dto.production_batch_id) {
+      throw new BadRequestException('生产批次不能为空');
     }
+
+    const batch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.production_batch_id },
+      select: { id: true },
+    });
+    if (!batch) throw new NotFoundException('生产批次不存在');
 
     return this.prisma.packagingMaterialUsage.create({
       data: {

--- a/server/src/prisma/migrations/20260501103000_require_packaging_material_usage_batch_id/migration.sql
+++ b/server/src/prisma/migrations/20260501103000_require_packaging_material_usage_batch_id/migration.sql
@@ -1,0 +1,29 @@
+-- Require every PackagingMaterialUsage in the production traceability chain to link to a ProductionBatch.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "PackagingMaterialUsage" WHERE "production_batch_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require PackagingMaterialUsage.production_batch_id: legacy rows with NULL production_batch_id exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "PackagingMaterialUsage" pmu
+    LEFT JOIN "production_batches" pb ON pb."id" = pmu."production_batch_id"
+    WHERE pb."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add PackagingMaterialUsage.production_batch_id FK: orphan production_batch_id rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "PackagingMaterialUsage" DROP CONSTRAINT IF EXISTS "PackagingMaterialUsage_production_batch_id_fkey";
+ALTER TABLE "PackagingMaterialUsage" ALTER COLUMN "production_batch_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "PackagingMaterialUsage_production_batch_id_idx"
+  ON "PackagingMaterialUsage"("production_batch_id");
+
+ALTER TABLE "PackagingMaterialUsage"
+  ADD CONSTRAINT "PackagingMaterialUsage_production_batch_id_fkey"
+  FOREIGN KEY ("production_batch_id") REFERENCES "production_batches"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1497,6 +1497,7 @@ model ProductionBatch {
   team             Team?       @relation(fields: [team_id], references: [id])
   shift_type       ShiftType?  @relation(fields: [shift_type_id], references: [id])
   aggregations     BatchMixingAggregation[]
+  packagingMaterialUsages PackagingMaterialUsage[]
 
   // 食品安全扩展字段
   output_qty      Decimal?  @db.Decimal(14, 4)
@@ -3635,7 +3636,8 @@ model ExternalParty {
 model PackagingMaterialUsage {
   id                  String    @id @default(cuid())
   company_id          String
-  production_batch_id String?
+  production_batch_id String
+  production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
   material_id         String?
   material            Material? @relation(fields: [material_id], references: [id], onDelete: SetNull)
   material_name       String
@@ -3649,6 +3651,7 @@ model PackagingMaterialUsage {
   created_at          DateTime  @default(now())
   deleted_at          DateTime?
 
+  @@index([production_batch_id])
   @@index([material_id])
 }
 


### PR DESCRIPTION
## Summary

- `PackagingMaterialUsage.production_batch_id` 改为非空 `String`，添加 FK 指向 `ProductionBatch.id`（`onDelete: Restrict`）及批次索引
- `ProductionBatch` 增加 `packagingMaterialUsages PackagingMaterialUsage[]` 反向 relation
- Migration 含 preflight 预检查：若存在 NULL 或 orphan 行则抛错停止，不做自动回填
- `CreatePackagingMaterialUsageDto.production_batch_id` 改为必填（`@IsString() @IsNotEmpty()`）
- Service 增加显式 `BadRequestException` 门禁，缺少批次时直接报 400，不存在时报 404
- Client API 类型更新：读取对象和创建 payload 的 `production_batch_id` 均为必填 `string`
- Vue 表单：物料和生产批次均设为必填验证，提交不再转为 `undefined`
- 新增 focused Jest spec：3 个测试覆盖缺失批次、批次不存在、正常创建

## 验收

- `npx prisma validate` ✅（需 DATABASE_URL）
- `npm test -- packaging-material-usage.service.spec.ts --runInBand` ✅ 3 passed
- `npm run build:client` ✅ built in 20s
- GAP-203 E2E: 当前仓库无 GAP-203 Playwright 测试用例（`No tests found`），以上三项作为替代验证