### PR TITLE
[GAP-310] require production batch for customer complaints

### DIFF
--- a/client/src/api/customer-complaint.ts
+++ b/client/src/api/customer-complaint.ts
@@ -11,7 +11,7 @@ export interface CustomerComplaint {
   company_id: string;
   complaint_no: string;
   customer_name: string;
-  production_batch_id: string | null;
+  production_batch_id: string;
   received_at: string;
   complaint_type: string | null;
   description: string;
@@ -24,7 +24,7 @@ export interface CustomerComplaint {
 
 export interface CreateComplaintPayload {
   customer_name: string;
-  production_batch_id?: string;
+  production_batch_id: string;
   description: string;
   complaint_type?: string;
 }

--- a/client/src/views/customer-complaint/CustomerComplaintList.vue
+++ b/client/src/views/customer-complaint/CustomerComplaintList.vue
@@ -155,6 +155,7 @@ const createForm = reactive({
 
 const createRules: FormRules = {
   customer_name: [{ required: true, message: '请输入顾客名称', trigger: 'blur' }],
+  production_batch_id: [{ required: true, message: '请选择相关批次', trigger: 'change' }],
   description: [{ required: true, message: '请填写投诉描述', trigger: 'blur' }],
 };
 
@@ -217,7 +218,7 @@ async function handleCreate() {
     await customerComplaintApi.create({
       customer_name: createForm.customer_name,
       complaint_type: createForm.complaint_type || undefined,
-      production_batch_id: createForm.production_batch_id || undefined,
+      production_batch_id: createForm.production_batch_id,
       description: createForm.description,
     });
     ElMessage.success('新建成功');

--- a/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
@@ -11,6 +11,9 @@ describe('CustomerComplaintService', () => {
       update: jest.fn(),
     },
     productionBatch: {
+      findUnique: jest.fn(),
+    },
+    product: {
       findFirst: jest.fn(),
     },
   };
@@ -32,12 +35,12 @@ describe('CustomerComplaintService', () => {
       ),
     ).rejects.toThrow('生产批次不能为空');
 
-    expect(prisma.productionBatch.findFirst).not.toHaveBeenCalled();
+    expect(prisma.productionBatch.findUnique).not.toHaveBeenCalled();
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
   it('rejects creation when the production batch does not exist', async () => {
-    prisma.productionBatch.findFirst.mockResolvedValue(null);
+    prisma.productionBatch.findUnique.mockResolvedValue(null);
 
     await expect(
       service.create(
@@ -50,15 +53,17 @@ describe('CustomerComplaintService', () => {
       ),
     ).rejects.toThrow('生产批次不存在或不属于当前公司');
 
-    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
-      where: { id: 'missing-batch', product: { company_id: '2' } },
-      select: { id: true },
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true, productId: true },
     });
+    expect(prisma.product.findFirst).not.toHaveBeenCalled();
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
   it('rejects creation when production batch belongs to a different company', async () => {
-    prisma.productionBatch.findFirst.mockResolvedValue(null);
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'other-company-batch', productId: 'prod-x' });
+    prisma.product.findFirst.mockResolvedValue(null);
 
     await expect(
       service.create(
@@ -71,15 +76,20 @@ describe('CustomerComplaintService', () => {
       ),
     ).rejects.toThrow('生产批次不存在或不属于当前公司');
 
-    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
-      where: { id: 'other-company-batch', product: { company_id: 'company-A' } },
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'other-company-batch' },
+      select: { id: true, productId: true },
+    });
+    expect(prisma.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-x', company_id: 'company-A' },
       select: { id: true },
     });
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
   it('scopes complaint numbering and writes by company', async () => {
-    prisma.productionBatch.findFirst.mockResolvedValue({ id: 'batch-1' });
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1', productId: 'prod-1' });
+    prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
     prisma.customerComplaint.count.mockResolvedValue(5);
     prisma.customerComplaint.create.mockResolvedValue({ id: 'cc1' });
 
@@ -92,8 +102,12 @@ describe('CustomerComplaintService', () => {
       '2',
     );
 
-    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
-      where: { id: 'batch-1', product: { company_id: '2' } },
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'batch-1' },
+      select: { id: true, productId: true },
+    });
+    expect(prisma.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-1', company_id: '2' },
       select: { id: true },
     });
     expect(prisma.customerComplaint.count).toHaveBeenCalledWith({ where: { company_id: '2' } });

--- a/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
@@ -11,7 +11,7 @@ describe('CustomerComplaintService', () => {
       update: jest.fn(),
     },
     productionBatch: {
-      findUnique: jest.fn(),
+      findFirst: jest.fn(),
     },
   };
   let service: CustomerComplaintService;
@@ -32,12 +32,12 @@ describe('CustomerComplaintService', () => {
       ),
     ).rejects.toThrow('生产批次不能为空');
 
-    expect(prisma.productionBatch.findUnique).not.toHaveBeenCalled();
+    expect(prisma.productionBatch.findFirst).not.toHaveBeenCalled();
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
   it('rejects creation when the production batch does not exist', async () => {
-    prisma.productionBatch.findUnique.mockResolvedValue(null);
+    prisma.productionBatch.findFirst.mockResolvedValue(null);
 
     await expect(
       service.create(
@@ -48,17 +48,38 @@ describe('CustomerComplaintService', () => {
         },
         '2',
       ),
-    ).rejects.toThrow('生产批次不存在');
+    ).rejects.toThrow('生产批次不存在或不属于当前公司');
 
-    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
-      where: { id: 'missing-batch' },
+    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
+      where: { id: 'missing-batch', product: { company_id: '2' } },
+      select: { id: true },
+    });
+    expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when production batch belongs to a different company', async () => {
+    prisma.productionBatch.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        {
+          customer_name: '客户',
+          production_batch_id: 'other-company-batch',
+          description: '投诉',
+        },
+        'company-A',
+      ),
+    ).rejects.toThrow('生产批次不存在或不属于当前公司');
+
+    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
+      where: { id: 'other-company-batch', product: { company_id: 'company-A' } },
       select: { id: true },
     });
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
   it('scopes complaint numbering and writes by company', async () => {
-    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1' });
+    prisma.productionBatch.findFirst.mockResolvedValue({ id: 'batch-1' });
     prisma.customerComplaint.count.mockResolvedValue(5);
     prisma.customerComplaint.create.mockResolvedValue({ id: 'cc1' });
 
@@ -71,8 +92,8 @@ describe('CustomerComplaintService', () => {
       '2',
     );
 
-    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
-      where: { id: 'batch-1' },
+    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
+      where: { id: 'batch-1', product: { company_id: '2' } },
       select: { id: true },
     });
     expect(prisma.customerComplaint.count).toHaveBeenCalledWith({ where: { company_id: '2' } });

--- a/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
@@ -10,6 +10,9 @@ describe('CustomerComplaintService', () => {
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    productionBatch: {
+      findUnique: jest.fn(),
+    },
   };
   let service: CustomerComplaintService;
 
@@ -18,15 +21,69 @@ describe('CustomerComplaintService', () => {
     service = new CustomerComplaintService(prisma as any);
   });
 
+  it('rejects creation when production_batch_id is missing', async () => {
+    await expect(
+      service.create(
+        {
+          customer_name: '客户',
+          description: '投诉',
+        } as any,
+        '2',
+      ),
+    ).rejects.toThrow('生产批次不能为空');
+
+    expect(prisma.productionBatch.findUnique).not.toHaveBeenCalled();
+    expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when the production batch does not exist', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        {
+          customer_name: '客户',
+          production_batch_id: 'missing-batch',
+          description: '投诉',
+        },
+        '2',
+      ),
+    ).rejects.toThrow('生产批次不存在');
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true },
+    });
+    expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
+  });
+
   it('scopes complaint numbering and writes by company', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1' });
     prisma.customerComplaint.count.mockResolvedValue(5);
     prisma.customerComplaint.create.mockResolvedValue({ id: 'cc1' });
 
-    await service.create({ customer_name: '客户', description: '投诉' }, '2');
+    await service.create(
+      {
+        customer_name: '客户',
+        production_batch_id: 'batch-1',
+        description: '投诉',
+      },
+      '2',
+    );
 
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'batch-1' },
+      select: { id: true },
+    });
     expect(prisma.customerComplaint.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
     expect(prisma.customerComplaint.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ company_id: '2', complaint_no: expect.stringMatching(/-0006$/) }) }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          company_id: '2',
