### PR TITLE
feat: GAP-311 ProductRecall independent model

### DIFF
--- a/client/src/api/__tests__/product-recall.spec.ts
+++ b/client/src/api/__tests__/product-recall.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/api/request', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import request from '@/api/request';
+import productRecallApi from '@/api/product-recall';
+
+describe('productRecallApi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (request.get as any).mockResolvedValue({ data: [] });
+    (request.post as any).mockResolvedValue({ data: {} });
+  });
+
+  it('calls /product-recalls for list', async () => {
+    await productRecallApi.getList();
+    expect(request.get).toHaveBeenCalledWith('/product-recalls', { params: undefined });
+  });
+
+  it('calls /product-recalls/:id for detail', async () => {
+    const id = 'recall-1';
+    await productRecallApi.getDetail(id);
+    expect(request.get).toHaveBeenCalledWith(`/product-recalls/${id}`);
+  });
+
+  it('calls /product-recalls/:id/submit', async () => {
+    const id = 'recall-1';
+    await productRecallApi.submit(id);
+    expect(request.post).toHaveBeenCalledWith(`/product-recalls/${id}/submit`);
+  });
+
+  it('calls /product-recalls/:id/notifications/:notificationId/mark-sent', async () => {
+    const id = 'recall-1';
+    const notificationId = 'notif-1';
+    await productRecallApi.markNotificationSent(id, notificationId, '已通知');
+    expect(request.post).toHaveBeenCalledWith(
+      `/product-recalls/${id}/notifications/${notificationId}/mark-sent`,
+      { response_summary: '已通知' },
+    );
+  });
+});

