### PR TITLE
fix(GAP-307): add tenant scope validation to traceability query

### DIFF
--- a/server/src/modules/traceability/traceability-query.service.spec.ts
+++ b/server/src/modules/traceability/traceability-query.service.spec.ts
@@ -4,7 +4,7 @@ describe('TraceabilityQueryService contract', () => {
   it('builds a ledger-and-graph result with stable top-level keys', async () => {
     const prisma = {
       materialBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'mb-1',
           batchNumber: 'RM-001',
           material: null,
@@ -51,7 +51,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles the main traceability chain for a material lot query', async () => {
     const prisma = {
       materialBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'mb-1',
           batchNumber: 'RM-001',
           material: null,
@@ -95,7 +95,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles a bidirectional chain for a production batch query', async () => {
     const prisma = {
       productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'pb-1',
           batchNumber: 'PB-001',
           productName: '海绵蛋糕',
@@ -161,7 +161,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles a backward chain from a delivery note query', async () => {
     const prisma = {
       deliveryNote: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 10,
           dn_no: 'DN-001',
           customer_name: '客户A',
@@ -213,5 +213,77 @@ describe('TraceabilityQueryService contract', () => {
       'ingredientUsage',
       'materialLot',
     ]);
+  });
+
+  it('returns empty result when materialLot objectId belongs to a different company', async () => {
+    const prisma = {
+      materialBatch: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'materialLot',
+        objectId: 'mb-other-company',
+        traceMode: 'forward',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['forwardTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
+  });
+
+  it('returns empty result when productionBatch objectId belongs to a different company', async () => {
+    const prisma = {
+      productionBatch: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'productionBatch',
+        objectId: 'pb-other-company',
+        traceMode: 'bidirectional',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['bidirectionalTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
+  });
+
+  it('returns empty result when deliveryNote objectId belongs to a different company', async () => {
+    const prisma = {
+      deliveryNote: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'deliveryNote',
+        objectId: '99',
+        traceMode: 'backward',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['backwardTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
   });
 });

--- a/server/src/modules/traceability/traceability-query.service.ts
+++ b/server/src/modules/traceability/traceability-query.service.ts
@@ -109,8 +109,16 @@ export class TraceabilityQueryService {
   }
 
   private async queryMaterialLot(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
-    const materialLot = await this.prisma.materialBatch.findUnique({
-      where: { id: dto.objectId },
+    // Material has no direct company_id; scope via production batch → product.company_id
+    const companyWhere = currentUser?.companyId
+      ? {
+          batchMaterialUsages: {
+            some: { productionBatch: { product: { company_id: currentUser.companyId } } },
+          },
+        }
+      : {};
+    const materialLot = await this.prisma.materialBatch.findFirst({
+      where: { id: dto.objectId, ...companyWhere },
       include: {
         material: true,
         supplier: true,
@@ -164,8 +172,11 @@ export class TraceabilityQueryService {
   }
 
   private async queryProductionBatch(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
-    const productionBatch = await this.prisma.productionBatch.findUnique({
-      where: { id: dto.objectId },
+    const companyWhere = currentUser?.companyId
+      ? { product: { company_id: currentUser.companyId } }
+      : {};
+    const productionBatch = await this.prisma.productionBatch.findFirst({
+      where: { id: dto.objectId, ...companyWhere },
       include: {
         materialUsages: {
           include: {
@@ -218,8 +229,11 @@ export class TraceabilityQueryService {
     const deliveryId = Number(dto.objectId);
     if (!Number.isInteger(deliveryId)) return this.emptyResult(dto, currentUser);
 
-    const deliveryNote = await this.prisma.deliveryNote.findUnique({
-      where: { id: deliveryId },
+    const companyWhere = currentUser?.companyId
+      ? { company_id: Number(currentUser.companyId) }
+      : {};
+    const deliveryNote = await this.prisma.deliveryNote.findFirst({
+      where: { id: deliveryId, ...companyWhere },
       include: {
         production_batch: {
           include: {


### PR DESCRIPTION
## Summary

Fixes P1 security blocker from PR #136 review.

- `queryMaterialLot`: changed `findUnique` → `findFirst` scoped via `batchMaterialUsages → productionBatch → product.company_id` (Material has no direct company_id in current schema; this is the closest available tenant path)
- `queryProductionBatch`: changed `findUnique` → `findFirst` scoped by `product.company_id`  
- `queryDeliveryNote`: changed `findUnique` → `findFirst` scoped by `company_id` (Int comparison)
- All three methods only apply company scope when `currentUser.companyId` is set (preserves backward compat)

## Test plan

- [ ] Updated existing 3 `findUnique` mocks → `findFirst` in spec file
- [ ] Added 3 new cross-company tests verifying each query type returns `resultStatus: 'empty'` and zero rows/nodes when `findFirst` returns `null` (simulating cross-company objectId rejection)
- [ ] `./node_modules/.bin/jest traceability-query.service.spec.ts traceability-contract.mapper.spec.ts --runInBand` → **18 tests PASS**