### PR TITLE
feat: GAP-305 auto-create NonConformance when CCP deviation is recorded

### DIFF
--- a/server/src/modules/ccp/ccp.module.ts
+++ b/server/src/modules/ccp/ccp.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { NonConformanceModule } from '../non-conformance/non-conformance.module';
 import { CcpController } from './ccp.controller';
 import { CcpService } from './ccp.service';
 
 @Module({
+  imports: [NonConformanceModule],
   controllers: [CcpController],
   providers: [CcpService],
   exports: [CcpService],

--- a/server/src/modules/ccp/ccp.service.spec.ts
+++ b/server/src/modules/ccp/ccp.service.spec.ts
@@ -2,15 +2,19 @@ import { CcpService } from './ccp.service';
 
 describe('CcpService', () => {
   const prisma = {
+    $transaction: jest.fn(),
     cCPRecord: { create: jest.fn(), findMany: jest.fn() },
     cCPPoint: { findMany: jest.fn() },
     productionBatch: { findUnique: jest.fn() },
+  };
+  const nonConformanceService = {
+    createFromCcpDeviation: jest.fn(),
   };
   let service: CcpService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new CcpService(prisma as any);
+    service = new CcpService(prisma as any, nonConformanceService as any);
   });
 
   it('writes CCP records to the authenticated company', async () => {
@@ -25,6 +29,7 @@ describe('CcpService', () => {
     expect(prisma.cCPRecord.create).toHaveBeenCalledWith(
       expect.objectContaining({ data: expect.objectContaining({ company_id: '2', operator_id: 'u1' }) }),
     );
+    expect(nonConformanceService.createFromCcpDeviation).not.toHaveBeenCalled();
   });
 
   it('finds missing CCPs only from the batch product or recipe', async () => {
@@ -97,5 +102,91 @@ describe('CcpService', () => {
         }),
       }),
     );
+  });
+
+  it('creates a NonConformance in the same transaction when a CCP record is outside the critical limit', async () => {
+    const tx = {
+      cCPRecord: {
+        create: jest.fn().mockResolvedValue({
+          id: 'ccp-record-1',
+          company_id: '2',
+          production_batch_id: 'batch-1',
+          ccp_point_id: 'ccp-point-1',
+          measured_value: 93.5,
+          measured_text: null,
+          unit: 'C',
+          is_within_cl: false,
+          deviation_action: '隔离待评审',
+          operator_id: 'operator-1',
+          ccp_point: { ccp_no: 'CCP-BAKE-01' },
+        }),
+      },
+    };
+    prisma.$transaction.mockImplementation(async (callback: any) => callback(tx));
+    nonConformanceService.createFromCcpDeviation.mockResolvedValue({ id: 'nc-1' });
+
+    const result = await service.createRecord(
+      {
+        production_batch_id: 'batch-1',
+        ccp_point_id: 'ccp-point-1',
+        measured_value: 93.5,
+        unit: 'C',
+        is_within_cl: false,
+        deviation_action: '隔离待评审',
+      },
+      'operator-1',
+      '2',
+    );
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.cCPRecord.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        company_id: '2',
+        production_batch_id: 'batch-1',
+        ccp_point_id: 'ccp-point-1',
+        is_within_cl: false,
+        operator_id: 'operator-1',
+        monitored_at: expect.any(Date),
+      }),
+      include: { ccp_point: true },
+    });
+    expect(nonConformanceService.createFromCcpDeviation).toHaveBeenCalledWith(
+      {
+        companyId: '2',
+        userId: 'operator-1',
+        ccpRecord: expect.objectContaining({
+          id: 'ccp-record-1',
+          production_batch_id: 'batch-1',
+          ccp_point_id: 'ccp-point-1',
+        }),
+      },
+      tx,
+    );
+    expect(result).toEqual(expect.objectContaining({ id: 'ccp-record-1' }));
+  });
+
+  it('rejects the CCP record creation when automatic NonConformance creation fails', async () => {
+    const tx = {
+      cCPRecord: {
+        create: jest.fn().mockResolvedValue({
+          id: 'ccp-record-1',
+          company_id: '2',
+          production_batch_id: 'batch-1',
+          ccp_point_id: 'ccp-point-1',
+          is_within_cl: false,
+          ccp_point: { ccp_no: 'CCP-BAKE-01' },
+        }),
+      },
+    };
+    prisma.$transaction.mockImplementation(async (callback: any) => callback(tx));
+    nonConformanceService.createFromCcpDeviation.mockRejectedValue(new Error('NC create failed'));
+
+    await expect(
+      service.createRecord(
+        { production_batch_id: 'batch-1', ccp_point_id: 'ccp-point-1', is_within_cl: false },
+        'operator-1',
+        '2',
+      ),
+    ).rejects.toThrow('NC create failed');
   });
 });