--- a/client/src/api/product-recall.ts
+++ b/client/src/api/product-recall.ts
@@ -1,0 +1,94 @@
+import request from './request';
+
+export type ProductRecallStatus =
+  | 'draft'
+  | 'pending_review'
+  | 'approved'
+  | 'notified'
+  | 'in_progress'
+  | 'completed'
+  | 'rejected'
+  | 'cancelled';
+
+export interface ProductRecallBatch {
+  id: string;
+  production_batch_id: string;
+  batch_number_snapshot: string;
+  product_name_snapshot: string;
+  affected_qty: string | null;
+  unit: string | null;
+  status: string;
+}
+
+export interface ProductRecallNotification {
+  id: string;
+  customer_name: string;
+  notification_method: string;
+  status: 'pending' | 'sent' | 'failed';
+  notified_at: string | null;
+  response_summary: string | null;
+}
+
+export interface ProductRecall {
+  id: string;
+  company_id: string;
+  recall_no: string;
+  title: string;
+  reason: string;
+  risk_level: 'low' | 'medium' | 'high' | 'critical';
+  status: ProductRecallStatus;
+  source_complaint_id: string | null;
+  source_query_ref: string | null;
+  requested_at: string;
+  completed_at: string | null;
+  batches?: ProductRecallBatch[];
+  notifications?: ProductRecallNotification[];
+}
+
+export interface CreateProductRecallPayload {
+  title: string;
+  reason: string;
+  risk_level?: 'low' | 'medium' | 'high' | 'critical';
+  source_complaint_id?: string;
+  source_query_ref?: string;
+  batches?: Array<{ production_batch_id: string; affected_qty?: number; unit?: string }>;
+  notifications?: Array<{
+    external_party_id?: string;
+    customer_name: string;
+    contact_name?: string;
+    contact_phone?: string;
+    notification_method?: 'phone' | 'email' | 'letter' | 'onsite';
+  }>;
+}
+
+const productRecallApi = {
+  getList(params?: { status?: ProductRecallStatus; risk_level?: string; production_batch_id?: string; source_complaint_id?: string }) {
+    return request.get<ProductRecall[]>('/product-recalls', { params });
+  },
+  getDetail(id: string) {
+    return request.get<ProductRecall>(`/product-recalls/${id}`);
+  },
+  create(payload: CreateProductRecallPayload) {
+    return request.post<ProductRecall>('/product-recalls', payload);
+  },
+  submit(id: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/submit`);
+  },
+  approve(id: string, review_note?: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/approve`, { review_note });
+  },
+  reject(id: string, review_note?: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/reject`, { review_note });
+  },
+  complete(id: string, completion_summary: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/complete`, { completion_summary });
+  },
+  cancel(id: string, cancel_reason: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/cancel`, { cancel_reason });
+  },
+  markNotificationSent(id: string, notificationId: string, response_summary?: string) {
+    return request.post<ProductRecall>(`/product-recalls/${id}/notifications/${notificationId}/mark-sent`, { response_summary });
+  },
+};
+
+export default productRecallApi;

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -727,6 +727,19 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/customer-complaint/CustomerComplaintList.vue'),
         meta: { title: '顾客投诉管理' },
       },
+      // 产品召回模块
+      {
+        path: 'product-recalls',
+        name: 'ProductRecallList',
+        component: () => import('@/views/product-recall/ProductRecallList.vue'),
+        meta: { title: '产品召回' },
+      },
+      {
+        path: 'product-recalls/:id',
+        name: 'ProductRecallDetail',
+        component: () => import('@/views/product-recall/ProductRecallDetail.vue'),
+        meta: { title: '召回详情' },
+      },
       // 环境温湿度记录模块
       {
         path: 'environment-records',

--- a/client/src/views/product-recall/ProductRecallDetail.vue
+++ b/client/src/views/product-recall/ProductRecallDetail.vue
@@ -1,0 +1,218 @@
+<template>
+  <div class="recall-detail-page" v-loading="loading">
+    <div class="page-header" v-if="recall">
+      <div class="header-left">
+        <el-button link @click="$router.back()">← 返回</el-button>
+        <span class="recall-no">{{ recall.recall_no }}</span>
+        <span class="recall-title">{{ recall.title }}</span>
+        <el-tag :type="statusTagType(recall.status)" size="small">{{ statusMap[recall.status] ?? recall.status }}</el-tag>
+        <el-tag :type="riskTagType(recall.risk_level)" size="small" class="ml-8">{{ riskMap[recall.risk_level] ?? recall.risk_level }}</el-tag>
+      </div>
+      <div class="header-actions">
+        <el-button v-if="recall.status === 'draft'" type="primary" @click="handleAction('submit')">提交审核</el-button>
+        <el-button v-if="recall.status === 'pending_review'" type="success" @click="handleAction('approve')">批准</el-button>
+        <el-button v-if="recall.status === 'pending_review'" type="warning" @click="handleAction('reject')">驳回</el-button>
+        <el-button v-if="recall.status === 'in_progress'" type="success" @click="handleAction('complete')">完成召回</el-button>
+        <el-button
+          v-if="['draft','approved','notified','in_progress'].includes(recall.status)"
+          type="danger"
+          plain
+          @click="handleAction('cancel')"
+        >取消</el-button>
+      </div>
+    </div>
+
+    <template v-if="recall">
+      <el-card class="section-card">
+        <template #header><span>召回信息</span></template>
+        <el-descriptions :column="2" border>
+          <el-descriptions-item label="召回原因">{{ recall.reason }}</el-descriptions-item>
+          <el-descriptions-item label="风险等级">{{ riskMap[recall.risk_level] ?? recall.risk_level }}</el-descriptions-item>
+          <el-descriptions-item label="请求时间">{{ recall.requested_at }}</el-descriptions-item>
+          <el-descriptions-item label="完成时间">{{ recall.completed_at ?? '-' }}</el-descriptions-item>
+        </el-descriptions>
+      </el-card>
+
+      <el-card class="section-card">
+        <template #header><span>受影响批次 ({{ recall.batches?.length ?? 0 }})</span></template>
+        <el-table :data="recall.batches ?? []" size="small">
+          <el-table-column prop="batch_number_snapshot" label="批次号" />
+          <el-table-column prop="product_name_snapshot" label="产品名称" />
+          <el-table-column prop="affected_qty" label="受影响数量" />
+          <el-table-column prop="unit" label="单位" />
+          <el-table-column prop="disposition" label="处置方式" />
+          <el-table-column prop="status" label="状态" />
+        </el-table>
+      </el-card>
+
+      <el-card class="section-card">
+        <template #header><span>客户通知 ({{ recall.notifications?.length ?? 0 }})</span></template>
+        <el-table :data="recall.notifications ?? []" size="small">
+          <el-table-column prop="customer_name" label="客户名称" />
+          <el-table-column prop="notification_method" label="通知方式" />
+          <el-table-column prop="status" label="状态">
+            <template #default="{ row }">
+              <el-tag :type="row.status === 'sent' ? 'success' : 'info'" size="small">
+                {{ row.status === 'sent' ? '已通知' : '待通知' }}
+              </el-tag>
+            </template>
+          </el-table-column>
+          <el-table-column prop="notified_at" label="通知时间" />
+          <el-table-column label="操作">
+            <template #default="{ row }">
+              <el-button
+                v-if="row.status === 'pending'"
+                size="small"
+                type="primary"
+                @click="markSent(row.id)"
+              >标记已通知</el-button>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-card>
+
+      <el-card class="section-card" v-if="recall.evidence?.length">
+        <template #header><span>证据记录 ({{ recall.evidence.length }})</span></template>
+        <el-table :data="recall.evidence" size="small">
+          <el-table-column prop="title" label="标题" />
+          <el-table-column prop="evidence_type" label="证据类型" />
+          <el-table-column prop="notes" label="备注" />
+        </el-table>
+      </el-card>
+    </template>
+
+    <el-dialog v-model="actionDialog.visible" :title="actionDialog.title" width="480px">
+      <el-form v-if="actionDialog.type === 'complete'" label-position="top">
+        <el-form-item label="完成摘要" required>
+          <el-input v-model="actionDialog.note" type="textarea" :rows="3" />
+        </el-form-item>
+      </el-form>
+      <el-form v-else-if="actionDialog.type === 'cancel'" label-position="top">
+        <el-form-item label="取消原因" required>
+          <el-input v-model="actionDialog.note" type="textarea" :rows="3" />
+        </el-form-item>
+      </el-form>
+      <el-form v-else-if="['approve','reject'].includes(actionDialog.type)" label-position="top">
+        <el-form-item label="审核备注">
+          <el-input v-model="actionDialog.note" type="textarea" :rows="3" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="actionDialog.visible = false">取消</el-button>
+        <el-button type="primary" @click="confirmAction">确认</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import productRecallApi, { type ProductRecall } from '@/api/product-recall';
+
+const route = useRoute();
+const loading = ref(false);
+const recall = ref<ProductRecall | null>(null);
+
+const statusMap: Record<string, string> = {
+  draft: '草稿',
+  pending_review: '待审核',
+  approved: '已批准',
+  notified: '已通知',
+  in_progress: '执行中',
+  completed: '已完成',
+  rejected: '已驳回',
+  cancelled: '已取消',
+};
+
+const riskMap: Record<string, string> = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  critical: '极高',
+};
+
+const statusTagType = (status: string) => {
+  const map: Record<string, string> = {
+    draft: 'info', pending_review: 'warning', approved: 'success',
+    notified: 'success', in_progress: 'primary', completed: 'success',
+    rejected: 'danger', cancelled: 'info',
+  };
+  return (map[status] ?? 'info') as any;
+};
+
+const riskTagType = (risk: string) => {
+  const map: Record<string, string> = { low: 'success', medium: 'warning', high: 'danger', critical: 'danger' };
+  return (map[risk] ?? 'info') as any;
+};
+
+const actionDialog = ref({ visible: false, type: '', title: '', note: '' });
+
+async function loadDetail() {
+  loading.value = true;
+  try {
+    const res = await productRecallApi.getDetail(route.params.id as string);
+    recall.value = (res as any).data ?? res;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function handleAction(type: string) {
+  const titles: Record<string, string> = {
+    submit: '提交审核', approve: '批准召回', reject: '驳回召回',
+    complete: '完成召回', cancel: '取消召回',
+  };
+  actionDialog.value = { visible: true, type, title: titles[type] ?? type, note: '' };
+  if (type === 'submit') confirmAction();
+}
+
+async function confirmAction() {
+  const id = route.params.id as string;
+  const { type, note } = actionDialog.value;
+  try {
+    if (type === 'submit') {
+      await productRecallApi.submit(id);
+    } else if (type === 'approve') {
+      await productRecallApi.approve(id, note);
+    } else if (type === 'reject') {
+      await productRecallApi.reject(id, note);
+    } else if (type === 'complete') {
+      if (!note) { ElMessage.error('请填写完成摘要'); return; }
+      await productRecallApi.complete(id, note);
+    } else if (type === 'cancel') {
+      if (!note) { ElMessage.error('请填写取消原因'); return; }
+      await productRecallApi.cancel(id, note);
+    }
+    ElMessage.success('操作成功');
+    actionDialog.value.visible = false;
+    await loadDetail();
+  } catch {
+    ElMessage.error('操作失败');
+  }
+}
+
+async function markSent(notificationId: string) {
+  const id = route.params.id as string;
+  try {
+    await productRecallApi.markNotificationSent(id, notificationId);
+    ElMessage.success('已标记通知');
+    await loadDetail();
+  } catch {
+    ElMessage.error('操作失败');
+  }
+}
+
+onMounted(loadDetail);
+</script>
+
+<style scoped>
+.recall-detail-page { padding: 20px; }
+.page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.header-left { display: flex; align-items: center; gap: 12px; }
+.recall-no { font-weight: 600; color: #409eff; }
+.recall-title { font-size: 16px; font-weight: 500; }
+.section-card { margin-bottom: 16px; }
+.ml-8 { margin-left: 8px; }
+</style>

--- a/client/src/views/product-recall/ProductRecallList.vue
+++ b/client/src/views/product-recall/ProductRecallList.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="recall-list-page">
+    <div class="page-header">
+      <h1 class="page-title">产品召回管理</h1>
+    </div>
+
+    <el-card class="table-card">
+      <template #header>
+        <div class="card-header">
+          <div class="card-title-wrap">
+            <span class="card-title">召回列表</span>
+            <span class="card-count">共 {{ list.length }} 条记录</span>
+          </div>
+          <div class="header-actions">
+            <el-select
+              v-model="filterStatus"
+              placeholder="全部状态"
+              clearable
+              style="width: 140px; margin-right: 12px"
+              @change="loadList"
+            >
+              <el-option v-for="(label, val) in statusMap" :key="val" :label="label" :value="val" />
+            </el-select>
+            <el-select
+              v-model="filterRisk"
+              placeholder="全部风险"
+              clearable
+              style="width: 120px; margin-right: 12px"
+              @change="loadList"
+            >
+              <el-option label="低" value="low" />
+              <el-option label="中" value="medium" />
+              <el-option label="高" value="high" />
+              <el-option label="严重" value="critical" />
+            </el-select>
+          </div>
+        </div>
+      </template>
+
+      <el-table :data="list" v-loading="loading" stripe>
+        <el-table-column prop="recall_no" label="召回编号" width="180" />
+        <el-table-column prop="title" label="召回标题" show-overflow-tooltip />
+        <el-table-column label="状态" width="110">
+          <template #default="{ row }">
+            <el-tag :type="statusTagType(row.status)" size="small">
+              {{ statusMap[row.status] ?? row.status }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="风险等级" width="100">
+          <template #default="{ row }">
+            <el-tag :type="riskTagType(row.risk_level)" size="small">
+              {{ riskMap[row.risk_level] ?? row.risk_level }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="受影响批次" width="100">
+          <template #default="{ row }">
+            {{ row.batches?.length ?? 0 }}
+          </template>
+        </el-table-column>
+        <el-table-column label="通知进度" width="120">
+          <template #default="{ row }">
+            <span v-if="row.notifications?.length">
+              {{ row.notifications.filter((n: any) => n.status === 'sent').length }} /
+              {{ row.notifications.length }}
+            </span>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
+        <el-table-column prop="requested_at" label="创建时间" width="170">
+          <template #default="{ row }">
+            {{ formatDate(row.requested_at) }}
+          </template>
+        </el-table-column>
+        <el-table-column label="操作" width="80" fixed="right">
+          <template #default="{ row }">
+            <el-button type="primary" link @click="goDetail(row.id)">详情</el-button>
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import productRecallApi from '@/api/product-recall';
+import type { ProductRecall, ProductRecallStatus } from '@/api/product-recall';
+
+const router = useRouter();
+const list = ref<ProductRecall[]>([]);
+const loading = ref(false);
+const filterStatus = ref<string>('');
+const filterRisk = ref<string>('');
+
+const statusMap: Record<string, string> = {
+  draft: '草稿',
+  pending_review: '待审核',
+  approved: '已批准',
+  notified: '已通知',
+  in_progress: '执行中',
+  completed: '已完成',
+  rejected: '已驳回',
+  cancelled: '已取消',
+};
+
+const riskMap: Record<string, string> = {
+  low: '低',
+  medium: '中',
+  high: '高',
+  critical: '严重',
+};
+
+function statusTagType(status: string): '' | 'success' | 'warning' | 'danger' | 'info' {
+  const map: Record<string, '' | 'success' | 'warning' | 'danger' | 'info'> = {
+    draft: 'info',
+    pending_review: 'warning',
+    approved: '',
+    notified: '',
+    in_progress: 'warning',
+    completed: 'success',
+    rejected: 'danger',
+    cancelled: 'info',
+  };
+  return map[status] ?? '';
+}
+
+function riskTagType(risk: string): '' | 'success' | 'warning' | 'danger' | 'info' {
+  const map: Record<string, '' | 'success' | 'warning' | 'danger' | 'info'> = {
+    low: 'success',
+    medium: 'warning',
+    high: 'danger',
+    critical: 'danger',
+  };
+  return map[risk] ?? '';
+}
+
+function formatDate(date: string) {
+  return date ? new Date(date).toLocaleString('zh-CN') : '-';
+}
+
+async function loadList() {
+  loading.value = true;
+  try {
+    const res = await productRecallApi.getList({
+      status: filterStatus.value as ProductRecallStatus || undefined,
+      risk_level: filterRisk.value || undefined,
+    });
+    list.value = (res as any).data ?? res;
+  } catch {
+    ElMessage.error('加载召回列表失败');
+  } finally {
+    loading.value = false;
+  }
+}
+
+function goDetail(id: string) {
+  router.push({ name: 'ProductRecallDetail', params: { id } });
+}
+
+onMounted(loadList);
+</script>

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "traceability:test": "jest traceability-query.service.spec.ts traceability-balance.service.spec.ts traceability-linkage.service.spec.ts traceability-export.service.spec.ts --runInBand",
     "traceability:contract:test": "jest traceability-contract.mapper.spec.ts --runInBand",
     "traceability:e2e": "jest traceability-contract.e2e-spec.ts traceability-query.e2e-spec.ts --runInBand",
-    "traceability:verify": "npm run traceability:test && npm run traceability:contract:test && npm run traceability:e2e"
+    "traceability:verify": "npm run traceability:test && npm run traceability:contract:test && npm run traceability:e2e",
+    "recall:migrate-records": "ts-node scripts/migrate-product-recall-records.ts"
   },
   "dependencies": {
     "@nestjs/axios": "^4.0.1",

--- a/server/scripts/migrate-product-recall-records.ts
+++ b/server/scripts/migrate-product-recall-records.ts
@@ -1,0 +1,84 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const RECALL_TEMPLATE_CODES = [
+  'GRSS-YX-JL-02',
+  'GRSS-YX-JL-03',
+  'GRSS-YX-JL-04',
+  'GRSS-YX-JL-05',
+];
+
+async function main() {
+  const records = await prisma.record.findMany({
+    where: {
+      template: { code: { in: RECALL_TEMPLATE_CODES } },
+      deletedAt: null,
+    },
+    include: {
+      template: { select: { code: true, name: true } },
+      productionBatch: {
+        select: { id: true, batchNumber: true, productName: true },
+      },
+    },
+  });
+
+  console.log(`Found ${records.length} recall-related records to migrate`);
+
+  for (const record of records) {
+    const companyId = record.createdBy;
+
+    const recallCount = await prisma.productRecall.count({ where: { company_id: companyId } });
+    const recall_no = `RC-HIST-${new Date().getFullYear()}-${String(recallCount + 1).padStart(4, '0')}`;
+
+    const recall = await prisma.productRecall.create({
+      data: {
+        company_id: companyId,
+        recall_no,
+        title: `历史记录迁移: ${record.number}`,
+        reason: `动态表单记录 ${record.template.code} 迁移`,
+        status: 'draft',
+        requested_by: record.createdBy,
+      },
+    });
+
+    await prisma.productRecallEvidence.create({
+      data: {
+        company_id: companyId,
+        recall_id: recall.id,
+        evidence_type: 'record',
+        record_id: record.id,
+        title: `${record.template.name} - ${record.number}`,
+      },
+    });
+
+    if (record.productionBatch) {
+      const existingBatch = await prisma.productRecallBatch.findFirst({
+        where: { recall_id: recall.id, production_batch_id: record.productionBatch.id },
+      });
+
+      if (!existingBatch) {
+        await prisma.productRecallBatch.create({
+          data: {
+            company_id: companyId,
+            recall_id: recall.id,
+            production_batch_id: record.productionBatch.id,
+            batch_number_snapshot: record.productionBatch.batchNumber,
+            product_name_snapshot: record.productionBatch.productName,
+          },
+        });
+      }
+    }
+
+    console.log(`Migrated record ${record.number} -> recall ${recall.recall_no}`);
+  }
+
+  console.log('Migration complete');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -44,6 +44,7 @@ import { TraceabilityModule } from './modules/traceability/traceability.module';
 import { NonConformanceModule } from './modules/non-conformance/non-conformance.module';
 import { CorrectiveActionModule } from './modules/corrective-action/corrective-action.module';
 import { CustomerComplaintModule } from './modules/customer-complaint/customer-complaint.module';
+import { ProductRecallModule } from './modules/product-recall/product-recall.module';
 import { CcpModule } from './modules/ccp/ccp.module';
 import { EnvironmentRecordModule } from './modules/environment-record/environment-record.module';
 import { ProcessRecordModule } from './modules/process-record/process-record.module';
@@ -135,6 +136,7 @@ import { ProductProcessChangeModule } from './modules/product-process-change/pro
     NonConformanceModule,
     CorrectiveActionModule,
     CustomerComplaintModule,
+    ProductRecallModule,
     CcpModule,
     EnvironmentRecordModule,
     ProcessRecordModule,

--- a/server/src/modules/corrective-action/corrective-action.service.spec.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.spec.ts
@@ -36,4 +36,21 @@ describe('CorrectiveActionService', () => {
     await expect(service.updateStatus('c1', 'closed', '2')).rejects.toThrow(NotFoundException);
     expect(prisma.correctiveAction.update).not.toHaveBeenCalled();
   });
+
+  it('accepts product_recall as trigger_type', async () => {
+    prisma.correctiveAction.count.mockResolvedValue(0);
+    prisma.correctiveAction.create.mockResolvedValue({ id: 'c2' });
+
+    await service.create(
+      { trigger_type: 'product_recall', trigger_id: 'recall-1', description: '召回后纠正措施' },
+      'u1',
+      'company-1',
+    );
+
+    expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ trigger_type: 'product_recall' }),
+      }),
+    );
+  });
 });

--- a/server/src/modules/corrective-action/dto/create-capa.dto.ts
+++ b/server/src/modules/corrective-action/dto/create-capa.dto.ts
@@ -1,7 +1,7 @@
 import { IsString, IsOptional } from 'class-validator';
 
 export class CreateCapaDto {
-  @IsString() trigger_type: string; // 'non_conformance'|'customer_complaint'|'internal_audit'|'other'
+  @IsString() trigger_type: string; // 'non_conformance'|'customer_complaint'|'internal_audit'|'product_recall'|'other'
   @IsOptional() @IsString() trigger_id?: string;
   @IsString() description: string;
   @IsOptional() @IsString() root_cause?: string;

--- a/server/src/modules/product-recall/dto/create-product-recall.dto.ts
+++ b/server/src/modules/product-recall/dto/create-product-recall.dto.ts
@@ -1,0 +1,75 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsEnum, IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+
+export class CreateProductRecallBatchDto {
+  @IsString()
+  @IsNotEmpty()
+  production_batch_id!: string;
+
+  @IsOptional()
+  affected_qty?: number;
+
+  @IsOptional()
+  @IsString()
+  unit?: string;
+}
+
+export class CreateProductRecallNotificationDto {
+  @IsOptional()
+  @IsString()
+  external_party_id?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  customer_name!: string;
+
+  @IsOptional()
+  @IsString()
+  contact_name?: string;
+
+  @IsOptional()
+  @IsString()
+  contact_phone?: string;
+
+  @IsOptional()
+  @IsEnum(['phone', 'email', 'letter', 'onsite'])
+  notification_method?: 'phone' | 'email' | 'letter' | 'onsite';
+}
+
+export class CreateProductRecallDto {
+  @IsString()
+  @IsNotEmpty()
+  title!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  reason!: string;
+
+  @IsOptional()
+  @IsEnum(['low', 'medium', 'high', 'critical'])
+  risk_level?: 'low' | 'medium' | 'high' | 'critical';
+
+  @IsOptional()
+  @IsString()
+  source_complaint_id?: string;
+
+  @IsOptional()
+  @IsString()
+  source_query_ref?: string;
+
+  @IsOptional()
+  @IsString()
+  source_traceability_snapshot_id?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateProductRecallBatchDto)
+  batches?: CreateProductRecallBatchDto[];
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateProductRecallNotificationDto)
+  notifications?: CreateProductRecallNotificationDto[];
+}

--- a/server/src/modules/product-recall/dto/query-product-recall.dto.ts
+++ b/server/src/modules/product-recall/dto/query-product-recall.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+
+export class QueryProductRecallDto {
+  @IsOptional()
+  @IsEnum(['draft', 'pending_review', 'approved', 'notified', 'in_progress', 'completed', 'rejected', 'cancelled'])
+  status?: string;
+
+  @IsOptional()
+  @IsEnum(['low', 'medium', 'high', 'critical'])
+  risk_level?: string;
+
+  @IsOptional()
+  @IsString()
+  production_batch_id?: string;
+
+  @IsOptional()
+  @IsString()
+  source_complaint_id?: string;
+}

--- a/server/src/modules/product-recall/dto/transition-product-recall.dto.ts
+++ b/server/src/modules/product-recall/dto/transition-product-recall.dto.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class RecallReviewDto {
+  @IsOptional()
+  @IsString()
+  review_note?: string;
+}
+
+export class RecallCompleteDto {
+  @IsString()
+  @IsNotEmpty()
+  completion_summary!: string;
+}
+
+export class RecallCancelDto {
+  @IsString()
+  @IsNotEmpty()
+  cancel_reason!: string;
+}
+
+export class MarkNotificationSentDto {
+  @IsOptional()
+  @IsString()
+  response_summary?: string;
+}

--- a/server/src/modules/product-recall/product-recall.controller.ts
+++ b/server/src/modules/product-recall/product-recall.controller.ts
@@ -1,0 +1,68 @@
+import { Body, Controller, Get, Param, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
+import { ProductRecallService } from './product-recall.service';
+import { CreateProductRecallDto, CreateProductRecallNotificationDto } from './dto/create-product-recall.dto';
+import { QueryProductRecallDto } from './dto/query-product-recall.dto';
+import { MarkNotificationSentDto, RecallCancelDto, RecallCompleteDto, RecallReviewDto } from './dto/transition-product-recall.dto';
+
+@Controller('product-recalls')
+@UseGuards(JwtAuthGuard)
+export class ProductRecallController {
+  constructor(private readonly service: ProductRecallService) {}
+
+  @Post()
+  create(@Body() dto: CreateProductRecallDto, @Request() req: AuthenticatedRequest) {
+    return this.service.create(dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Get()
+  findAll(@Query() query: QueryProductRecallDto, @Request() req: AuthenticatedRequest) {
+    return this.service.findAll(req.user.companyId, query);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findOne(id, req.user.companyId);
+  }
+
+  @Post(':id/submit')
+  submit(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.submit(id, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/approve')
+  approve(@Param('id') id: string, @Body() dto: RecallReviewDto, @Request() req: AuthenticatedRequest) {
+    return this.service.approve(id, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/reject')
+  reject(@Param('id') id: string, @Body() dto: RecallReviewDto, @Request() req: AuthenticatedRequest) {
+    return this.service.reject(id, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/complete')
+  complete(@Param('id') id: string, @Body() dto: RecallCompleteDto, @Request() req: AuthenticatedRequest) {
+    return this.service.complete(id, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/cancel')
+  cancel(@Param('id') id: string, @Body() dto: RecallCancelDto, @Request() req: AuthenticatedRequest) {
+    return this.service.cancel(id, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/notifications')
+  createNotification(@Param('id') id: string, @Body() dto: CreateProductRecallNotificationDto, @Request() req: AuthenticatedRequest) {
+    return this.service.createNotification(id, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Post(':id/notifications/:notificationId/mark-sent')
+  markNotificationSent(
+    @Param('id') id: string,
+    @Param('notificationId') notificationId: string,
+    @Body() dto: MarkNotificationSentDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.service.markNotificationSent(id, notificationId, dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+}

--- a/server/src/modules/product-recall/product-recall.module.ts
+++ b/server/src/modules/product-recall/product-recall.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { ProductRecallController } from './product-recall.controller';
+import { ProductRecallService } from './product-recall.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProductRecallController],
+  providers: [ProductRecallService],
+  exports: [ProductRecallService],
+})
+export class ProductRecallModule {}

--- a/server/src/modules/product-recall/product-recall.service.spec.ts
+++ b/server/src/modules/product-recall/product-recall.service.spec.ts
@@ -1,0 +1,81 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ProductRecallService } from './product-recall.service';
+
+describe('ProductRecallService', () => {
+  const prisma: any = {
+    productRecall: {
+      count: jest.fn(),
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    productRecallBatch: { create: jest.fn() },
+    productRecallNotification: { create: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
+    productionBatch: { findFirst: jest.fn() },
+    $transaction: jest.fn(),
+  };
+
+  const service = new ProductRecallService(prisma);
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('creates recall draft with production batch snapshots', async () => {
+    prisma.productRecall.count.mockResolvedValue(0);
+    prisma.productionBatch.findFirst.mockResolvedValue({
+      id: 'batch-1',
+      batchNumber: 'PB-001',
+      productName: '蛋糕',
+    });
+    prisma.$transaction.mockImplementation(async (fn: any) => fn(prisma));
+    prisma.productRecall.create.mockResolvedValue({ id: 'recall-1', recall_no: 'RC-2026-0001' });
+
+    await service.create(
+      {
+        title: '批次召回',
+        reason: '客户投诉',
+        batches: [{ production_batch_id: 'batch-1', affected_qty: 10, unit: '箱' }],
+      },
+      { id: 'user-1', companyId: 'company-1' },
+    );
+
+    expect(prisma.productRecall.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        company_id: 'company-1',
+        recall_no: 'RC-2026-0001',
+        status: 'draft',
+      }),
+    }));
+    expect(prisma.productRecallBatch.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        batch_number_snapshot: 'PB-001',
+        product_name_snapshot: '蛋糕',
+      }),
+    }));
+  });
+
+  it('rejects invalid state transition', async () => {
+    prisma.productRecall.findFirst.mockResolvedValue({ id: 'recall-1', status: 'completed' });
+
+    await expect(service.submit('recall-1', { id: 'user-1', companyId: 'company-1' })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('marks notification sent and advances approved recall to notified', async () => {
+    prisma.productRecallNotification.findFirst.mockResolvedValue({ id: 'n1', recall_id: 'recall-1', status: 'pending' });
+    prisma.productRecall.findFirst.mockResolvedValue({ id: 'recall-1', status: 'approved' });
+    prisma.productRecallNotification.update.mockResolvedValue({ id: 'n1', status: 'sent' });
+    prisma.productRecall.update.mockResolvedValue({ id: 'recall-1', status: 'notified' });
+
+    await service.markNotificationSent('recall-1', 'n1', { response_summary: '已通知' }, { id: 'user-1', companyId: 'company-1' });
+
+    expect(prisma.productRecall.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: 'notified' }),
+    }));
+  });
+
+  it('throws when recall is missing', async () => {
+    prisma.productRecall.findFirst.mockResolvedValue(null);
+
+    await expect(service.findOne('missing', 'company-1')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/server/src/modules/product-recall/product-recall.service.ts
+++ b/server/src/modules/product-recall/product-recall.service.ts
@@ -1,0 +1,192 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateProductRecallDto, CreateProductRecallNotificationDto } from './dto/create-product-recall.dto';
+import { QueryProductRecallDto } from './dto/query-product-recall.dto';
+import { MarkNotificationSentDto, RecallCancelDto, RecallCompleteDto, RecallReviewDto } from './dto/transition-product-recall.dto';
+
+type CurrentUser = { id: string; companyId: string };
+
+const allowedTransitions: Record<string, string[]> = {
+  draft: ['pending_review', 'cancelled'],
+  pending_review: ['approved', 'rejected'],
+  approved: ['notified', 'cancelled'],
+  notified: ['in_progress', 'cancelled'],
+  in_progress: ['completed', 'cancelled'],
+  completed: [],
+  rejected: [],
+  cancelled: [],
+};
+
+@Injectable()
+export class ProductRecallService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(dto: CreateProductRecallDto, currentUser: CurrentUser) {
+    const companyId = currentUser.companyId;
+    const count = await this.prisma.productRecall.count({ where: { company_id: companyId } });
+    const recall_no = `RC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+
+    return this.prisma.$transaction(async (tx: any) => {
+      const recall = await tx.productRecall.create({
+        data: {
+          company_id: companyId,
+          recall_no,
+          title: dto.title,
+          reason: dto.reason,
+          risk_level: dto.risk_level ?? 'medium',
+          status: 'draft',
+          source_complaint_id: dto.source_complaint_id,
+          source_query_ref: dto.source_query_ref,
+          source_traceability_snapshot_id: dto.source_traceability_snapshot_id,
+          requested_by: currentUser.id,
+        },
+      });
+
+      for (const batch of dto.batches ?? []) {
+        const productionBatch = await tx.productionBatch.findFirst({
+          where: { id: batch.production_batch_id },
+          select: { id: true, batchNumber: true, productName: true },
+        });
+        if (!productionBatch) throw new BadRequestException(`生产批次不存在: ${batch.production_batch_id}`);
+
+        await tx.productRecallBatch.create({
+          data: {
+            company_id: companyId,
+            recall_id: recall.id,
+            production_batch_id: productionBatch.id,
+            batch_number_snapshot: productionBatch.batchNumber,
+            product_name_snapshot: productionBatch.productName,
+            affected_qty: batch.affected_qty,
+            unit: batch.unit,
+          },
+        });
+      }
+
+      for (const notification of dto.notifications ?? []) {
+        await this.createNotificationRow(tx, recall.id, notification, companyId);
+      }
+
+      return recall;
+    });
+  }
+
+  async findAll(companyId: string, query: QueryProductRecallDto) {
+    return this.prisma.productRecall.findMany({
+      where: {
+        company_id: companyId,
+        ...(query.status ? { status: query.status } : {}),
+        ...(query.risk_level ? { risk_level: query.risk_level } : {}),
+        ...(query.source_complaint_id ? { source_complaint_id: query.source_complaint_id } : {}),
+        ...(query.production_batch_id
+          ? { batches: { some: { production_batch_id: query.production_batch_id } } }
+          : {}),
+      },
+      include: { batches: true, notifications: true },
+      orderBy: { created_at: 'desc' },
+      take: 100,
+    });
+  }
+
+  async findOne(id: string, companyId: string) {
+    const recall = await this.prisma.productRecall.findFirst({
+      where: { id, company_id: companyId },
+      include: {
+        batches: true,
+        notifications: true,
+        evidence: true,
+      },
+    });
+    if (!recall) throw new NotFoundException('召回记录不存在');
+    return recall;
+  }
+
+  async submit(id: string, currentUser: CurrentUser) {
+    return this.transition(id, currentUser, 'pending_review', {});
+  }
+
+  async approve(id: string, dto: RecallReviewDto, currentUser: CurrentUser) {
+    return this.transition(id, currentUser, 'approved', {
+      reviewed_by: currentUser.id,
+      reviewed_at: new Date(),
+      review_note: dto.review_note,
+    });
+  }
+
+  async reject(id: string, dto: RecallReviewDto, currentUser: CurrentUser) {
+    return this.transition(id, currentUser, 'rejected', {
+      reviewed_by: currentUser.id,
+      reviewed_at: new Date(),
+      review_note: dto.review_note,
+    });
+  }
+
+  async complete(id: string, dto: RecallCompleteDto, currentUser: CurrentUser) {
+    return this.transition(id, currentUser, 'completed', {
+      completed_by: currentUser.id,
+      completed_at: new Date(),
+      completion_summary: dto.completion_summary,
+    });
+  }
+
+  async cancel(id: string, dto: RecallCancelDto, currentUser: CurrentUser) {
+    return this.transition(id, currentUser, 'cancelled', {
+      cancelled_at: new Date(),
+      cancel_reason: dto.cancel_reason,
+    });
+  }
+
+  async createNotification(id: string, dto: CreateProductRecallNotificationDto, currentUser: CurrentUser) {
+    await this.findOne(id, currentUser.companyId);
+    return this.createNotificationRow(this.prisma, id, dto, currentUser.companyId);
+  }
+
+  async markNotificationSent(id: string, notificationId: string, dto: MarkNotificationSentDto, currentUser: CurrentUser) {
+    const notification = await this.prisma.productRecallNotification.findFirst({
+      where: { id: notificationId, recall_id: id, company_id: currentUser.companyId },
+    });
+    if (!notification) throw new NotFoundException('召回通知不存在');
+
+    const recall = await this.findOne(id, currentUser.companyId);
+    await this.prisma.productRecallNotification.update({
+      where: { id: notificationId },
+      data: {
+        status: 'sent',
+        notified_at: new Date(),
+        response_summary: dto.response_summary,
+      },
+    });
+
+    if (recall.status === 'approved') {
+      return this.prisma.productRecall.update({
+        where: { id },
+        data: { status: 'notified' },
+      });
+    }
+    return this.findOne(id, currentUser.companyId);
+  }
+
+  private async transition(id: string, currentUser: CurrentUser, nextStatus: string, data: Record<string, unknown>) {
+    const recall = await this.findOne(id, currentUser.companyId);
+    if (!allowedTransitions[recall.status]?.includes(nextStatus)) {
+      throw new BadRequestException(`召回状态不允许从 ${recall.status} 流转到 ${nextStatus}`);
+    }
+    return this.prisma.productRecall.update({
+      where: { id },
+      data: { ...data, status: nextStatus },
+    });
+  }
+
+  private createNotificationRow(tx: any, recallId: string, dto: CreateProductRecallNotificationDto, companyId: string) {
+    return tx.productRecallNotification.create({
+      data: {
+        company_id: companyId,
+        recall_id: recallId,
+        external_party_id: dto.external_party_id,
+        customer_name: dto.customer_name,
+        contact_name: dto.contact_name,
+        contact_phone: dto.contact_phone,
+        notification_method: dto.notification_method ?? 'phone',
+      },
+    });
+  }
+}

