### PR TITLE
fix: GAP-301 require production batch for fragile item inspections

### DIFF
--- a/client/src/api/fragile-item-inspection.ts
+++ b/client/src/api/fragile-item-inspection.ts
@@ -7,7 +7,7 @@ import request from './request';
 export interface FragileItemInspection {
   id: string;
   company_id: string;
-  production_batch_id: string | null;
+  production_batch_id: string;
   location: string | null;
   item_name: string;
   total_qty: number;
@@ -20,7 +20,7 @@ export interface FragileItemInspection {
 }
 
 export interface CreateFragileItemInspectionPayload {
-  production_batch_id?: string;
+  production_batch_id: string;
   location?: string;
   item_name: string;
   total_qty: number;

--- a/client/src/views/fragile-item-inspection/FragileItemInspectionList.vue
+++ b/client/src/views/fragile-item-inspection/FragileItemInspectionList.vue
@@ -137,8 +137,8 @@
             placeholder="发现破损时的处置措施"
           />
         </el-form-item>
-        <el-form-item label="批次号">
-          <el-input v-model="createForm.production_batch_id" placeholder="可选" />
+        <el-form-item label="生产批次" prop="production_batch_id">
+          <ProductionBatchSelect v-model="createForm.production_batch_id" />
         </el-form-item>
       </el-form>
       <template #footer>
@@ -155,6 +155,7 @@ import { ElMessage } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import type { FormInstance, FormRules } from 'element-plus';
 import fragileItemInspectionApi, { type FragileItemInspection } from '@/api/fragile-item-inspection';
+import ProductionBatchSelect from '@/components/master-data/ProductionBatchSelect.vue';
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
@@ -184,6 +185,7 @@ const createRules: FormRules = {
   inspected_at: [{ required: true, message: '请选择检查时间', trigger: 'change' }],
   total_qty: [{ required: true, message: '请输入总数量', trigger: 'blur' }],
   intact_qty: [{ required: true, message: '请输入完好数量', trigger: 'blur' }],
+  production_batch_id: [{ required: true, message: '请选择生产批次', trigger: 'change' }],
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -240,7 +242,7 @@ async function handleCreate() {
       intact_qty: createForm.intact_qty!,
       is_pass: createForm.is_pass,
       damage_action: createForm.damage_action || undefined,
-      production_batch_id: createForm.production_batch_id || undefined,
+      production_batch_id: createForm.production_batch_id,
     });
     ElMessage.success('新建成功');
     createDialogVisible.value = false;

--- a/server/src/modules/fragile-item-inspection/dto/create-fragile-item-inspection.dto.ts
+++ b/server/src/modules/fragile-item-inspection/dto/create-fragile-item-inspection.dto.ts
@@ -1,9 +1,9 @@
-import { IsString, IsOptional, IsBoolean, IsInt, IsDateString } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsInt, IsDateString, IsNotEmpty } from 'class-validator';
 
 export class CreateFragileItemInspectionDto {
-  @IsOptional()
   @IsString()
-  production_batch_id?: string;
+  @IsNotEmpty()
+  production_batch_id: string;
 
   @IsOptional()
   @IsString()

--- a/server/src/modules/fragile-item-inspection/fragile-item-inspection.service.spec.ts
+++ b/server/src/modules/fragile-item-inspection/fragile-item-inspection.service.spec.ts
@@ -1,0 +1,70 @@
+import { BadRequestException } from '@nestjs/common';
+import { FragileItemInspectionService } from './fragile-item-inspection.service';
+
+describe('FragileItemInspectionService', () => {
+  it('rejects creation when the production batch does not exist', async () => {
+    const prisma: any = {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue(null),
+      },
+      fragileItemInspection: {
+        create: jest.fn(),
+      },
+    };
+    const service = new FragileItemInspectionService(prisma);
+
+    await expect(
+      service.create({
+        production_batch_id: 'missing-batch',
+        item_name: '玻璃量杯',
+        total_qty: 10,
+        intact_qty: 10,
+        is_pass: true,
+        inspected_at: '2026-05-01T09:00:00',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true },
+    });
+    expect(prisma.fragileItemInspection.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an inspection linked to an existing production batch', async () => {
+    const prisma: any = {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1' }),
+      },
+      fragileItemInspection: {
+        create: jest.fn().mockResolvedValue({ id: 'fii-1' }),
+      },
+    };
+    const service = new FragileItemInspectionService(prisma);
+
+    await service.create({
+      production_batch_id: 'batch-1',
+      location: '生产车间A区',
+      item_name: '玻璃量杯',
+      total_qty: 10,
+      intact_qty: 10,
+      is_pass: true,
+      inspected_at: '2026-05-01T09:00:00',
+      inspector_id: 'user-1',
+    });
+
+    expect(prisma.fragileItemInspection.create).toHaveBeenCalledWith({
+      data: {
+        production_batch_id: 'batch-1',
+        location: '生产车间A区',
+        item_name: '玻璃量杯',
+        total_qty: 10,
+        intact_qty: 10,
+        is_pass: true,
+        inspected_at: expect.any(Date),
+        inspector_id: 'user-1',
+        company_id: '1',
+      },
+    });
+  });
+});

--- a/server/src/modules/fragile-item-inspection/fragile-item-inspection.service.ts
+++ b/server/src/modules/fragile-item-inspection/fragile-item-inspection.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateFragileItemInspectionDto } from './dto/create-fragile-item-inspection.dto';
 