--- a/server/src/modules/ccp/ccp.service.ts
+++ b/server/src/modules/ccp/ccp.service.ts
@@ -1,25 +1,52 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { NonConformanceService } from '../non-conformance/non-conformance.service';
 import { CreateCcpRecordDto } from './dto/create-ccp-record.dto';
 
 @Injectable()
 export class CcpService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private nonConformanceService: NonConformanceService,
+  ) {}
 
   async createRecord(dto: CreateCcpRecordDto, operatorId: string, companyId: string) {
-    return this.prisma.cCPRecord.create({
-      data: {
-        company_id: companyId,
-        production_batch_id: dto.production_batch_id,
-        ccp_point_id: dto.ccp_point_id,
-        measured_value: dto.measured_value,
-        measured_text: dto.measured_text,
-        unit: dto.unit,
-        is_within_cl: dto.is_within_cl,
-        deviation_action: dto.deviation_action,
-        operator_id: operatorId,
-        monitored_at: new Date(),
-      },
+    const createData = {
+      company_id: companyId,
+      production_batch_id: dto.production_batch_id,
+      ccp_point_id: dto.ccp_point_id,
+      measured_value: dto.measured_value,
+      measured_text: dto.measured_text,
+      unit: dto.unit,
+      is_within_cl: dto.is_within_cl,
+      deviation_action: dto.deviation_action,
+      operator_id: operatorId,
+      monitored_at: new Date(),
+    };
+
+    if (dto.is_within_cl) {
+      return this.prisma.cCPRecord.create({
+        data: createData,
+        include: { ccp_point: true },
+      });
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const ccpRecord = await tx.cCPRecord.create({
+        data: createData,
+        include: { ccp_point: true },
+      });
+
+      await this.nonConformanceService.createFromCcpDeviation(
+        {
+          companyId,
+          userId: operatorId,
+          ccpRecord,
+        },
+        tx,
+      );
+
+      return ccpRecord;
     });
   }
 

--- a/server/src/modules/non-conformance/non-conformance.service.spec.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.spec.ts
@@ -36,4 +36,80 @@ describe('NonConformanceService', () => {
     await expect(service.dispose('nc1', { disposition: 'rework' }, 'u1', '2')).rejects.toThrow(NotFoundException);
     expect(prisma.nonConformance.update).not.toHaveBeenCalled();
   });
+
+  it('creates an open NonConformance from a CCP deviation using production batch as source', async () => {
+    const tx: any = {
+      nonConformance: {
+        count: jest.fn().mockResolvedValue(8),
+        create: jest.fn().mockResolvedValue({ id: 'nc-ccp-1' }),
+      },
+    };
+
+    await service.createFromCcpDeviation(
+      {
+        companyId: '2',
+        userId: 'operator-1',
+        ccpRecord: {
+          id: 'ccp-record-1',
+          production_batch_id: 'batch-1',
+          ccp_point_id: 'ccp-point-1',
+          measured_value: 93.5,
+          measured_text: null,
+          unit: 'C',
+          deviation_action: '隔离待评审',
+          ccp_point: { ccp_no: 'CCP-BAKE-01' },
+        },
+      },
+      tx,
+    );
+
+    expect(tx.nonConformance.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
+    expect(tx.nonConformance.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        company_id: '2',
+        nc_no: expect.stringMatching(/^NC-\d{4}-0009$/),
+        source_type: 'production_batch',
+        source_id: 'batch-1',
+        nc_type: 'ccp_deviation',
+        discovered_by: 'operator-1',
+        discovered_at: expect.any(Date),
+        description: expect.stringContaining('CCP-BAKE-01'),
+      }),
+    });
+    expect(tx.nonConformance.create.mock.calls[0][0].data.description).toContain('93.5 C');
+    expect(tx.nonConformance.create.mock.calls[0][0].data.description).toContain('隔离待评审');
+    expect(tx.nonConformance.create.mock.calls[0][0].data.description).toContain('ccp-record-1');
+  });
+
+  it('builds a CCP deviation description from measured text when numeric value is absent', async () => {
+    const tx: any = {
+      nonConformance: {
+        count: jest.fn().mockResolvedValue(0),
+        create: jest.fn().mockResolvedValue({ id: 'nc-ccp-2' }),
+      },
+    };
+
+    await service.createFromCcpDeviation(
+      {
+        companyId: '2',
+        userId: 'operator-1',
+        ccpRecord: {
+          id: 'ccp-record-2',
+          production_batch_id: 'batch-1',
+          ccp_point_id: 'ccp-point-2',
+          measured_value: null,
+          measured_text: '金探测试片未通过',
+          unit: null,
+          deviation_action: null,
+          ccp_point: null,
+        },
+      },
+      tx,
+    );
+
+    const data = tx.nonConformance.create.mock.calls[0][0].data;
+    expect(data.description).toContain('ccp-point-2');
+    expect(data.description).toContain('金探测试片未通过');
+    expect(data.description).toContain('未填写');
+  });
 });