+          complaint_no: expect.stringMatching(/-0006$/),
+          production_batch_id: 'batch-1',
+        }),
+      }),
     );
   });
 

--- a/server/src/modules/customer-complaint/customer-complaint.service.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.ts
@@ -11,13 +11,13 @@ export class CustomerComplaintService {
       throw new BadRequestException('生产批次不能为空');
     }
 
-    const productionBatch = await this.prisma.productionBatch.findUnique({
-      where: { id: dto.production_batch_id },
+    const productionBatch = await this.prisma.productionBatch.findFirst({
+      where: { id: dto.production_batch_id, product: { company_id: companyId } },
       select: { id: true },
     });
 
     if (!productionBatch) {
-      throw new BadRequestException('生产批次不存在');
+      throw new BadRequestException('生产批次不存在或不属于当前公司');
     }
 
     const count = await this.prisma.customerComplaint.count({ where: { company_id: companyId } });

--- a/server/src/modules/customer-complaint/customer-complaint.service.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateComplaintDto } from './dto/create-complaint.dto';
 
@@ -7,6 +7,19 @@ export class CustomerComplaintService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateComplaintDto, companyId: string) {
+    if (!dto.production_batch_id) {
+      throw new BadRequestException('生产批次不能为空');
+    }
+
+    const productionBatch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.production_batch_id },
+      select: { id: true },
+    });
+
+    if (!productionBatch) {
+      throw new BadRequestException('生产批次不存在');
+    }
+
     const count = await this.prisma.customerComplaint.count({ where: { company_id: companyId } });
     const complaint_no = `CC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
     return this.prisma.customerComplaint.create({

--- a/server/src/modules/customer-complaint/customer-complaint.service.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.ts
@@ -11,12 +11,21 @@ export class CustomerComplaintService {
       throw new BadRequestException('生产批次不能为空');
     }
 
-    const productionBatch = await this.prisma.productionBatch.findFirst({
-      where: { id: dto.production_batch_id, product: { company_id: companyId } },
+    const productionBatch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.production_batch_id },
+      select: { id: true, productId: true },
+    });
+
+    if (!productionBatch || !productionBatch.productId) {
+      throw new BadRequestException('生产批次不存在或不属于当前公司');
+    }
+
+    const product = await this.prisma.product.findFirst({
+      where: { id: productionBatch.productId, company_id: companyId },
       select: { id: true },
     });
 
-    if (!productionBatch) {
+    if (!product) {
       throw new BadRequestException('生产批次不存在或不属于当前公司');
     }
 

--- a/server/src/modules/customer-complaint/dto/create-complaint.dto.ts
+++ b/server/src/modules/customer-complaint/dto/create-complaint.dto.ts
@@ -1,8 +1,10 @@
-import { IsString, IsOptional } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateComplaintDto {
   @IsString() customer_name: string;
-  @IsOptional() @IsString() production_batch_id?: string;
+  @IsString()
+  @IsNotEmpty()
+  production_batch_id: string;
   @IsString() description: string;
   @IsOptional() @IsString() complaint_type?: string;
 }

--- a/server/src/prisma/migrations/20260502093000_require_customer_complaint_batch_id/migration.sql
+++ b/server/src/prisma/migrations/20260502093000_require_customer_complaint_batch_id/migration.sql
@@ -1,0 +1,29 @@
+-- Require every CustomerComplaint in the recall and traceability chain to link to a ProductionBatch.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "CustomerComplaint" WHERE "production_batch_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require CustomerComplaint.production_batch_id: legacy rows with NULL production_batch_id exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "CustomerComplaint" cc
+    LEFT JOIN "production_batches" pb ON pb."id" = cc."production_batch_id"
+    WHERE pb."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add CustomerComplaint.production_batch_id FK: orphan production_batch_id rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "CustomerComplaint" DROP CONSTRAINT IF EXISTS "CustomerComplaint_production_batch_id_fkey";
+ALTER TABLE "CustomerComplaint" ALTER COLUMN "production_batch_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "CustomerComplaint_production_batch_id_idx"
+  ON "CustomerComplaint"("production_batch_id");
+
+ALTER TABLE "CustomerComplaint"
+  ADD CONSTRAINT "CustomerComplaint_production_batch_id_fkey"
+  FOREIGN KEY ("production_batch_id") REFERENCES "production_batches"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1484,6 +1484,7 @@ model ProductionBatch {
   materialBalances MaterialBalance[]    @relation("MaterialBalanceProductionBatch")
   // TASK-169: 动态表单记录关联
   relatedRecords   Record[]             @relation("RecordProductionBatch")
+  customer_complaints CustomerComplaint[]
 
   // 班组排班扩展字段
   team_id          String?
@@ -3108,7 +3109,8 @@ model CustomerComplaint {
   company_id          String
   complaint_no        String
   customer_name       String
-  production_batch_id String?
+  production_batch_id String
+  production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
   received_at         DateTime
   complaint_type      String?
   description         String
@@ -3118,6 +3120,7 @@ model CustomerComplaint {
   created_at          DateTime  @default(now())
   updated_at          DateTime  @updatedAt
   @@unique([company_id, complaint_no])
+  @@index([production_batch_id])
 }
 
 model ReworkRecord {


### PR DESCRIPTION
## Summary
- Add non-null FK from `CustomerComplaint.production_batch_id` to `ProductionBatch.id` (schema + migration)
- Guard migration with preflight checks: fails fast on NULL or orphan rows
- Service validates batch existence before create, returning 400 with clear error messages
- DTO makes `production_batch_id` required with `@IsNotEmpty`
- Frontend form validates the batch selector is required before submit

## Verification
- `prisma validate`: PASS
- `npm test -- customer-complaint.service.spec.ts --runInBand`: 4/4 PASS
- `npm run build:client`: PASS
- No GAP-310 E2E test exists; above substitutes as per plan

## Remaining risks
- `npm run verify` (server build) has 199 pre-existing TypeScript errors unrelated to GAP-310; not introduced by this PR
- Migration preflight will block deploy if legacy NULL/orphan rows exist — requires business confirmation to resolve