@@ -7,6 +7,15 @@ export class FragileItemInspectionService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateFragileItemInspectionDto) {
+    const productionBatch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.production_batch_id },
+      select: { id: true },
+    });
+
+    if (!productionBatch) {
+      throw new BadRequestException('生产批次不存在');
+    }
+
     return this.prisma.fragileItemInspection.create({
       data: {
         ...dto,

--- a/server/src/prisma/migrations/20260501100000_require_fragile_item_inspection_batch_id/migration.sql
+++ b/server/src/prisma/migrations/20260501100000_require_fragile_item_inspection_batch_id/migration.sql
@@ -1,0 +1,29 @@
+-- Require every FragileItemInspection in the quality release chain to link to a ProductionBatch.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "FragileItemInspection" WHERE "production_batch_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require FragileItemInspection.production_batch_id: legacy rows with NULL production_batch_id exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "FragileItemInspection" fii
+    LEFT JOIN "production_batches" pb ON pb."id" = fii."production_batch_id"
+    WHERE pb."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add FragileItemInspection.production_batch_id FK: orphan production_batch_id rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "FragileItemInspection" DROP CONSTRAINT IF EXISTS "FragileItemInspection_production_batch_id_fkey";
+ALTER TABLE "FragileItemInspection" ALTER COLUMN "production_batch_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "FragileItemInspection_production_batch_id_idx"
+  ON "FragileItemInspection"("production_batch_id");
+
+ALTER TABLE "FragileItemInspection"
+  ADD CONSTRAINT "FragileItemInspection_production_batch_id_fkey"
+  FOREIGN KEY ("production_batch_id") REFERENCES "production_batches"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1523,6 +1523,7 @@ model ProductionBatch {
   process_monitor_records ProcessMonitorRecord[]
   metal_detection_logs    MetalDetectionLog[]
   environment_records     EnvironmentRecord[]
+  fragile_item_inspections FragileItemInspection[]
 
   production_run_id String?
   production_run    ProductionRun? @relation(fields: [production_run_id], references: [id], onDelete: SetNull)
@@ -3535,7 +3536,8 @@ model AssetLoanRecord {
 model FragileItemInspection {
   id                  String    @id @default(cuid())
   company_id          String
-  production_batch_id String?
+  production_batch_id String
+  production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
   location            String?
   item_name           String
   total_qty           Int
@@ -3545,6 +3547,8 @@ model FragileItemInspection {
   inspected_at        DateTime
   inspector_id        String?
   created_at          DateTime  @default(now())
+
+  @@index([production_batch_id])
 }
 
 model ChangeComplianceRecord {


### PR DESCRIPTION
## Summary

- Adds database-level non-null FK from `FragileItemInspection.production_batch_id` to `ProductionBatch.id`
- `ProductionBatch` gains `fragile_item_inspections` reverse relation for traceability queries
- Guarded migration with preflight: fails fast if NULL or orphan rows exist (no silent data backfill)
- NestJS service validates batch existence before write, returns 400 `生产批次不存在` if missing
- DTO `@IsNotEmpty()` ensures 400 at API gateway if field is absent
- Client API type narrowed from `string | null` to `string`
- Form replaces optional free-text input with `ProductionBatchSelect` (required field)

## Verification

- `npx prisma validate` — PASS
- `npm test -- fragile-item-inspection.service.spec.ts --runInBand` — 2 tests PASS (RED → GREEN)
- `npm run build -w client` — PASS

## Test plan

- [ ] Create a fragile item inspection record in the UI — batch selector is required (cannot submit without selection)
- [ ] POST `/fragile-item-inspections` with missing `production_batch_id` returns 400
- [ ] POST `/fragile-item-inspections` with non-existent `production_batch_id` returns 400 `生产批次不存在`
- [ ] Existing records with valid batch IDs are unaffected
- [ ] `run_migration` in staging — migration passes if no NULL or orphan rows