### PR TITLE
fix(GAP-308): add tenant isolation to snapshot read endpoints

### DIFF
--- a/server/src/modules/traceability/traceability-export.service.spec.ts
+++ b/server/src/modules/traceability/traceability-export.service.spec.ts
@@ -1,4 +1,4 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { TraceabilityExportService } from './traceability-export.service';
 
 const createPrisma = () => ({
@@ -10,6 +10,7 @@ const createPrisma = () => ({
 
 const snapshotRow = {
   id: 'snap-1',
+  company_id: 'company-1',
   sourceQueryHash: 'hash-001',
   exportMode: 'simple',
   requesterId: 'user-1',
@@ -150,12 +151,12 @@ describe('TraceabilityExportService', () => {
     });
   });
 
-  it('reads snapshots from database', async () => {
+  it('reads snapshots from database for same-tenant user', async () => {
     const prisma = createPrisma();
     prisma.traceabilitySnapshot.findUnique.mockResolvedValue(snapshotRow);
     const service = new TraceabilityExportService(prisma as any);
 
-    const result = await service.getSnapshot('snap-1');
+    const result = await service.getSnapshot('snap-1', { id: 'user-1', companyId: 'company-1' });
 
     expect(prisma.traceabilitySnapshot.findUnique).toHaveBeenCalledWith({ where: { id: 'snap-1' } });
     expect(result).toMatchObject({
@@ -166,12 +167,22 @@ describe('TraceabilityExportService', () => {
     });
   });
 
+  it('rejects cross-tenant snapshot reads with ForbiddenException', async () => {
+    const prisma = createPrisma();
+    prisma.traceabilitySnapshot.findUnique.mockResolvedValue(snapshotRow);
+    const service = new TraceabilityExportService(prisma as any);
+
+    await expect(
+      service.getSnapshot('snap-1', { id: 'attacker', companyId: 'other-company' }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('throws NotFoundException for missing snapshots', async () => {
     const prisma = createPrisma();
     prisma.traceabilitySnapshot.findUnique.mockResolvedValue(null);
     const service = new TraceabilityExportService(prisma as any);
 
-    await expect(service.getSnapshot('missing')).rejects.toBeInstanceOf(NotFoundException);
+    await expect(service.getSnapshot('missing', { id: 'user-1', companyId: 'company-1' })).rejects.toBeInstanceOf(NotFoundException);
   });
 
   it('returns persisted formal result payload for snapshot result', async () => {
@@ -179,7 +190,7 @@ describe('TraceabilityExportService', () => {
     prisma.traceabilitySnapshot.findUnique.mockResolvedValue(snapshotRow);
     const service = new TraceabilityExportService(prisma as any);
 
-    const result = await service.getSnapshotResult('snap-1') as any;
+    const result = await service.getSnapshotResult('snap-1', { id: 'user-1', companyId: 'company-1' }) as any;
 
     expect(result.summary.queryId).toBe('q-1');
     expect(result.meta.queryHash).toBe('hash-001');
@@ -193,6 +204,6 @@ describe('TraceabilityExportService', () => {
     });
     const service = new TraceabilityExportService(prisma as any);
 
-    await expect(service.getSnapshotResult('snap-1')).rejects.toBeInstanceOf(ConflictException);
+    await expect(service.getSnapshotResult('snap-1', { id: 'user-1', companyId: 'company-1' })).rejects.toBeInstanceOf(ConflictException);
   });
 });

--- a/server/src/modules/traceability/traceability-export.service.ts
+++ b/server/src/modules/traceability/traceability-export.service.ts
@@ -1,15 +1,16 @@
-import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateTraceabilityExportDto } from './dto/create-traceability-export.dto';
 import { CreateTraceabilitySnapshotDto } from './dto/create-traceability-snapshot.dto';
 
 type TraceCurrentUser = {
   id?: string;
+  companyId?: string;
 };
 
 type TraceabilitySnapshotRow = {
   id: string;
+  company_id: string | null;
   sourceQueryHash: string;
   exportMode: string;
   requesterId: string;
@@ -92,13 +93,13 @@ export class TraceabilityExportService {
     return this.mapSnapshot(row);
   }
 
-  async getSnapshot(snapshotId: string) {
-    const row = await this.findSnapshot(snapshotId);
+  async getSnapshot(snapshotId: string, currentUser: TraceCurrentUser) {
+    const row = await this.findSnapshot(snapshotId, currentUser);
     return this.mapSnapshot(row);
   }
 
-  async getSnapshotResult(snapshotId: string) {
-    const row = await this.findSnapshot(snapshotId);
+  async getSnapshotResult(snapshotId: string, currentUser: TraceCurrentUser) {
+    const row = await this.findSnapshot(snapshotId, currentUser);
     const summary = asSummary(row.summary);
 
     if (!summary.resultPayload) {
@@ -108,11 +109,16 @@ export class TraceabilityExportService {
     return summary.resultPayload;
   }
 
-  private async findSnapshot(snapshotId: string): Promise<TraceabilitySnapshotRow> {
+  private async findSnapshot(snapshotId: string, currentUser: TraceCurrentUser): Promise<TraceabilitySnapshotRow> {
     const row = await this.prisma.traceabilitySnapshot.findUnique({ where: { id: snapshotId } });
 
     if (!row) {
       throw new NotFoundException(`Traceability snapshot ${snapshotId} not found`);
+    }
+
+    const companyId = currentUser?.companyId;
+    if (companyId && (row as any).company_id && (row as any).company_id !== companyId) {
+      throw new ForbiddenException(`Traceability snapshot ${snapshotId} does not belong to the current tenant`);
     }
 
     return row as TraceabilitySnapshotRow;
@@ -148,12 +154,13 @@ export class TraceabilityExportService {
 
     return this.prisma.traceabilitySnapshot.create({
       data: {
+        company_id: input.currentUser?.companyId ?? null,
         sourceQueryHash: input.sourceQueryRef,
         exportMode: input.exportMode,
         requesterId,
         status: input.status,
         snapshotType: input.snapshotType,
-        summary: summary as unknown as Prisma.InputJsonValue,
+        summary: summary as unknown as object,
       },
     }) as Promise<TraceabilitySnapshotRow>;
   }

--- a/server/src/modules/traceability/traceability.controller.ts
+++ b/server/src/modules/traceability/traceability.controller.ts
@@ -43,12 +43,12 @@ export class TraceabilityController {
   }
 
   @Get('snapshots/:snapshotId')
-  getSnapshot(@Param('snapshotId') snapshotId: string) {
-    return this.service.getSnapshot(snapshotId);
+  getSnapshot(@Param('snapshotId') snapshotId: string, @Req() req: any) {
+    return this.service.getSnapshot(snapshotId, req.user);
   }
 
   @Get('snapshots/:snapshotId/result')
-  getSnapshotResult(@Param('snapshotId') snapshotId: string) {
-    return this.service.getSnapshotResult(snapshotId);
+  getSnapshotResult(@Param('snapshotId') snapshotId: string, @Req() req: any) {
+    return this.service.getSnapshotResult(snapshotId, req.user);
   }
 }

--- a/server/src/modules/traceability/traceability.service.spec.ts
+++ b/server/src/modules/traceability/traceability.service.spec.ts
@@ -26,11 +26,14 @@ describe('TraceabilityService snapshot/export delegation', () => {
       getSnapshotResult: jest.fn().mockResolvedValue({ summary: { queryId: 'q-1' } }),
     };
     const service = new TraceabilityService(prisma as any, queryService as any, exportService as any);
+    const currentUser = { id: 'user-2', companyId: 'company-1' };
 
     await expect(
-      service.createSnapshot({ sourceQueryRef: 'hash-002', snapshotType: 'query' }, { id: 'user-2' }),
+      service.createSnapshot({ sourceQueryRef: 'hash-002', snapshotType: 'query' }, currentUser),
     ).resolves.toMatchObject({ snapshotId: 'snap-2' });
-    await expect(service.getSnapshot('snap-2')).resolves.toMatchObject({ snapshotId: 'snap-2' });
-    await expect(service.getSnapshotResult('snap-2')).resolves.toMatchObject({ summary: { queryId: 'q-1' } });
+    await expect(service.getSnapshot('snap-2', currentUser)).resolves.toMatchObject({ snapshotId: 'snap-2' });
+    await expect(service.getSnapshotResult('snap-2', currentUser)).resolves.toMatchObject({ summary: { queryId: 'q-1' } });
+    expect(exportService.getSnapshot).toHaveBeenCalledWith('snap-2', currentUser);
+    expect(exportService.getSnapshotResult).toHaveBeenCalledWith('snap-2', currentUser);
   });
 });

--- a/server/src/modules/traceability/traceability.service.ts
+++ b/server/src/modules/traceability/traceability.service.ts
@@ -6,6 +6,7 @@ import { TraceabilityExportService } from './traceability-export.service';
 
 interface TraceCurrentUser {
   id?: string;
+  companyId?: string;
   department?: string;
   scenarioPermissions?: string[];
 }
@@ -104,11 +105,11 @@ export class TraceabilityService {
     return this.exportService.createSnapshot(dto as any, currentUser);
   }
 
-  async getSnapshot(snapshotId: string) {
-    return this.exportService.getSnapshot(snapshotId);
+  async getSnapshot(snapshotId: string, currentUser: TraceCurrentUser) {
+    return this.exportService.getSnapshot(snapshotId, currentUser);
   }
 
-  async getSnapshotResult(snapshotId: string) {
-    return this.exportService.getSnapshotResult(snapshotId);
+  async getSnapshotResult(snapshotId: string, currentUser: TraceCurrentUser) {
+    return this.exportService.getSnapshotResult(snapshotId, currentUser);
   }
 }

--- a/server/src/prisma/migrations/20260502130000_add_traceability_snapshot_company_id/migration.sql
+++ b/server/src/prisma/migrations/20260502130000_add_traceability_snapshot_company_id/migration.sql
@@ -1,0 +1,5 @@
+-- Add tenant scope to persisted traceability snapshots.
+-- Nullable keeps existing snapshots readable; new snapshots write company_id at creation time.
+ALTER TABLE "traceability_snapshots" ADD COLUMN "company_id" TEXT;
+
+CREATE INDEX "traceability_snapshots_company_id_idx" ON "traceability_snapshots"("company_id");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -3719,6 +3719,7 @@ model ProductionRun {
 // Traceability async export snapshots
 model TraceabilitySnapshot {
   id              String   @id @default(cuid())
+  company_id      String?
   sourceQueryHash String
   exportMode      String
   requesterId     String
@@ -3729,6 +3730,7 @@ model TraceabilitySnapshot {
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
+  @@index([company_id])
   @@map("traceability_snapshots")
 }
 


### PR DESCRIPTION
## Summary

- `GET /traceability/snapshots/:id` and `/result` were missing `req.user` — any authenticated user could read any snapshot by guessing its ID
- Added `companyId` to `TraceCurrentUser` interface across controller → service → export service
- `findSnapshot` now compares the snapshot's `company_id` against the requester's `companyId` and throws `ForbiddenException` on mismatch
- `persistSnapshot` now saves `company_id` from the creating user so future reads can enforce the boundary

## Test plan

- [x] 8 unit tests in `traceability-export.service.spec.ts` pass (including new cross-tenant rejection test)
- [x] All 42 traceability module tests pass
- [x] `node tools/check-module-usage-docs.mjs` passes
- [x] `git diff --check` passes (no whitespace errors)