--- a/server/src/modules/traceability/traceability-linkage.service.spec.ts
+++ b/server/src/modules/traceability/traceability-linkage.service.spec.ts
@@ -1,8 +1,12 @@
 import { TraceabilityLinkageService } from './traceability-linkage.service';
 
+const mockProductRecallService = { create: jest.fn() };
+
 describe('TraceabilityLinkageService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
   it('creates a linkage payload with created status for standard action types', async () => {
-    const service = new TraceabilityLinkageService();
+    const service = new TraceabilityLinkageService(mockProductRecallService as any);
 
     const result = await service.create(
       { actionType: 'deviation', sourceQueryRef: 'hash-abc', note: '有异常' },
@@ -20,7 +24,8 @@ describe('TraceabilityLinkageService', () => {
   });
 
   it('sets pendingReview status for recallAssessment actions', async () => {
-    const service = new TraceabilityLinkageService();
+    mockProductRecallService.create.mockResolvedValue({ id: 'recall-1', recall_no: 'RC-2026-0001' });
+    const service = new TraceabilityLinkageService(mockProductRecallService as any);
 
     const result = await service.create(
       { actionType: 'recallAssessment', sourceQueryRef: 'hash-xyz' },
@@ -31,7 +36,7 @@ describe('TraceabilityLinkageService', () => {
   });
 
   it('falls back to system requestedBy when user id is absent', async () => {
-    const service = new TraceabilityLinkageService();
+    const service = new TraceabilityLinkageService(mockProductRecallService as any);
 
     const result = await service.create(
       { actionType: 'capa', sourceQueryRef: 'hash-001' },
@@ -39,5 +44,24 @@ describe('TraceabilityLinkageService', () => {
     );
 
     expect(result.requestedBy).toBe('system');
+  });
+
+  it('creates ProductRecall draft for recallAssessment actions', async () => {
+    const productRecallService = {
+      create: jest.fn().mockResolvedValue({ id: 'recall-1', recall_no: 'RC-2026-0001' }),
+    };
+    const service = new TraceabilityLinkageService(productRecallService as any);
+
+    const result = await service.create(
+      { actionType: 'recallAssessment', sourceQueryRef: 'hash-xyz', note: '高风险批次' },
+      { id: 'user-1', companyId: 'company-1' },
+    );
+
+    expect(productRecallService.create).toHaveBeenCalledWith(expect.objectContaining({
+      title: '追溯召回评估',
+      reason: '高风险批次',
+      source_query_ref: 'hash-xyz',
+    }), { id: 'user-1', companyId: 'company-1' });
+    expect(result.productRecall).toEqual({ id: 'recall-1', recall_no: 'RC-2026-0001' });
   });
 });

--- a/server/src/modules/traceability/traceability-linkage.service.ts
+++ b/server/src/modules/traceability/traceability-linkage.service.ts
@@ -1,10 +1,26 @@
 import { Injectable } from '@nestjs/common';
+import { ProductRecallService } from '../product-recall/product-recall.service';
 import { CreateTraceabilityActionDto as CreateTraceabilityLinkageDto } from './dto/create-traceability-linkage.dto';
 
 @Injectable()
 export class TraceabilityLinkageService {
+  constructor(private readonly productRecallService: ProductRecallService) {}
+
   async create(dto: CreateTraceabilityLinkageDto, currentUser: any) {
     const status = dto.actionType === 'recallAssessment' ? 'pendingReview' : 'created';
+    let productRecall: { id: string; recall_no: string } | null = null;
+
+    if (dto.actionType === 'recallAssessment') {
+      productRecall = await this.productRecallService.create(
+        {
+          title: '追溯召回评估',
+          reason: dto.note ?? '追溯查询触发召回评估',
+          source_query_ref: dto.sourceQueryRef,
+          risk_level: 'high',
+        },
+        { id: currentUser?.id ?? 'system', companyId: currentUser?.companyId ?? '1' },
+      );
+    }
 
     return {
       actionType: dto.actionType,
@@ -12,6 +28,7 @@ export class TraceabilityLinkageService {
       requestedBy: currentUser?.id ?? 'system',
       note: dto.note ?? null,
       status,
+      productRecall,
       writeback: {
         sourceQueryRef: dto.sourceQueryRef,
         linkedAt: new Date().toISOString(),

--- a/server/src/modules/traceability/traceability.module.spec.ts
+++ b/server/src/modules/traceability/traceability.module.spec.ts
@@ -6,6 +6,7 @@ import { TraceabilityExportService } from './traceability-export.service';
 import { TraceabilityBalanceService } from './traceability-balance.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ModelLandingService } from '../model-landing/model-landing.service';
+import { ProductRecallService } from '../product-recall/product-recall.service';
 
 describe('TraceabilityModule', () => {
   it('registers traceability sub-services for DI', async () => {
@@ -16,6 +17,8 @@ describe('TraceabilityModule', () => {
       .useValue({})
       .overrideProvider(ModelLandingService)
       .useValue({})
+      .overrideProvider(ProductRecallService)
+      .useValue({ create: jest.fn() })
       .compile();
 
     expect(moduleRef.get(TraceabilityQueryService)).toBeInstanceOf(TraceabilityQueryService);

--- a/server/src/modules/traceability/traceability.module.ts
+++ b/server/src/modules/traceability/traceability.module.ts
@@ -7,9 +7,10 @@ import { TraceabilityQueryService } from './traceability-query.service';
 import { TraceabilityLinkageService } from './traceability-linkage.service';
 import { TraceabilityExportService } from './traceability-export.service';
 import { TraceabilityBalanceService } from './traceability-balance.service';
+import { ProductRecallModule } from '../product-recall/product-recall.module';
 
 @Module({
-  imports: [PrismaModule, ModelLandingModule],
+  imports: [PrismaModule, ModelLandingModule, ProductRecallModule],
   controllers: [TraceabilityController],
   providers: [
     TraceabilityService,

--- a/server/src/modules/traceability/traceability.service.spec.ts
+++ b/server/src/modules/traceability/traceability.service.spec.ts
@@ -1,0 +1,25 @@
+import { TraceabilityService } from './traceability.service';
+
+describe('TraceabilityService recall actions', () => {
+  it('delegates recallAssessment actions to TraceabilityLinkageService', async () => {
+    const linkageService = {
+      create: jest.fn().mockResolvedValue({
+        actionType: 'recallAssessment',
+        status: 'pendingReview',
+        productRecall: { id: 'recall-1', recall_no: 'RC-2026-0001' },
+      }),
+    };
+    const service = new TraceabilityService({} as any, linkageService as any);
+
+    const result = await service.createAction(
+      { actionType: 'recallAssessment', sourceQueryRef: 'hash-xyz' },
+      { id: 'user-1', companyId: 'company-1' } as any,
+    );
+
+    expect(linkageService.create).toHaveBeenCalledWith(
+      { actionType: 'recallAssessment', sourceQueryRef: 'hash-xyz' },
+      { id: 'user-1', companyId: 'company-1' },
+    );
+    expect(result.productRecall).toEqual({ id: 'recall-1', recall_no: 'RC-2026-0001' });
+  });
+});

--- a/server/src/modules/traceability/traceability.service.ts
+++ b/server/src/modules/traceability/traceability.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { mapForwardTraceResult, SOURCE_VERSION } from './traceability-contract.mapper';
+import { TraceabilityLinkageService } from './traceability-linkage.service';
 
 interface TraceCurrentUser {
   id?: string;
+  companyId?: string;
   department?: string;
   scenarioPermissions?: string[];
 }
@@ -95,7 +97,10 @@ const MATERIAL_LOT_INCLUDE = {
 
 @Injectable()
 export class TraceabilityService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly linkageService: TraceabilityLinkageService,
+  ) {}
 
   async query(dto: TraceQueryDto, currentUser: TraceCurrentUser) {
     const isMaterialLotQuery =
@@ -148,11 +153,14 @@ export class TraceabilityService {
   }
 
   async createAction(dto: TraceActionDto, currentUser: TraceCurrentUser) {
-    const status = dto.actionType === 'recallAssessment' ? 'pendingReview' : 'created';
+    if (dto.actionType === 'recallAssessment') {
+      return this.linkageService.create(dto as any, currentUser);
+    }
+
     return {
       actionId: `action:${Date.now()}`,
       actionType: dto.actionType,
-      status: status as 'pendingReview' | 'created',
+      status: 'created' as const,
       sourceQueryRef: dto.sourceQueryRef,
       createdAt: new Date().toISOString(),
       requestedBy: currentUser?.id ?? 'system',

--- a/server/src/prisma/migrations/20260502000000_product_recall_independent_model/migration.sql
+++ b/server/src/prisma/migrations/20260502000000_product_recall_independent_model/migration.sql
@@ -1,0 +1,131 @@
+-- CreateTable
+CREATE TABLE "product_recalls" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "recall_no" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "reason" TEXT NOT NULL,
+    "risk_level" TEXT NOT NULL DEFAULT 'medium',
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "source_complaint_id" TEXT,
+    "source_query_ref" TEXT,
+    "source_traceability_snapshot_id" TEXT,
+    "requested_by" TEXT,
+    "requested_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "reviewed_by" TEXT,
+    "reviewed_at" TIMESTAMP(3),
+    "review_note" TEXT,
+    "completed_by" TEXT,
+    "completed_at" TIMESTAMP(3),
+    "completion_summary" TEXT,
+    "cancelled_at" TIMESTAMP(3),
+    "cancel_reason" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "product_recalls_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "product_recall_batches" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "recall_id" TEXT NOT NULL,
+    "production_batch_id" TEXT NOT NULL,
+    "batch_number_snapshot" TEXT NOT NULL,
+    "product_name_snapshot" TEXT NOT NULL,
+    "affected_qty" DECIMAL(14,4),
+    "unit" TEXT,
+    "disposition" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'identified',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "product_recall_batches_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "product_recall_notifications" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "recall_id" TEXT NOT NULL,
+    "external_party_id" TEXT,
+    "customer_name" TEXT NOT NULL,
+    "contact_name" TEXT,
+    "contact_phone" TEXT,
+    "notification_method" TEXT NOT NULL DEFAULT 'phone',
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "notified_at" TIMESTAMP(3),
+    "response_summary" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "product_recall_notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "product_recall_evidence" (
+    "id" TEXT NOT NULL,
+    "company_id" TEXT NOT NULL,
+    "recall_id" TEXT NOT NULL,
+    "evidence_type" TEXT NOT NULL,
+    "record_id" TEXT,
+    "traceability_snapshot_id" TEXT,
+    "external_ref" TEXT,
+    "title" TEXT NOT NULL,
+    "notes" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "product_recall_evidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "product_recalls_company_id_recall_no_key" ON "product_recalls"("company_id", "recall_no");
+
+-- CreateIndex
+CREATE INDEX "product_recalls_company_id_status_idx" ON "product_recalls"("company_id", "status");
+
+-- CreateIndex
+CREATE INDEX "product_recalls_company_id_source_complaint_id_idx" ON "product_recalls"("company_id", "source_complaint_id");
+
+-- CreateIndex
+CREATE INDEX "product_recalls_source_traceability_snapshot_id_idx" ON "product_recalls"("source_traceability_snapshot_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "product_recall_batches_recall_id_production_batch_id_key" ON "product_recall_batches"("recall_id", "production_batch_id");
+
+-- CreateIndex
+CREATE INDEX "product_recall_batches_company_id_production_batch_id_idx" ON "product_recall_batches"("company_id", "production_batch_id");
+
+-- CreateIndex
+CREATE INDEX "product_recall_notifications_company_id_recall_id_idx" ON "product_recall_notifications"("company_id", "recall_id");
+
+-- CreateIndex
+CREATE INDEX "product_recall_notifications_external_party_id_idx" ON "product_recall_notifications"("external_party_id");
+
+-- CreateIndex
+CREATE INDEX "product_recall_evidence_company_id_recall_id_idx" ON "product_recall_evidence"("company_id", "recall_id");
+
+-- CreateIndex
+CREATE INDEX "product_recall_evidence_record_id_idx" ON "product_recall_evidence"("record_id");
+
+-- AddForeignKey
+ALTER TABLE "product_recalls" ADD CONSTRAINT "product_recalls_source_traceability_snapshot_id_fkey" FOREIGN KEY ("source_traceability_snapshot_id") REFERENCES "traceability_snapshots"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_batches" ADD CONSTRAINT "product_recall_batches_recall_id_fkey" FOREIGN KEY ("recall_id") REFERENCES "product_recalls"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_batches" ADD CONSTRAINT "product_recall_batches_production_batch_id_fkey" FOREIGN KEY ("production_batch_id") REFERENCES "production_batches"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_notifications" ADD CONSTRAINT "product_recall_notifications_recall_id_fkey" FOREIGN KEY ("recall_id") REFERENCES "product_recalls"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_notifications" ADD CONSTRAINT "product_recall_notifications_external_party_id_fkey" FOREIGN KEY ("external_party_id") REFERENCES "ExternalParty"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_evidence" ADD CONSTRAINT "product_recall_evidence_recall_id_fkey" FOREIGN KEY ("recall_id") REFERENCES "product_recalls"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "product_recall_evidence" ADD CONSTRAINT "product_recall_evidence_record_id_fkey" FOREIGN KEY ("record_id") REFERENCES "records"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -878,6 +878,7 @@ model Record {
   changeEventId  String?
   changeEvent    ChangeEvent? @relation("ChangeEventRecords", fields: [changeEventId], references: [id], onDelete: SetNull)
   changeFormTasks ChangeEventFormTask[]
+  product_recall_evidence ProductRecallEvidence[]
 
   @@index([templateId])
   @@index([number])
@@ -1527,6 +1528,8 @@ model ProductionBatch {
 
   production_run_id String?
   production_run    ProductionRun? @relation(fields: [production_run_id], references: [id], onDelete: SetNull)
+
+  product_recall_batches ProductRecallBatch[]
 
   @@index([batchNumber])
   @@index([productionDate])
@@ -3635,6 +3638,8 @@ model ExternalParty {
   created_at      DateTime  @default(now())
   updated_at      DateTime  @updatedAt
   deleted_at      DateTime?
+
+  product_recall_notifications ProductRecallNotification[]
 }
 
 model PackagingMaterialUsage {
@@ -3725,6 +3730,8 @@ model TraceabilitySnapshot {
   filePath        String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+
+  productRecalls ProductRecall[] @relation("ProductRecallTraceabilitySnapshot")
 
   @@map("traceability_snapshots")
 }
@@ -3898,4 +3905,104 @@ model TaskRecord {
   @@index([taskId])
   @@index([approvalInstanceId])
   @@map("task_records")
+}
+
+// GAP-311: ProductRecall independent model
+
+model ProductRecall {
+  id                              String    @id @default(cuid())
+  company_id                      String
+  recall_no                       String
+  title                           String
+  reason                          String
+  risk_level                      String    @default("medium")
+  status                          String    @default("draft")
+  source_complaint_id             String?
+  source_query_ref                String?
+  source_traceability_snapshot_id String?
+  source_traceability_snapshot    TraceabilitySnapshot? @relation("ProductRecallTraceabilitySnapshot", fields: [source_traceability_snapshot_id], references: [id], onDelete: SetNull)
+  requested_by                    String?
+  requested_at                    DateTime  @default(now())
+  reviewed_by                     String?
+  reviewed_at                     DateTime?
+  review_note                     String?
+  completed_by                    String?
+  completed_at                    DateTime?
+  completion_summary              String?
+  cancelled_at                    DateTime?
+  cancel_reason                   String?
+  created_at                      DateTime  @default(now())
+  updated_at                      DateTime  @updatedAt
+
+  batches       ProductRecallBatch[]
+  notifications ProductRecallNotification[]
+  evidence      ProductRecallEvidence[]
+
+  @@unique([company_id, recall_no])
+  @@index([company_id, status])
+  @@index([company_id, source_complaint_id])
+  @@index([source_traceability_snapshot_id])
+  @@map("product_recalls")
+}
+
+model ProductRecallBatch {
+  id                  String          @id @default(cuid())
+  company_id          String
+  recall_id           String
+  recall              ProductRecall   @relation(fields: [recall_id], references: [id], onDelete: Cascade)
+  production_batch_id String
+  production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
+  batch_number_snapshot String
+  product_name_snapshot String
+  affected_qty        Decimal?        @db.Decimal(14, 4)
+  unit                String?
+  disposition         String?
+  status              String          @default("identified")
+  created_at          DateTime        @default(now())
+  updated_at          DateTime        @updatedAt
+
+  @@unique([recall_id, production_batch_id])
+  @@index([company_id, production_batch_id])
+  @@map("product_recall_batches")
+}
+
+model ProductRecallNotification {
+  id                   String         @id @default(cuid())
+  company_id           String
+  recall_id            String
+  recall               ProductRecall  @relation(fields: [recall_id], references: [id], onDelete: Cascade)
+  external_party_id    String?
+  external_party       ExternalParty? @relation(fields: [external_party_id], references: [id], onDelete: SetNull)
+  customer_name        String
+  contact_name         String?
+  contact_phone        String?
+  notification_method  String         @default("phone")
+  status               String         @default("pending")
+  notified_at          DateTime?
+  response_summary     String?
+  created_at           DateTime       @default(now())
+  updated_at           DateTime       @updatedAt
+
+  @@index([company_id, recall_id])
+  @@index([external_party_id])
+  @@map("product_recall_notifications")
+}
+
+model ProductRecallEvidence {
+  id                 String        @id @default(cuid())
+  company_id         String
+  recall_id          String
+  recall             ProductRecall @relation(fields: [recall_id], references: [id], onDelete: Cascade)
+  evidence_type      String
+  record_id          String?
+  record             Record?       @relation(fields: [record_id], references: [id], onDelete: SetNull)
+  traceability_snapshot_id String?
+  external_ref       String?
+  title              String
+  notes              String?
+  created_at         DateTime      @default(now())
+
+  @@index([company_id, recall_id])
+  @@index([record_id])
+  @@map("product_recall_evidence")
 }


### PR DESCRIPTION
## Summary

- Add independent `ProductRecall` model with state machine (draft → pending_review → approved → notified → in_progress → completed), affected production batches, customer notifications, and evidence tables
- Add Prisma schema for `product_recalls`, `product_recall_batches`, `product_recall_notifications`, `product_recall_evidence` with FK relations to `ProductionBatch`, `ExternalParty`, `Record`, `TraceabilitySnapshot`
- Add `ProductRecallModule` (service, controller, DTOs) registered in AppModule
- Wire `TraceabilityLinkageService` to create ProductRecall drafts when `recallAssessment` actions are triggered; update `TraceabilityService.createAction` to delegate
- Add `product_recall` trigger type to CAPA DTO
- Add client API adapter (`client/src/api/product-recall.ts`) and Vitest contract tests
- Add `ProductRecallList.vue` and `ProductRecallDetail.vue` workbench pages with routes
- Add `server/scripts/migrate-product-recall-records.ts` for migrating historical recall Record rows as evidence (not executed; local DB unavailable)

## Test plan

- [ ] Server unit tests: `npm run test --workspace server -- product-recall.service traceability-linkage.service traceability.service corrective-action --runInBand`
- [ ] Client vitest: `npm run test --workspace client -- product-recall`
- [ ] Server build: `npm run build:server`
- [ ] Client build: `npm run build:client`
- [ ] `npm run prisma:generate --workspace server` (requires DB)
- [ ] Manual smoke: navigate to `/product-recalls`, create recall, advance state machine, mark notification sent

## Notes

- `prisma generate` and `prisma migrate` require a running PostgreSQL (DB not available in this execution environment); migration SQL is committed manually at `server/src/prisma/migrations/20260502000000_product_recall_independent_model/migration.sql`
- `recall:migrate-records` script created but not executed (no local DB)
- Does not touch GAP-308, GAP-309, GAP-310, complaint/NC chains