### PR TITLE
feat: complete traceability query chain (GAP-307)

### DIFF
--- a/client/src/views/traceability/TraceabilityQuery.vue
+++ b/client/src/views/traceability/TraceabilityQuery.vue
@@ -61,6 +61,20 @@ const runObjectQuery = async (payload: any) => {
 const runScenarioQuery = async (payload: any) => {
   error.value = '';
   try {
+    if (payload.scenario === 'materialBalance') {
+      const balance = await traceabilityApi.materialBalance({
+        productionBatchId: payload.filters?.objectType === 'productionBatch' ? payload.filters.objectId : undefined,
+        materialLotId: payload.filters?.objectType === 'materialLot' ? payload.filters.objectId : undefined,
+        timeMode: payload.timeMode,
+        asOfAt: payload.asOfAt,
+        includeEvidence: true,
+        includeRecommendations: true,
+      });
+      result.value = null;
+      ElMessage.success(`物料平衡分析完成：${balance.summary.status}`);
+      return;
+    }
+
     result.value = await traceabilityApi.query({ ...payload, viewMode: activeView.value }) as TraceQueryResult;
   } catch {
     error.value = '场景分析失败，请稍后重试';

--- a/client/src/views/traceability/__tests__/TraceabilityQuery.spec.ts
+++ b/client/src/views/traceability/__tests__/TraceabilityQuery.spec.ts
@@ -7,6 +7,7 @@ vi.mock('@/api/traceability', () => ({
     graph: vi.fn(),
     createLinkage: vi.fn(),
     export: vi.fn(),
+    materialBalance: vi.fn(),
   },
 }));
 
@@ -32,5 +33,24 @@ describe('TraceabilityQuery', () => {
     expect(wrapper.text()).toContain('场景工作台');
     expect(wrapper.text()).toContain('台账视图');
     expect(wrapper.text()).toContain('链路图视图');
+  });
+
+  it('keeps the scenario workbench visible for traceability workflows', async () => {
+    const wrapper = mount(TraceabilityQuery, {
+      global: {
+        stubs: {
+          'el-card': { template: '<div><slot /></div>' },
+          'el-radio-group': { template: '<div><slot /></div>' },
+          'el-radio-button': { template: '<button><slot /></button>' },
+          ObjectTraceQueryPanel: { template: '<div />' },
+          ScenarioWorkbenchPanel: { template: '<div>场景工作台</div>' },
+          TraceLedgerView: { template: '<div />' },
+          TraceGraphView: { template: '<div />' },
+          TraceRiskPanel: { template: '<div />' },
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain('场景工作台');
   });
 });

--- a/client/src/views/traceability/components/ScenarioWorkbenchPanel.vue
+++ b/client/src/views/traceability/components/ScenarioWorkbenchPanel.vue
@@ -14,6 +14,20 @@
             </el-select>
           </el-form-item>
         </el-col>
+        <el-col :span="5">
+          <el-form-item label="对象类型">
+            <el-select v-model="form.objectType" style="width: 100%">
+              <el-option label="原料批次" value="materialLot" />
+              <el-option label="产品批次" value="productionBatch" />
+              <el-option label="发货单" value="deliveryNote" />
+            </el-select>
+          </el-form-item>
+        </el-col>
+        <el-col :span="6">
+          <el-form-item label="对象编号">
+            <el-input v-model="form.objectId" placeholder="批次号 / ID" clearable />
+          </el-form-item>
+        </el-col>
         <el-col :span="4">
           <el-form-item label="历史模式">
             <el-switch v-model="asOfEnabled" />
@@ -43,17 +57,35 @@
 import { reactive, ref } from 'vue';
 
 const asOfEnabled = ref(false);
-const form = reactive({ scenario: 'forwardTrace', asOfAt: '' });
+const form = reactive({
+  scenario: 'forwardTrace',
+  objectType: 'materialLot',
+  objectId: '',
+  asOfAt: '',
+});
 
 const emit = defineEmits<{ submit: [payload: Record<string, unknown>] }>();
 
+const scenarioTraceMode = (scenario: string) => {
+  if (scenario === 'backwardTrace' || scenario === 'complaintInvestigation' || scenario === 'recallAssessment') {
+    return 'backward';
+  }
+  if (scenario === 'materialBalance') return 'bidirectional';
+  return 'forward';
+};
+
 const handleSubmit = () => {
   emit('submit', {
-    ...form,
+    scenario: form.scenario,
     entryMode: 'scenario',
-    traceMode: 'forward',
+    traceMode: scenarioTraceMode(form.scenario),
     viewMode: 'ledger',
     timeMode: asOfEnabled.value ? 'asOf' : 'current',
+    asOfAt: form.asOfAt,
+    filters: {
+      objectType: form.objectType,
+      objectId: form.objectId,
+    },
   });
 };
 </script>

--- a/server/src/modules/traceability/traceability-contract.mapper.spec.ts
+++ b/server/src/modules/traceability/traceability-contract.mapper.spec.ts
@@ -38,4 +38,37 @@ describe('traceability contract mapper', () => {
     ]);
     expect(result.graph.nodes).toHaveLength(4);
   });
+
+  it('uses current Prisma field names when building labels', () => {
+    const result = mapForwardTraceResult({
+      id: 'mb-1',
+      batchNumber: 'RM-001',
+      batchMaterialUsages: [
+        {
+          id: 'use-1',
+          quantity: 10,
+          productionBatch: {
+            id: 'pb-1',
+            batchNumber: 'PB-001',
+            delivery_notes: [{ id: 10, dn_no: 'DN-001' }],
+          },
+        },
+      ],
+    } as any, {
+      departmentScope: '品质',
+      scenarioPermissions: ['forwardTrace'],
+      canViewSummary: true,
+      canViewDetail: true,
+      canViewEvidence: true,
+      canInitiateLinkage: true,
+      canExportSimple: true,
+      canExportFullPackage: true,
+      canUseAsOfPlayback: true,
+      canExecuteHighRiskAction: false,
+    });
+
+    expect(result.ledger.rows.map((row: any) => row.label)).toContain('RM-001');
+    expect(result.ledger.rows.map((row: any) => row.label)).toContain('PB-001');
+    expect(result.ledger.rows.map((row: any) => row.label)).toContain('DN-001');
+  });
 });

--- a/server/src/modules/traceability/traceability-contract.mapper.ts
+++ b/server/src/modules/traceability/traceability-contract.mapper.ts
@@ -15,91 +15,179 @@ const defaultPermission = () => ({
   actionable: true,
 });
 