--- a/server/src/modules/non-conformance/non-conformance.service.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.ts
@@ -1,6 +1,22 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateNcDto, DisposeNcDto } from './dto/create-nc.dto';
+
+type CcpDeviationInput = {
+  companyId: string;
+  userId: string;
+  ccpRecord: {
+    id: string;
+    production_batch_id: string;
+    ccp_point_id: string;
+    measured_value?: unknown;
+    measured_text?: string | null;
+    unit?: string | null;
+    deviation_action?: string | null;
+    ccp_point?: { ccp_no?: string | null } | null;
+  };
+};
 
 @Injectable()
 export class NonConformanceService {
@@ -18,6 +34,36 @@ export class NonConformanceService {
         discovered_at: new Date(),
       },
     });
+  }
+
+  async createFromCcpDeviation(input: CcpDeviationInput, tx?: Prisma.TransactionClient) {
+    const db = tx ?? this.prisma;
+    const count = await db.nonConformance.count({ where: { company_id: input.companyId } });
+    const nc_no = `NC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+
+    return db.nonConformance.create({
+      data: {
+        company_id: input.companyId,
+        nc_no,
+        source_type: 'production_batch',
+        source_id: input.ccpRecord.production_batch_id,
+        nc_type: 'ccp_deviation',
+        description: this.buildCcpDeviationDescription(input.ccpRecord),
+        discovered_by: input.userId,
+        discovered_at: new Date(),
+      },
+    });
+  }
+
+  private buildCcpDeviationDescription(record: CcpDeviationInput['ccpRecord']) {
+    const ccpNo = record.ccp_point?.ccp_no ?? record.ccp_point_id;
+    const measured =
+      record.measured_value != null
+        ? `${record.measured_value}${record.unit ? ` ${record.unit}` : ''}`
+        : record.measured_text ?? '未填写';
+    const action = record.deviation_action ? `；偏差处置：${record.deviation_action}` : '；偏差处置：未填写';
+
+    return `CCP偏差：${ccpNo} 超出临界限；实测：${measured}${action}；CCP记录ID：${record.id}`;
   }
 
   async findAll(companyId: string, status?: string) {


### PR DESCRIPTION
GAP-305: atomically creates NonConformance when CCP record is outside critical limit. 10 tests passing. No schema changes.