-export function mapForwardTraceResult(materialBatch: any, permission: any): any {
-  const rows: any[] = [];
+const toStringId = (value: unknown) => String(value ?? '');
 
-  rows.push({
-    nodeId: materialBatch.id,
-    nodeType: 'materialLot',
-    businessObject: 'MaterialBatch',
-    label: materialBatch.batch_no,
-    batchNo: materialBatch.batch_no,
-    riskLevel: 'normal',
-    permission: defaultPermission(),
-  });
-
-  for (const usage of materialBatch.batchMaterialUsages ?? []) {
-    rows.push({
-      nodeId: usage.id,
-      nodeType: 'ingredientUsage',
-      businessObject: 'BatchMaterialUsage',
-      label: `投料 ${usage.quantity}`,
-      riskLevel: 'normal',
-      permission: { ...defaultPermission(), actionable: false },
-      attributes: { quantity: usage.quantity },
-    });
-
-    rows.push({
-      nodeId: usage.productionBatch.id,
-      nodeType: 'productionBatch',
-      businessObject: 'ProductionBatch',
-      label: usage.productionBatch.batch_no,
-      batchNo: usage.productionBatch.batch_no,
-      riskLevel: 'normal',
-      permission: defaultPermission(),
-    });
-
-    for (const dn of usage.productionBatch.delivery_notes ?? []) {
-      rows.push({
-        nodeId: dn.id,
-        nodeType: 'deliveryNote',
-        businessObject: 'DeliveryNote',
-        label: dn.delivery_no,
-        batchNo: dn.delivery_no,
-        riskLevel: 'normal',
-        permission: { ...defaultPermission(), actionable: false },
-      });
+const labelOf = (entity: any, keys: string[], fallback: string) => {
+  for (const key of keys) {
+    if (entity?.[key] !== undefined && entity?.[key] !== null && String(entity[key]).length > 0) {
+      return String(entity[key]);
     }
   }
+  return fallback;
+};
 
+const node = (
+  nodeId: string,
+  nodeType: string,
+  businessObject: string,
+  label: string,
+  attributes: Record<string, unknown> = {},
+) => ({
+  nodeId,
+  nodeType,
+  businessObject,
+  label,
+  batchNo: label,
+  riskLevel: 'normal' as const,
+  permission: defaultPermission(),
+  attributes,
+});
+
+export const edge = (
+  sourceNodeId: string,
+  targetNodeId: string,
+  relationType: string,
+  direction: 'forward' | 'backward' | 'bidirectional',
+  index: number,
+) => ({
+  edgeId: `${relationType}:${sourceNodeId}:${targetNodeId}:${index}`,
+  sourceNodeId,
+  targetNodeId,
+  relationType,
+  direction,
+  isMainChain: true,
+  isAuxiliary: false,
+  riskLevel: 'normal' as const,
+});
+
+export const materialLotNode = (materialBatch: any) =>
+  node(
+    materialBatch.id,
+    'materialLot',
+    'MaterialBatch',
+    labelOf(materialBatch, ['batch_no', 'batchNumber', 'supplierBatchNo'], materialBatch.id),
+    {
+      materialId: materialBatch.materialId ?? materialBatch.material?.id,
+      materialName: materialBatch.material?.name,
+      supplierId: materialBatch.supplierId ?? materialBatch.supplier?.id,
+      supplierName: materialBatch.supplier?.name,
+    },
+  );
+
+export const ingredientUsageNode = (usage: any) =>
+  node(usage.id, 'ingredientUsage', 'BatchMaterialUsage', `投料 ${usage.quantity}`, {
+    quantity: usage.quantity,
+    materialBatchId: usage.materialBatchId ?? usage.materialBatch?.id,
+    productionBatchId: usage.productionBatchId ?? usage.productionBatch?.id,
+  });
+
+export const productionBatchNode = (productionBatch: any) =>
+  node(
+    productionBatch.id,
+    'productionBatch',
+    'ProductionBatch',
+    labelOf(productionBatch, ['batch_no', 'batchNumber', 'productName'], productionBatch.id),
+    {
+      productId: productionBatch.productId,
+      productName: productionBatch.productName,
+      status: productionBatch.status,
+    },
+  );
+
+export const deliveryNoteNode = (deliveryNote: any) =>
+  node(
+    toStringId(deliveryNote.id),
+    'deliveryNote',
+    'DeliveryNote',
+    labelOf(deliveryNote, ['delivery_no', 'dn_no'], toStringId(deliveryNote.id)),
+    {
+      customerName: deliveryNote.customer_name,
+      shippedQty: deliveryNote.shipped_qty,
+      unit: deliveryNote.unit,
+    },
+  );
+
+export function buildTraceResult(input: {
+  queryId: string;
+  entryMode: 'object' | 'scenario';
+  objectType?: string;
+  objectId?: string;
+  scenario?: string;
+  traceMode: 'forward' | 'backward' | 'bidirectional';
+  viewMode: 'ledger' | 'graph';
+  timeMode: 'current' | 'asOf';
+  asOfAt?: string;
+  permission: any;
+  rows: any[];
+  edges: any[];
+}) {
   return {
     summary: {
-      queryId: `forward:${materialBatch.id}`,
-      entryMode: 'object',
-      objectType: 'materialLot',
-      objectId: materialBatch.id,
-      traceMode: 'forward',
-      viewMode: 'ledger',
-      timeMode: 'current',
-      riskLevel: 'normal',
-      resultStatus: rows.length ? 'ok' : 'empty',
+      queryId: input.queryId,
+      entryMode: input.entryMode,
+      objectType: input.objectType,
+      objectId: input.objectId,
+      scenario: input.scenario,
+      traceMode: input.traceMode,
+      viewMode: input.viewMode,
+      timeMode: input.timeMode,
+      asOfAt: input.asOfAt,
+      riskLevel: 'normal' as const,
+      resultStatus: input.rows.length ? ('ok' as const) : ('empty' as const),
     },
-    permission,
-    risk: { summaryRiskLevel: 'normal', riskCount: 0, highRiskCount: 0, items: [] },
+    permission: input.permission,
+    risk: { summaryRiskLevel: 'normal' as const, riskCount: 0, highRiskCount: 0, items: [] },
     ledger: {
       columns: [{ key: 'label', label: '节点' }],
-      rows,
+      rows: input.rows,
       grouping: ['nodeType'],
-      totals: { rowCount: rows.length },
+      totals: { rowCount: input.rows.length },
     },
     graph: {
-      nodes: rows,
-      edges: rows.slice(1).map((row: any, index: number) => ({
-        edgeId: `edge-${index + 1}`,
-        sourceNodeId: rows[index].nodeId,
-        targetNodeId: row.nodeId,
-        relationType: 'linked',
-        direction: 'forward',
-        isMainChain: true,
-        isAuxiliary: false,
-      })),
+      nodes: input.rows,
+      edges: input.edges,
       layout: 'vertical',
       legend: ['mainChain'],
     },
-    evidence: { count: 0, items: [] },
-    actions: { available: ['deviation', 'complaint'], recommended: [], created: [] },
-    export: { simpleExportAvailable: true, fullPackageAvailable: true, latestExportId: null },
+    evidence: {
+      count: input.rows.length,
+      items: input.rows.map((row) => ({ type: 'record' as const, label: row.label, refId: row.nodeId })),
+    },
+    actions: { available: ['deviation', 'complaint', 'recallAssessment'], recommended: [], created: [] },
+    export: { simpleExportAvailable: true, fullPackageAvailable: true, latestExportId: null as string | null },
     meta: baseMeta(),
     extensions: {},
   };
+}
+
+export function mapForwardTraceResult(materialBatch: any, permission: any): any {
+  const rows = [materialLotNode(materialBatch)];
+  const edges: any[] = [];
+
+  for (const usage of materialBatch.batchMaterialUsages ?? []) {
+    const usageNode = ingredientUsageNode(usage);
+    const productionNode = productionBatchNode(usage.productionBatch);
+    rows.push(usageNode, productionNode);
+    edges.push(edge(materialBatch.id, usage.id, 'usedIn', 'forward', edges.length));
+    edges.push(edge(usage.id, usage.productionBatch.id, 'produces', 'forward', edges.length));
+
+    for (const dn of usage.productionBatch.delivery_notes ?? []) {
+      const deliveryNode = deliveryNoteNode(dn);
+      rows.push(deliveryNode);
+      edges.push(edge(usage.productionBatch.id, toStringId(dn.id), 'shippedBy', 'forward', edges.length));
+    }
+  }
+
+  return buildTraceResult({
+    queryId: `forward:${materialBatch.id}`,
+    entryMode: 'object',
+    objectType: 'materialLot',
+    objectId: materialBatch.id,
+    traceMode: 'forward',
+    viewMode: 'ledger',
+    timeMode: 'current',
+    permission,
+    rows,
+    edges,
+  });
 }

--- a/server/src/modules/traceability/traceability-query.service.spec.ts
+++ b/server/src/modules/traceability/traceability-query.service.spec.ts
@@ -3,7 +3,15 @@ import { TraceabilityQueryService } from './traceability-query.service';
 describe('TraceabilityQueryService contract', () => {
   it('builds a ledger-and-graph result with stable top-level keys', async () => {
     const prisma = {
-      materialBatch: { findFirst: jest.fn().mockResolvedValue({ id: 'mb-1', batch_no: 'RM-001' }) },
+      materialBatch: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'mb-1',
+          batchNumber: 'RM-001',
+          material: null,
+          supplier: null,
+          batchMaterialUsages: [],
+        }),
+      },
     };
     const modelLanding = { getSummary: jest.fn().mockReturnValue({ totalForms: 283, totalGroups: 59 }) };
     const service = new TraceabilityQueryService(prisma as any, modelLanding as any);
@@ -19,11 +27,11 @@ describe('TraceabilityQueryService contract', () => {
       }, { department: '品质', scenarioPermissions: ['forwardTrace'] } as any),
     ).resolves.toMatchObject({
       summary: expect.objectContaining({ objectType: 'materialLot', traceMode: 'forward', timeMode: 'current' }),
-      ledger: expect.any(Array),
+      ledger: expect.objectContaining({ rows: expect.any(Array) }),
       graph: expect.objectContaining({ nodes: expect.any(Array), edges: expect.any(Array) }),
-      risks: expect.any(Array),
-      evidence: expect.any(Array),
-      permission: expect.any(Object),
+      risk: expect.objectContaining({ items: expect.any(Array) }),
+      evidence: expect.objectContaining({ items: expect.any(Array) }),
+      permission: expect.objectContaining({ canInitiateLinkage: expect.any(Boolean) }),
     });
   });
 
@@ -36,24 +44,30 @@ describe('TraceabilityQueryService contract', () => {
 
     expect(response.canViewSummary).toBe(true);
     expect(response.canViewDetail).toBe(true);
-    expect(response.canInitiateAction).toBe(true);
+    expect(response.canInitiateLinkage).toBe(true);
     expect(response.canExecuteHighRiskAction).toBe(false);
   });
 
   it('assembles the main traceability chain for a material lot query', async () => {
     const prisma = {
       materialBatch: {
-        findFirst: jest.fn().mockResolvedValue({
+        findUnique: jest.fn().mockResolvedValue({
           id: 'mb-1',
-          batch_no: 'RM-001',
-          batchMaterialUsages: [{ id: 'use-1', productionBatchId: 'pb-1', quantity: 25 }],
+          batchNumber: 'RM-001',
+          material: null,
+          supplier: null,
+          batchMaterialUsages: [
+            {
+              id: 'use-1',
+              quantity: 25,
+              productionBatch: {
+                id: 'pb-1',
+                batchNumber: 'PB-001',
+                delivery_notes: [{ id: 'dn-1', dn_no: 'DN-001', customer_name: '客户A', shipped_qty: 100, unit: '箱' }],
+              },
+            },
+          ],
         }),
-      },
-      // TASK-9: finishedGoods removed from productionBatch — no fg nodes in ledger
-      productionBatch: {
-        findMany: jest.fn().mockResolvedValue([
-          { id: 'pb-1', batch_no: 'PB-001', delivery_notes: [{ id: 'dn-1', delivery_no: 'DN-001' }] },
-        ]),
       },
     };
 
@@ -70,11 +84,134 @@ describe('TraceabilityQueryService contract', () => {
       { department: '品质', scenarioPermissions: ['forwardTrace'] } as any,
     );
 
-    expect(result.ledger.map((row) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
       'materialLot',
       'ingredientUsage',
       'productionBatch',
       'deliveryNote',
+    ]);
+  });
+
+  it('assembles a bidirectional chain for a production batch query', async () => {
+    const prisma = {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'pb-1',
+          batchNumber: 'PB-001',
+          productName: '海绵蛋糕',
+          status: 'completed',
+          materialUsages: [
+            {
+              id: 'use-1',
+              quantity: 25,
+              materialBatch: {
+                id: 'mb-1',
+                batchNumber: 'RM-001',
+                supplierBatchNo: 'SUP-001',
+                material: { id: 'mat-1', name: '面粉' },
+                supplier: { id: 'sup-1', name: '合格供应商' },
+              },
+            },
+          ],
+          delivery_notes: [
+            {
+              id: 10,
+              dn_no: 'DN-001',
+              customer_name: '客户A',
+              shipped_qty: 100,
+              unit: '箱',
+            },
+          ],
+        }),
+      },
+    };
+
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'productionBatch',
+        objectId: 'pb-1',
+        traceMode: 'bidirectional',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['bidirectionalTrace'] } as any,
+    );
+
+    expect(result.summary).toMatchObject({
+      objectType: 'productionBatch',
+      objectId: 'pb-1',
+      traceMode: 'bidirectional',
+      resultStatus: 'ok',
+    });
+    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
+      'materialLot',
+      'ingredientUsage',
+      'productionBatch',
+      'deliveryNote',
+    ]);
+    expect(result.graph.edges.map((edge) => edge.relationType)).toEqual([
+      'usedIn',
+      'produces',
+      'shippedBy',
+    ]);
+  });
+
+  it('assembles a backward chain from a delivery note query', async () => {
+    const prisma = {
+      deliveryNote: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 10,
+          dn_no: 'DN-001',
+          customer_name: '客户A',
+          shipped_qty: 100,
+          unit: '箱',
+          production_batch: {
+            id: 'pb-1',
+            batchNumber: 'PB-001',
+            productName: '海绵蛋糕',
+            materialUsages: [
+              {
+                id: 'use-1',
+                quantity: 25,
+                materialBatch: {
+                  id: 'mb-1',
+                  batchNumber: 'RM-001',
+                  material: { id: 'mat-1', name: '面粉' },
+                  supplier: { id: 'sup-1', name: '合格供应商' },
+                },
+              },
+            ],
+          },
+        }),
+      },
+    };
+
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'deliveryNote',
+        objectId: '10',
+        traceMode: 'backward',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['backwardTrace'] } as any,
+    );
+
+    expect(result.summary).toMatchObject({
+      objectType: 'deliveryNote',
+      objectId: '10',
+      traceMode: 'backward',
+      resultStatus: 'ok',
+    });
+    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
+      'deliveryNote',
+      'productionBatch',
+      'ingredientUsage',
+      'materialLot',
     ]);
   });
 });

--- a/server/src/modules/traceability/traceability-query.service.spec.ts
+++ b/server/src/modules/traceability/traceability-query.service.spec.ts
@@ -4,7 +4,7 @@ describe('TraceabilityQueryService contract', () => {
   it('builds a ledger-and-graph result with stable top-level keys', async () => {
     const prisma = {
       materialBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'mb-1',
           batchNumber: 'RM-001',
           material: null,
@@ -51,7 +51,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles the main traceability chain for a material lot query', async () => {
     const prisma = {
       materialBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'mb-1',
           batchNumber: 'RM-001',
           material: null,
@@ -95,7 +95,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles a bidirectional chain for a production batch query', async () => {
     const prisma = {
       productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 'pb-1',
           batchNumber: 'PB-001',
           productName: '海绵蛋糕',
@@ -161,7 +161,7 @@ describe('TraceabilityQueryService contract', () => {
   it('assembles a backward chain from a delivery note query', async () => {
     const prisma = {
       deliveryNote: {
-        findUnique: jest.fn().mockResolvedValue({
+        findFirst: jest.fn().mockResolvedValue({
           id: 10,
           dn_no: 'DN-001',
           customer_name: '客户A',
@@ -213,5 +213,77 @@ describe('TraceabilityQueryService contract', () => {
       'ingredientUsage',
       'materialLot',
     ]);
+  });
+
+  it('returns empty result when materialLot objectId belongs to a different company', async () => {
+    const prisma = {
+      materialBatch: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'materialLot',
+        objectId: 'mb-other-company',
+        traceMode: 'forward',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['forwardTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
+  });
+
+  it('returns empty result when productionBatch objectId belongs to a different company', async () => {
+    const prisma = {
+      productionBatch: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'productionBatch',
+        objectId: 'pb-other-company',
+        traceMode: 'bidirectional',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['bidirectionalTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
+  });
+
+  it('returns empty result when deliveryNote objectId belongs to a different company', async () => {
+    const prisma = {
+      deliveryNote: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+    const service = new TraceabilityQueryService(prisma as any, { getSummary: jest.fn() } as any);
+    const result = await service.query(
+      {
+        entryMode: 'object',
+        objectType: 'deliveryNote',
+        objectId: '99',
+        traceMode: 'backward',
+        viewMode: 'ledger',
+        timeMode: 'current',
+      },
+      { department: '品质', scenarioPermissions: ['backwardTrace'], companyId: 'company-A' } as any,
+    );
+
+    expect(result.summary.resultStatus).toBe('empty');
+    expect(result.ledger.rows).toHaveLength(0);
+    expect(result.graph.nodes).toHaveLength(0);
   });
 });

--- a/server/src/modules/traceability/traceability-query.service.spec.ts
+++ b/server/src/modules/traceability/traceability-query.service.spec.ts
@@ -1,3 +1,4 @@
+import type { TraceEdge, TraceNode } from '@noidear/types';
 import { TraceabilityQueryService } from './traceability-query.service';
 
 describe('TraceabilityQueryService contract', () => {
@@ -84,7 +85,7 @@ describe('TraceabilityQueryService contract', () => {
       { department: '品质', scenarioPermissions: ['forwardTrace'] } as any,
     );
 
-    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
       'materialLot',
       'ingredientUsage',
       'productionBatch',
@@ -145,13 +146,13 @@ describe('TraceabilityQueryService contract', () => {
       traceMode: 'bidirectional',
       resultStatus: 'ok',
     });
-    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
       'materialLot',
       'ingredientUsage',
       'productionBatch',
       'deliveryNote',
     ]);
-    expect(result.graph.edges.map((edge) => edge.relationType)).toEqual([
+    expect(result.graph.edges.map((edge: TraceEdge) => edge.relationType)).toEqual([
       'usedIn',
       'produces',
       'shippedBy',
@@ -207,7 +208,7 @@ describe('TraceabilityQueryService contract', () => {
       traceMode: 'backward',
       resultStatus: 'ok',
     });
-    expect(result.ledger.rows.map((row) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
       'deliveryNote',
       'productionBatch',
       'ingredientUsage',

--- a/server/src/modules/traceability/traceability-query.service.spec.ts
+++ b/server/src/modules/traceability/traceability-query.service.spec.ts
@@ -1,4 +1,3 @@
-import type { TraceEdge, TraceNode } from '@noidear/types';
 import { TraceabilityQueryService } from './traceability-query.service';
 
 describe('TraceabilityQueryService contract', () => {
@@ -85,7 +84,7 @@ describe('TraceabilityQueryService contract', () => {
       { department: '品质', scenarioPermissions: ['forwardTrace'] } as any,
     );
 
-    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: { nodeType: string }) => row.nodeType)).toEqual([
       'materialLot',
       'ingredientUsage',
       'productionBatch',
@@ -146,13 +145,13 @@ describe('TraceabilityQueryService contract', () => {
       traceMode: 'bidirectional',
       resultStatus: 'ok',
     });
-    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: { nodeType: string }) => row.nodeType)).toEqual([
       'materialLot',
       'ingredientUsage',
       'productionBatch',
       'deliveryNote',
     ]);
-    expect(result.graph.edges.map((edge: TraceEdge) => edge.relationType)).toEqual([
+    expect(result.graph.edges.map((edge: { relationType: string }) => edge.relationType)).toEqual([
       'usedIn',
       'produces',
       'shippedBy',
@@ -208,7 +207,7 @@ describe('TraceabilityQueryService contract', () => {
       traceMode: 'backward',
       resultStatus: 'ok',
     });
-    expect(result.ledger.rows.map((row: TraceNode) => row.nodeType)).toEqual([
+    expect(result.ledger.rows.map((row: { nodeType: string }) => row.nodeType)).toEqual([
       'deliveryNote',
       'productionBatch',
       'ingredientUsage',

--- a/server/src/modules/traceability/traceability-query.service.ts
+++ b/server/src/modules/traceability/traceability-query.service.ts
@@ -2,7 +2,6 @@ import { ForbiddenException, Injectable } from '@nestjs/common';
 import { ModelLandingService } from '../model-landing/model-landing.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { QueryTraceabilityDto } from './dto/query-traceability.dto';
-import type { TraceQueryResult } from '@noidear/types';
 import {
   SOURCE_VERSION,
   buildTraceResult,
@@ -12,6 +11,8 @@ import {
   materialLotNode,
   productionBatchNode,
 } from './traceability-contract.mapper';
+
+type TraceQueryResult = ReturnType<typeof buildTraceResult>;
 
 @Injectable()
 export class TraceabilityQueryService {

--- a/server/src/modules/traceability/traceability-query.service.ts
+++ b/server/src/modules/traceability/traceability-query.service.ts
@@ -109,8 +109,16 @@ export class TraceabilityQueryService {
   }
 
   private async queryMaterialLot(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
-    const materialLot = await this.prisma.materialBatch.findUnique({
-      where: { id: dto.objectId },
+    // Material has no direct company_id; scope via production batch → product.company_id
+    const companyWhere = currentUser?.companyId
+      ? {
+          batchMaterialUsages: {
+            some: { productionBatch: { product: { company_id: currentUser.companyId } } },
+          },
+        }
+      : {};
+    const materialLot = await this.prisma.materialBatch.findFirst({
+      where: { id: dto.objectId, ...companyWhere },
       include: {
         material: true,
         supplier: true,
@@ -164,8 +172,11 @@ export class TraceabilityQueryService {
   }
 
   private async queryProductionBatch(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
-    const productionBatch = await this.prisma.productionBatch.findUnique({
-      where: { id: dto.objectId },
+    const companyWhere = currentUser?.companyId
+      ? { product: { company_id: currentUser.companyId } }
+      : {};
+    const productionBatch = await this.prisma.productionBatch.findFirst({
+      where: { id: dto.objectId, ...companyWhere },
       include: {
         materialUsages: {
           include: {
@@ -218,8 +229,11 @@ export class TraceabilityQueryService {
     const deliveryId = Number(dto.objectId);
     if (!Number.isInteger(deliveryId)) return this.emptyResult(dto, currentUser);
 
-    const deliveryNote = await this.prisma.deliveryNote.findUnique({
-      where: { id: deliveryId },
+    const companyWhere = currentUser?.companyId
+      ? { company_id: Number(currentUser.companyId) }
+      : {};
+    const deliveryNote = await this.prisma.deliveryNote.findFirst({
+      where: { id: deliveryId, ...companyWhere },
       include: {
         production_batch: {
           include: {

--- a/server/src/modules/traceability/traceability-query.service.ts
+++ b/server/src/modules/traceability/traceability-query.service.ts
@@ -2,37 +2,16 @@ import { ForbiddenException, Injectable } from '@nestjs/common';
 import { ModelLandingService } from '../model-landing/model-landing.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { QueryTraceabilityDto } from './dto/query-traceability.dto';
-
-type TraceRiskLevel = 'normal' | 'minor' | 'important' | 'high';
-
-interface TraceLedgerRow {
-  nodeType: string;
-  nodeId: string;
-  label: string;
-  batchNo?: string;
-  status?: string;
-  riskLevel?: TraceRiskLevel;
-  upstreamNodeId?: string;
-  downstreamNodeId?: string;
-}
-
-interface TraceQueryResult {
-  summary: {
-    entryMode?: string;
-    objectType?: string;
-    objectId?: string;
-    scenario?: string;
-    traceMode?: string;
-    viewMode?: string;
-    timeMode?: string;
-    asOfAt?: string;
-  };
-  ledger: TraceLedgerRow[];
-  graph: { nodes: Array<{ id: string; type: string; label: string; riskLevel?: TraceRiskLevel }>; edges: Array<{ id: string; source: string; target: string; relation: string }> };
-  risks: Array<{ code: string; level: TraceRiskLevel; message: string }>;
-  evidence: Array<{ type: 'record'; label: string; refId: string }>;
-  permission: { canViewSummary: boolean; canViewDetail: boolean; canInitiateAction: boolean; canExecuteHighRiskAction: boolean };
-}
+import type { TraceQueryResult } from '@noidear/types';
+import {
+  SOURCE_VERSION,
+  buildTraceResult,
+  deliveryNoteNode,
+  edge,
+  ingredientUsageNode,
+  materialLotNode,
+  productionBatchNode,
+} from './traceability-contract.mapper';
 
 @Injectable()
 export class TraceabilityQueryService {
@@ -44,28 +23,20 @@ export class TraceabilityQueryService {
   async query(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
     this.assertScenarioPermission(dto, currentUser);
 
-    const summary = {
-      entryMode: dto.entryMode,
-      objectType: dto.objectType,
-      objectId: dto.objectId,
-      scenario: dto.scenario,
-      traceMode: dto.traceMode,
-      viewMode: dto.viewMode,
-      timeMode: dto.timeMode,
-      asOfAt: dto.asOfAt,
-    };
+    if (dto.entryMode === 'object' && dto.objectType === 'materialLot' && dto.objectId) {
+      return this.queryMaterialLot(dto, currentUser);
+    }
+    if (dto.entryMode === 'object' && dto.objectType === 'productionBatch' && dto.objectId) {
+      return this.queryProductionBatch(dto, currentUser);
+    }
+    if (dto.entryMode === 'object' && dto.objectType === 'deliveryNote' && dto.objectId) {
+      return this.queryDeliveryNote(dto, currentUser);
+    }
+    if (dto.entryMode === 'scenario') {
+      return this.queryScenario(dto, currentUser);
+    }
 
-    const ledger = await this.buildLedger(dto);
-    const graph = this.buildGraph(ledger);
-
-    return {
-      summary,
-      ledger,
-      graph,
-      risks: this.buildRisks(ledger),
-      evidence: this.buildEvidenceRefs(ledger),
-      permission: this.buildPermissionView(currentUser),
-    };
+    return this.emptyResult(dto, currentUser);
   }
 
   private assertScenarioPermission(dto: QueryTraceabilityDto, currentUser: any): void {
@@ -81,124 +52,236 @@ export class TraceabilityQueryService {
     }
   }
 
-  private async buildLedger(dto: QueryTraceabilityDto): Promise<TraceLedgerRow[]> {
-    if (dto.objectType === 'materialLot' && dto.objectId) {
-      return this.buildForwardLedgerFromMaterialLot(dto.objectId);
-    }
-    return [];
+  private buildPermissionView(currentUser: any) {
+    return {
+      departmentScope: currentUser?.department ?? 'unknown',
+      scenarioPermissions: currentUser?.scenarioPermissions ?? [],
+      canViewSummary: true,
+      canViewDetail: currentUser?.department !== '访客',
+      canViewEvidence: currentUser?.department !== '访客',
+      canInitiateLinkage: Boolean(currentUser?.scenarioPermissions?.length),
+      canExportSimple: true,
+      canExportFullPackage:
+        currentUser?.department === '品质' || currentUser?.department === '管理层',
+      canUseAsOfPlayback: true,
+      canExecuteHighRiskAction:
+        currentUser?.department === '品质' || currentUser?.department === '管理层',
+    };
   }
 
-  private async buildForwardLedgerFromMaterialLot(objectId: string): Promise<TraceLedgerRow[]> {
-    const materialLot: any = await this.prisma.materialBatch.findFirst({
-      where: { id: objectId },
-      include: { batchMaterialUsages: true },
+  private emptyResult(dto: QueryTraceabilityDto, currentUser: any): TraceQueryResult {
+    return {
+      summary: {
+        queryId: `empty:${dto.objectType ?? dto.scenario ?? 'unknown'}:${dto.objectId ?? 'none'}`,
+        entryMode: dto.entryMode,
+        objectType: dto.objectType,
+        objectId: dto.objectId,
+        scenario: dto.scenario,
+        traceMode: dto.traceMode,
+        viewMode: dto.viewMode,
+        timeMode: dto.timeMode,
+        asOfAt: dto.asOfAt,
+        riskLevel: 'normal',
+        resultStatus: 'empty',
+      },
+      permission: this.buildPermissionView(currentUser),
+      risk: { summaryRiskLevel: 'normal', riskCount: 0, highRiskCount: 0, items: [] },
+      ledger: {
+        columns: [{ key: 'label', label: '节点' }],
+        rows: [],
+        grouping: ['nodeType'],
+        totals: { rowCount: 0 },
+      },
+      graph: { nodes: [], edges: [], layout: 'vertical', legend: ['mainChain'] },
+      evidence: { count: 0, items: [] },
+      actions: { available: [], recommended: [], created: [] },
+      export: { simpleExportAvailable: true, fullPackageAvailable: true, latestExportId: null },
+      meta: {
+        generatedAt: new Date().toISOString(),
+        queryHash: `empty:${dto.objectId ?? dto.scenario ?? 'unknown'}`,
+        degraded: false,
+        snapshotId: null,
+        sourceVersion: SOURCE_VERSION,
+      },
+      extensions: {},
+    } as unknown as TraceQueryResult;
+  }
+
+  private async queryMaterialLot(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
+    const materialLot = await this.prisma.materialBatch.findUnique({
+      where: { id: dto.objectId },
+      include: {
+        material: true,
+        supplier: true,
+        batchMaterialUsages: {
+          include: {
+            productionBatch: {
+              include: { delivery_notes: true },
+            },
+          },
+        },
+      },
     });
 
-    if (!materialLot) return [];
+    if (!materialLot) return this.emptyResult(dto, currentUser);
 
-    const batchLabel: string = materialLot.batch_no ?? materialLot.batchNumber ?? materialLot.id;
+    return buildTraceResult({
+      queryId: `forward:${materialLot.id}`,
+      entryMode: dto.entryMode as 'object',
+      objectType: dto.objectType,
+      objectId: dto.objectId,
+      traceMode: dto.traceMode as 'forward' | 'backward' | 'bidirectional',
+      viewMode: dto.viewMode as 'ledger' | 'graph',
+      timeMode: dto.timeMode as 'current' | 'asOf',
+      asOfAt: dto.asOfAt,
+      permission: this.buildPermissionView(currentUser),
+      ...this.materialLotChain(materialLot, dto.traceMode as 'forward' | 'backward' | 'bidirectional'),
+    }) as unknown as TraceQueryResult;
+  }
 
-    const rows: TraceLedgerRow[] = [
-      {
-        nodeType: 'materialLot',
-        nodeId: materialLot.id,
-        label: batchLabel,
-        batchNo: batchLabel,
-      },
-    ];
+  private materialLotChain(
+    materialLot: any,
+    direction: 'forward' | 'backward' | 'bidirectional',
+  ) {
+    const rows = [materialLotNode(materialLot)];
+    const edges: any[] = [];
 
-    const usages: any[] = materialLot.batchMaterialUsages ?? [];
-    const productionBatchIds = usages.map((u: any) => u.productionBatchId);
-
-    for (const usage of usages) {
-      rows.push({
-        nodeType: 'ingredientUsage',
-        nodeId: usage.id,
-        label: `投料 ${usage.quantity}`,
-        upstreamNodeId: materialLot.id,
-        downstreamNodeId: usage.productionBatchId,
-      });
-    }
-
-    if (productionBatchIds.length > 0) {
-      // TASK-9: finishedGoods (FinishedGoodsBatch) removed; productionBatch is terminal node
-      const productionBatches = await this.prisma.productionBatch.findMany({
-        where: { id: { in: productionBatchIds } },
-        include: {
-          delivery_notes: true,
-        },
-      });
-
-      for (const pb of productionBatches as any[]) {
-        rows.push({
-          nodeType: 'productionBatch',
-          nodeId: pb.id,
-          label: pb.batch_no,
-          batchNo: pb.batch_no,
-        });
-
-        for (const dn of pb.delivery_notes as any[]) {
-          rows.push({
-            nodeType: 'deliveryNote',
-            nodeId: dn.id,
-            label: dn.delivery_no,
-            upstreamNodeId: pb.id,
-          });
+    for (const usage of materialLot.batchMaterialUsages ?? []) {
+      rows.push(ingredientUsageNode(usage));
+      if (usage.productionBatch) rows.push(productionBatchNode(usage.productionBatch));
+      edges.push(edge(materialLot.id, usage.id, 'usedIn', direction, edges.length));
+      if (usage.productionBatch) {
+        edges.push(edge(usage.id, usage.productionBatch.id, 'produces', direction, edges.length));
+        for (const dn of usage.productionBatch.delivery_notes ?? []) {
+          rows.push(deliveryNoteNode(dn));
+          edges.push(edge(usage.productionBatch.id, String(dn.id), 'shippedBy', direction, edges.length));
         }
       }
     }
 
-    return rows;
+    return { rows, edges };
   }
 
-  private buildGraph(ledger: TraceLedgerRow[]) {
-    return {
-      nodes: ledger.map((row) => ({
-        id: row.nodeId,
-        type: row.nodeType,
-        label: row.label,
-        riskLevel: row.riskLevel,
-      })),
-      edges: ledger
-        .filter((row) => row.upstreamNodeId && row.downstreamNodeId)
-        .map((row) => ({
-          id: `${row.upstreamNodeId}:${row.downstreamNodeId}`,
-          source: row.upstreamNodeId as string,
-          target: row.downstreamNodeId as string,
-          relation: row.nodeType,
-        })),
-    };
+  private async queryProductionBatch(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
+    const productionBatch = await this.prisma.productionBatch.findUnique({
+      where: { id: dto.objectId },
+      include: {
+        materialUsages: {
+          include: {
+            materialBatch: {
+              include: { material: true, supplier: true },
+            },
+          },
+        },
+        delivery_notes: true,
+      },
+    });
+
+    if (!productionBatch) return this.emptyResult(dto, currentUser);
+
+    const rows: any[] = [];
+    const edges: any[] = [];
+
+    for (const usage of (productionBatch as any).materialUsages ?? []) {
+      if (usage.materialBatch) rows.push(materialLotNode(usage.materialBatch));
+      rows.push(ingredientUsageNode(usage));
+      if (usage.materialBatch) {
+        edges.push(edge(usage.materialBatch.id, usage.id, 'usedIn', dto.traceMode as any, edges.length));
+      }
+      edges.push(edge(usage.id, productionBatch.id, 'produces', dto.traceMode as any, edges.length));
+    }
+
+    rows.push(productionBatchNode(productionBatch));
+
+    for (const dn of (productionBatch as any).delivery_notes ?? []) {
+      rows.push(deliveryNoteNode(dn));
+      edges.push(edge(productionBatch.id, String(dn.id), 'shippedBy', dto.traceMode as any, edges.length));
+    }
+
+    return buildTraceResult({
+      queryId: `${dto.traceMode}:${productionBatch.id}`,
+      entryMode: dto.entryMode as 'object',
+      objectType: dto.objectType,
+      objectId: dto.objectId,
+      traceMode: dto.traceMode as 'forward' | 'backward' | 'bidirectional',
+      viewMode: dto.viewMode as 'ledger' | 'graph',
+      timeMode: dto.timeMode as 'current' | 'asOf',
+      asOfAt: dto.asOfAt,
+      permission: this.buildPermissionView(currentUser),
+      rows,
+      edges,
+    }) as unknown as TraceQueryResult;
   }
 
-  private buildRisks(ledger: TraceLedgerRow[]) {
-    return ledger
-      .filter((row) => row.riskLevel && row.riskLevel !== 'normal')
-      .map((row) => ({
-        code: row.nodeType,
-        level: row.riskLevel as TraceRiskLevel,
-        message: `${row.label} 存在风险标记`,
-      }));
+  private async queryDeliveryNote(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
+    const deliveryId = Number(dto.objectId);
+    if (!Number.isInteger(deliveryId)) return this.emptyResult(dto, currentUser);
+
+    const deliveryNote = await this.prisma.deliveryNote.findUnique({
+      where: { id: deliveryId },
+      include: {
+        production_batch: {
+          include: {
+            materialUsages: {
+              include: {
+                materialBatch: {
+                  include: { material: true, supplier: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!deliveryNote) return this.emptyResult(dto, currentUser);
+
+    const rows: any[] = [deliveryNoteNode(deliveryNote)];
+    const edges: any[] = [];
+    const productionBatch = (deliveryNote as any).production_batch;
+    rows.push(productionBatchNode(productionBatch));
+    edges.push(edge(String(deliveryNote.id), productionBatch.id, 'shipsFrom', 'backward', edges.length));
+
+    for (const usage of productionBatch.materialUsages ?? []) {
+      rows.push(ingredientUsageNode(usage));
+      if (usage.materialBatch) rows.push(materialLotNode(usage.materialBatch));
+      edges.push(edge(productionBatch.id, usage.id, 'containsUsage', 'backward', edges.length));
+      if (usage.materialBatch) {
+        edges.push(edge(usage.id, usage.materialBatch.id, 'usesLot', 'backward', edges.length));
+      }
+    }
+
+    return buildTraceResult({
+      queryId: `backward:${deliveryNote.id}`,
+      entryMode: dto.entryMode as 'object',
+      objectType: dto.objectType,
+      objectId: dto.objectId,
+      traceMode: dto.traceMode as 'forward' | 'backward' | 'bidirectional',
+      viewMode: dto.viewMode as 'ledger' | 'graph',
+      timeMode: dto.timeMode as 'current' | 'asOf',
+      asOfAt: dto.asOfAt,
+      permission: this.buildPermissionView(currentUser),
+      rows,
+      edges,
+    }) as unknown as TraceQueryResult;
   }
 
-  private buildEvidenceRefs(ledger: TraceLedgerRow[]) {
-    return ledger.map((row) => ({
-      type: 'record' as const,
-      label: row.label,
-      refId: row.nodeId,
-    }));
+  private async queryScenario(dto: QueryTraceabilityDto, currentUser: any): Promise<TraceQueryResult> {
+    const objectId =
+      typeof (dto as any).filters?.objectId === 'string'
+        ? (dto as any).filters.objectId
+        : dto.objectId;
+    const objectType =
+      typeof (dto as any).filters?.objectType === 'string'
+        ? (dto as any).filters.objectType
+        : dto.objectType;
+
+    if (!objectId || !objectType) return this.emptyResult(dto, currentUser);
+
+    return this.query({ ...dto, entryMode: 'object', objectType, objectId }, currentUser);
   }
 
   getTraceabilityPermissionView(currentUser: any) {
     return this.buildPermissionView(currentUser);
-  }
-
-  private buildPermissionView(currentUser: any) {
-    return {
-      canViewSummary: true,
-      canViewDetail: currentUser?.department !== '访客',
-      canInitiateAction: Boolean(currentUser?.scenarioPermissions?.length),
-      canExecuteHighRiskAction:
-        currentUser?.department === '品质' || currentUser?.department === '管理层',
-    };
   }
 }

--- a/server/src/modules/traceability/traceability.service.ts
+++ b/server/src/modules/traceability/traceability.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { mapForwardTraceResult, SOURCE_VERSION } from './traceability-contract.mapper';
+import { SOURCE_VERSION } from './traceability-contract.mapper';
+import { TraceabilityQueryService } from './traceability-query.service';
 
 interface TraceCurrentUser {
   id?: string;
@@ -39,86 +40,16 @@ interface TraceBalanceDto {
   materialLotId?: string;
 }
 
-const HIGH_RISK_DEPARTMENTS = ['品质', '管理层'];
-
-const buildPermission = (currentUser: TraceCurrentUser, isHighRisk: boolean) => ({
-  departmentScope: currentUser?.department ?? 'unknown',
-  scenarioPermissions: currentUser?.scenarioPermissions ?? [],
-  canViewSummary: true,
-  canViewDetail: true,
-  canViewEvidence: true,
-  canInitiateLinkage: true,
-  canExportSimple: true,
-  canExportFullPackage: true,
-  canUseAsOfPlayback: true,
-  canExecuteHighRiskAction: isHighRisk,
-});
-
-const buildEmptyResult = (dto: TraceQueryDto, currentUser: TraceCurrentUser) => ({
-  summary: {
-    queryId: `missing:${dto.objectId ?? 'unknown'}`,
-    entryMode: dto.entryMode,
-    objectType: dto.objectType,
-    objectId: dto.objectId,
-    traceMode: dto.traceMode,
-    viewMode: dto.viewMode,
-    timeMode: dto.timeMode,
-    riskLevel: 'normal' as const,
-    resultStatus: 'empty' as const,
-  },
-  permission: buildPermission(currentUser, false),
-  risk: { summaryRiskLevel: 'normal' as const, riskCount: 0, highRiskCount: 0, items: [] },
-  ledger: { columns: [], rows: [], grouping: [], totals: {} },
-  graph: { nodes: [], edges: [], layout: 'vertical', legend: [] },
-  evidence: { count: 0, items: [] },
-  actions: { available: [], recommended: [], created: [] },
-  export: { simpleExportAvailable: true, fullPackageAvailable: true, latestExportId: null as string | null },
-  meta: {
-    generatedAt: new Date().toISOString(),
-    queryHash: `missing:${dto.objectId}`,
-    degraded: false,
-    snapshotId: null as string | null,
-    sourceVersion: SOURCE_VERSION,
-  },
-  extensions: {},
-});
-
-const MATERIAL_LOT_INCLUDE = {
-  batchMaterialUsages: {
-    include: {
-      productionBatch: {
-        include: { delivery_notes: true },
-      },
-    },
-  },
-};
 
 @Injectable()
 export class TraceabilityService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly traceabilityQueryService: TraceabilityQueryService,
+  ) {}
 
   async query(dto: TraceQueryDto, currentUser: TraceCurrentUser) {
-    const isMaterialLotQuery =
-      dto.entryMode === 'object' &&
-      dto.objectType === 'materialLot' &&
-      dto.objectId;
-
-    if (!isMaterialLotQuery) return buildEmptyResult(dto, currentUser);
-
-    try {
-      const materialBatch = await this.prisma.materialBatch.findUnique({
-        where: { id: dto.objectId },
-        include: MATERIAL_LOT_INCLUDE,
-      });
-
-      if (!materialBatch) return buildEmptyResult(dto, currentUser);
-
-      const isHighRisk = HIGH_RISK_DEPARTMENTS.includes(currentUser?.department ?? '');
-
-      return mapForwardTraceResult(materialBatch, buildPermission(currentUser, isHighRisk));
-    } catch (error) {
-      throw new Error(`Traceability query failed: ${(error as Error).message}`);
-    }
+    return this.traceabilityQueryService.query(dto as any, currentUser);
   }
 
   async balance(dto: TraceBalanceDto, _currentUser: TraceCurrentUser) {


### PR DESCRIPTION
## Summary

- Completes GAP-307 traceability query chain against the frozen traceability contract.
- Includes tenant-scoped object queries for materialLot, productionBatch, and deliveryNote.
- Supersedes closed PR #136 and branch-level fix PR #147.

## Verification

- `cd server && ./node_modules/.bin/jest traceability-query.service.spec.ts traceability-contract.mapper.spec.ts --runInBand` -> 18 tests passed
- `git diff --check --cached` -> passed during local mergecheck against current master

## Notes

- This PR targets `master`; #147 only merged into the intermediate branch `fix/gap-307-ts-errors`.