### PR TITLE
fix: GAP-309 CustomerComplaint customer FK

### DIFF
--- a/client/src/api/customer-complaint.ts
+++ b/client/src/api/customer-complaint.ts
@@ -10,6 +10,7 @@ export interface CustomerComplaint {
   id: string;
   company_id: string;
   complaint_no: string;
+  customer_id: string | null;
   customer_name: string;
   production_batch_id: string;
   received_at: string;
@@ -23,7 +24,7 @@ export interface CustomerComplaint {
 }
 
 export interface CreateComplaintPayload {
-  customer_name: string;
+  customer_id: string;
   production_batch_id: string;
   description: string;
   complaint_type?: string;

--- a/client/src/views/customer-complaint/CustomerComplaintList.vue
+++ b/client/src/views/customer-complaint/CustomerComplaintList.vue
@@ -75,8 +75,21 @@
     <!-- 新建对话框 -->
     <el-dialog v-model="createDialogVisible" title="新建顾客投诉" width="520px" :close-on-click-modal="false">
       <el-form ref="createFormRef" :model="createForm" :rules="createRules" label-width="100px">
-        <el-form-item label="顾客名称" prop="customer_name">
-          <el-input v-model="createForm.customer_name" placeholder="请输入顾客名称" />
+        <el-form-item label="顾客名称" prop="customer_id">
+          <el-select
+            v-model="createForm.customer_id"
+            filterable
+            placeholder="请选择顾客主数据"
+            style="width: 100%"
+            :loading="customerLoading"
+          >
+            <el-option
+              v-for="customer in customers"
+              :key="customer.id"
+              :label="customer.name"
+              :value="customer.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="投诉类型" prop="complaint_type">
           <el-input v-model="createForm.complaint_type" placeholder="例如：质量问题、包装问题等" />
@@ -132,6 +145,7 @@ import customerComplaintApi, {
   getComplaintStatusText,
   getComplaintStatusType,
 } from '@/api/customer-complaint';
+import externalPartyApi, { type ExternalParty } from '@/api/external-party';
 import ProductionBatchSelect from '@/components/master-data/ProductionBatchSelect.vue';
 
 // ── State ────────────────────────────────────────────────────────────────────
@@ -139,6 +153,8 @@ import ProductionBatchSelect from '@/components/master-data/ProductionBatchSelec
 const list = ref<CustomerComplaint[]>([]);
 const loading = ref(false);
 const filterStatus = ref<string>('');
+const customers = ref<ExternalParty[]>([]);
+const customerLoading = ref(false);
 
 // ── Create dialog ─────────────────────────────────────────────────────────────
 
@@ -147,14 +163,14 @@ const submitting = ref(false);
 const createFormRef = ref<FormInstance>();
 
 const createForm = reactive({
-  customer_name: '',
+  customer_id: '',
   complaint_type: '',
   production_batch_id: '',
   description: '',
 });
 
 const createRules: FormRules = {
-  customer_name: [{ required: true, message: '请输入顾客名称', trigger: 'blur' }],
+  customer_id: [{ required: true, message: '请选择顾客主数据', trigger: 'change' }],
   production_batch_id: [{ required: true, message: '请选择相关批次', trigger: 'change' }],
   description: [{ required: true, message: '请填写投诉描述', trigger: 'blur' }],
 };
@@ -203,12 +219,27 @@ async function loadList() {
 
 // ── Create ────────────────────────────────────────────────────────────────────
 
-function openCreateDialog() {
-  createForm.customer_name = '';
+async function loadCustomers() {
+  customerLoading.value = true;
+  try {
+    const res = await externalPartyApi.getList('customer');
+    customers.value = (res as unknown as ExternalParty[]).filter(
+      (customer) => customer.status === 'active' && !customer.deleted_at,
+    );
+  } catch {
+    ElMessage.error('加载顾客主数据失败');
+  } finally {
+    customerLoading.value = false;
+  }
+}
+
+async function openCreateDialog() {
+  createForm.customer_id = '';
   createForm.complaint_type = '';
   createForm.production_batch_id = '';
   createForm.description = '';
   createDialogVisible.value = true;
+  await loadCustomers();
 }
 
 async function handleCreate() {
@@ -216,7 +247,7 @@ async function handleCreate() {
   submitting.value = true;
   try {
     await customerComplaintApi.create({
-      customer_name: createForm.customer_name,
+      customer_id: createForm.customer_id,
       complaint_type: createForm.complaint_type || undefined,
       production_batch_id: createForm.production_batch_id,
       description: createForm.description,

--- a/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.spec.ts
@@ -16,6 +16,9 @@ describe('CustomerComplaintService', () => {
     product: {
       findFirst: jest.fn(),
     },
+    externalParty: {
+      findFirst: jest.fn(),
+    },
   };
   let service: CustomerComplaintService;
 
@@ -48,7 +51,7 @@ describe('CustomerComplaintService', () => {
           customer_name: '客户',
           production_batch_id: 'missing-batch',
           description: '投诉',
-        },
+        } as any,
         '2',
       ),
     ).rejects.toThrow('生产批次不存在或不属于当前公司');
@@ -71,7 +74,7 @@ describe('CustomerComplaintService', () => {
           customer_name: '客户',
           production_batch_id: 'other-company-batch',
           description: '投诉',
-        },
+        } as any,
         'company-A',
       ),
     ).rejects.toThrow('生产批次不存在或不属于当前公司');
@@ -87,18 +90,68 @@ describe('CustomerComplaintService', () => {
     expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
   });
 
+  it('rejects creation when customer_id is missing after batch validation passes', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1', productId: 'prod-1' });
+    prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
+
+    await expect(
+      service.create(
+        {
+          customer_name: '客户',
+          production_batch_id: 'batch-1',
+          description: '投诉',
+        } as any,
+        '2',
+      ),
+    ).rejects.toThrow('客户不能为空');
+
+    expect(prisma.externalParty.findFirst).not.toHaveBeenCalled();
+    expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when the customer does not belong to the current company or is unavailable', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1', productId: 'prod-1' });
+    prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
+    prisma.externalParty.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        {
+          customer_id: 'missing-customer',
+          production_batch_id: 'batch-1',
+          description: '投诉',
+        } as any,
+        '2',
+      ),
+    ).rejects.toThrow('客户不存在或不可用');
+
+    expect(prisma.externalParty.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'missing-customer',
+        company_id: '2',
+        party_type: 'customer',
+        status: 'active',
+        deleted_at: null,
+      },
+      select: { id: true, name: true },
+    });
+    expect(prisma.customerComplaint.create).not.toHaveBeenCalled();
+  });
+
   it('scopes complaint numbering and writes by company', async () => {
     prisma.productionBatch.findUnique.mockResolvedValue({ id: 'batch-1', productId: 'prod-1' });
     prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
+    prisma.externalParty.findFirst.mockResolvedValue({ id: 'cust-1', name: '客户A' });
     prisma.customerComplaint.count.mockResolvedValue(5);
     prisma.customerComplaint.create.mockResolvedValue({ id: 'cc1' });
 
     await service.create(
       {
-        customer_name: '客户',
+        customer_id: 'cust-1',
+        customer_name: '不应信任的手填名称',
         production_batch_id: 'batch-1',
         description: '投诉',
-      },
+      } as any,
       '2',
     );
 
@@ -110,12 +163,24 @@ describe('CustomerComplaintService', () => {
       where: { id: 'prod-1', company_id: '2' },
       select: { id: true },
     });
+    expect(prisma.externalParty.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'cust-1',
+        company_id: '2',
+        party_type: 'customer',
+        status: 'active',
+        deleted_at: null,
+      },
+      select: { id: true, name: true },
+    });
     expect(prisma.customerComplaint.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
     expect(prisma.customerComplaint.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           company_id: '2',
           complaint_no: expect.stringMatching(/-0006$/),
+          customer_id: 'cust-1',
+          customer_name: '客户A',
           production_batch_id: 'batch-1',
         }),
       }),

--- a/server/src/modules/customer-complaint/customer-complaint.service.ts
+++ b/server/src/modules/customer-complaint/customer-complaint.service.ts
@@ -29,10 +29,39 @@ export class CustomerComplaintService {
       throw new BadRequestException('生产批次不存在或不属于当前公司');
     }
 
+    if (!dto.customer_id) {
+      throw new BadRequestException('客户不能为空');
+    }
+
+    const customer = await this.prisma.externalParty.findFirst({
+      where: {
+        id: dto.customer_id,
+        company_id: companyId,
+        party_type: 'customer',
+        status: 'active',
+        deleted_at: null,
+      },
+      select: { id: true, name: true },
+    });
+
+    if (!customer) {
+      throw new BadRequestException('客户不存在或不可用');
+    }
+
     const count = await this.prisma.customerComplaint.count({ where: { company_id: companyId } });
     const complaint_no = `CC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+
     return this.prisma.customerComplaint.create({
-      data: { ...dto, company_id: companyId, complaint_no, received_at: new Date() },
+      data: {
+        company_id: companyId,
+        complaint_no,
+        customer_id: customer.id,
+        customer_name: customer.name,
+        production_batch_id: dto.production_batch_id,
+        complaint_type: dto.complaint_type,
+        description: dto.description,
+        received_at: new Date(),
+      },
     });
   }
 

--- a/server/src/modules/customer-complaint/dto/create-complaint.dto.ts
+++ b/server/src/modules/customer-complaint/dto/create-complaint.dto.ts
@@ -1,12 +1,25 @@
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class CreateComplaintDto {
-  @IsString() customer_name: string;
+  @IsString()
+  @IsNotEmpty()
+  customer_id: string;
+
+  @IsOptional()
+  @IsString()
+  customer_name?: string;
+
   @IsString()
   @IsNotEmpty()
   production_batch_id: string;
-  @IsString() description: string;
-  @IsOptional() @IsString() complaint_type?: string;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  complaint_type?: string;
 }
 
 export class ResolveComplaintDto {

--- a/server/src/modules/external-party/external-party.controller.ts
+++ b/server/src/modules/external-party/external-party.controller.ts
@@ -8,11 +8,13 @@ import {
   Param,
   Query,
   UseGuards,
+  Request,
 } from '@nestjs/common';
 import { ExternalPartyService } from './external-party.service';
 import { CreateExternalPartyDto } from './dto/create-external-party.dto';
 import { UpdateExternalPartyDto } from './dto/update-external-party.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 
 @Controller('external-parties')
 @UseGuards(JwtAuthGuard)
@@ -20,27 +22,27 @@ export class ExternalPartyController {
   constructor(private service: ExternalPartyService) {}
 
   @Get()
-  findAll(@Query('party_type') partyType?: string) {
-    return this.service.findAll(partyType);
+  findAll(@Request() req: AuthenticatedRequest, @Query('party_type') partyType?: string) {
+    return this.service.findAll(req.user.companyId, partyType);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.service.findOne(id);
+  findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findOne(id, req.user.companyId);
   }
 
   @Post()
-  create(@Body() dto: CreateExternalPartyDto) {
-    return this.service.create(dto);
+  create(@Body() dto: CreateExternalPartyDto, @Request() req: AuthenticatedRequest) {
+    return this.service.create(req.user.companyId, dto);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateExternalPartyDto) {
-    return this.service.update(id, dto);
+  update(@Param('id') id: string, @Body() dto: UpdateExternalPartyDto, @Request() req: AuthenticatedRequest) {
+    return this.service.update(id, req.user.companyId, dto);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.service.remove(id);
+  remove(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.remove(id, req.user.companyId);
   }
 }

--- a/server/src/modules/external-party/external-party.service.spec.ts
+++ b/server/src/modules/external-party/external-party.service.spec.ts
@@ -1,0 +1,82 @@
+import { NotFoundException } from '@nestjs/common';
+import { ExternalPartyService } from './external-party.service';
+
+describe('ExternalPartyService', () => {
+  const prisma = {
+    externalParty: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  };
+
+  const service = new ExternalPartyService(prisma as any);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('lists only non-deleted parties for the current company and optional type', async () => {
+    prisma.externalParty.findMany.mockResolvedValue([{ id: 'cust-1' }]);
+
+    await expect(service.findAll('company-2', 'customer')).resolves.toEqual([{ id: 'cust-1' }]);
+
+    expect(prisma.externalParty.findMany).toHaveBeenCalledWith({
+      where: {
+        company_id: 'company-2',
+        deleted_at: null,
+        party_type: 'customer',
+      },
+      orderBy: { created_at: 'desc' },
+      take: 200,
+    });
+  });
+
+  it('creates parties in the current company and defaults active status', async () => {
+    prisma.externalParty.create.mockResolvedValue({ id: 'cust-1' });
+
+    await service.create('company-2', {
+      party_type: 'customer',
+      name: '客户A',
+    } as any);
+
+    expect(prisma.externalParty.create).toHaveBeenCalledWith({
+      data: {
+        party_type: 'customer',
+        name: '客户A',
+        company_id: 'company-2',
+        status: 'active',
+      },
+    });
+  });
+
+  it('rejects update when the party is outside the current company', async () => {
+    prisma.externalParty.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(service.update('other-party', 'company-2', { name: '新名称' } as any)).rejects.toThrow(
+      NotFoundException,
+    );
+
+    expect(prisma.externalParty.updateMany).toHaveBeenCalledWith({
+      where: { id: 'other-party', company_id: 'company-2', deleted_at: null },
+      data: { name: '新名称' },
+    });
+    expect(prisma.externalParty.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('soft deletes only parties in the current company', async () => {
+    prisma.externalParty.updateMany.mockResolvedValue({ count: 1 });
+    prisma.externalParty.findFirst.mockResolvedValue({ id: 'cust-1', deleted_at: expect.any(Date) });
+
+    await service.remove('cust-1', 'company-2');
+
+    expect(prisma.externalParty.updateMany).toHaveBeenCalledWith({
+      where: { id: 'cust-1', company_id: 'company-2', deleted_at: null },
+      data: { deleted_at: expect.any(Date) },
+    });
+    expect(prisma.externalParty.findFirst).toHaveBeenCalledWith({
+      where: { id: 'cust-1', company_id: 'company-2' },
+    });
+  });
+});

--- a/server/src/modules/external-party/external-party.service.ts
+++ b/server/src/modules/external-party/external-party.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateExternalPartyDto } from './dto/create-external-party.dto';
 import { UpdateExternalPartyDto } from './dto/update-external-party.dto';
@@ -7,10 +7,10 @@ import { UpdateExternalPartyDto } from './dto/update-external-party.dto';
 export class ExternalPartyService {
   constructor(private prisma: PrismaService) {}
 
-  async findAll(partyType?: string) {
+  async findAll(companyId: string, partyType?: string) {
     return this.prisma.externalParty.findMany({
       where: {
-        company_id: '1',
+        company_id: companyId,
         deleted_at: null,
         ...(partyType ? { party_type: partyType } : {}),
       },
@@ -19,33 +19,55 @@ export class ExternalPartyService {
     });
   }
 
-  async findOne(id: string) {
-    return this.prisma.externalParty.findFirst({
-      where: { id, company_id: '1', deleted_at: null },
+  async findOne(id: string, companyId: string) {
+    const party = await this.prisma.externalParty.findFirst({
+      where: { id, company_id: companyId, deleted_at: null },
     });
+
+    if (!party) {
+      throw new NotFoundException('外部方不存在或不属于当前公司');
+    }
+
+    return party;
   }
 
-  async create(dto: CreateExternalPartyDto) {
+  async create(companyId: string, dto: CreateExternalPartyDto) {
     return this.prisma.externalParty.create({
       data: {
         ...dto,
-        company_id: '1',
+        company_id: companyId,
         status: dto.status ?? 'active',
       },
     });
   }
 
-  async update(id: string, dto: UpdateExternalPartyDto) {
-    return this.prisma.externalParty.update({
-      where: { id },
+  async update(id: string, companyId: string, dto: UpdateExternalPartyDto) {
+    const result = await this.prisma.externalParty.updateMany({
+      where: { id, company_id: companyId, deleted_at: null },
       data: { ...dto },
+    });
+
+    if (result.count === 0) {
+      throw new NotFoundException('外部方不存在或不属于当前公司');
+    }
+
+    return this.prisma.externalParty.findFirst({
+      where: { id, company_id: companyId, deleted_at: null },
     });
   }
 
-  async remove(id: string) {
-    return this.prisma.externalParty.update({
-      where: { id },
+  async remove(id: string, companyId: string) {
+    const result = await this.prisma.externalParty.updateMany({
+      where: { id, company_id: companyId, deleted_at: null },
       data: { deleted_at: new Date() },
+    });
+
+    if (result.count === 0) {
+      throw new NotFoundException('外部方不存在或不属于当前公司');
+    }
+
+    return this.prisma.externalParty.findFirst({
+      where: { id, company_id: companyId },
     });
   }
 }

--- a/server/src/prisma/migrations/20260502103000_add_customer_complaint_customer_id/migration.sql
+++ b/server/src/prisma/migrations/20260502103000_add_customer_complaint_customer_id/migration.sql
@@ -1,0 +1,37 @@
+-- Link customer complaints to ExternalParty customers while preserving legacy customer_name snapshots.
+-- Historical complaints may keep NULL customer_id until a business-confirmed data cleanup maps them.
+
+ALTER TABLE "CustomerComplaint"
+  ADD COLUMN IF NOT EXISTS "customer_id" TEXT;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "CustomerComplaint" cc
+    LEFT JOIN "ExternalParty" ep ON ep."id" = cc."customer_id"
+    WHERE cc."customer_id" IS NOT NULL
+      AND ep."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add CustomerComplaint.customer_id FK: orphan customer_id rows exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "CustomerComplaint" cc
+    JOIN "ExternalParty" ep ON ep."id" = cc."customer_id"
+    WHERE cc."customer_id" IS NOT NULL
+      AND ep."party_type" <> 'customer'
+  ) THEN
+    RAISE EXCEPTION 'Cannot add CustomerComplaint.customer_id FK: non-customer ExternalParty rows are referenced';
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "CustomerComplaint_customer_id_idx"
+  ON "CustomerComplaint"("customer_id");
+
+ALTER TABLE "CustomerComplaint" DROP CONSTRAINT IF EXISTS "CustomerComplaint_customer_id_fkey";
+ALTER TABLE "CustomerComplaint"
+  ADD CONSTRAINT "CustomerComplaint_customer_id_fkey"
+  FOREIGN KEY ("customer_id") REFERENCES "ExternalParty"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -3112,6 +3112,8 @@ model CustomerComplaint {
   id                  String    @id @default(cuid())
   company_id          String
   complaint_no        String
+  customer_id         String?
+  customer            ExternalParty? @relation(fields: [customer_id], references: [id], onDelete: SetNull)
   customer_name       String
   production_batch_id String
   production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
@@ -3125,6 +3127,7 @@ model CustomerComplaint {
   updated_at          DateTime  @updatedAt
   @@unique([company_id, complaint_no])
   @@index([production_batch_id])
+  @@index([customer_id])
 }
 
 model ReworkRecord {
@@ -3643,6 +3646,7 @@ model ExternalParty {
   deleted_at      DateTime?
 
   product_recall_notifications ProductRecallNotification[]
+  customer_complaints CustomerComplaint[]
 }
 
 model PackagingMaterialUsage {


### PR DESCRIPTION
## Summary
- Scope `ExternalPartyController/Service` to use JWT `companyId` instead of hardcoded `company_id='1'`
- Add nullable `CustomerComplaint.customer_id` FK to `ExternalParty(party_type='customer')`
- Enforce `customer_id` validation in `CreateComplaintDto`/service: require non-null, verify active customer belongs to current company, snapshot `customer_name` from `ExternalParty.name`
- Replace free-text customer input in `CustomerComplaintList.vue` with `el-select` loading from `/external-parties?party_type=customer`
- Add guarded migration with orphan/type safety checks before adding FK constraint
- Preserve GAP-310 `production_batch_id` required FK validation

## Test plan
- [ ] `ExternalPartyService` tests: 4 pass (tenant scoping, create defaults, update cross-company rejection, soft delete)
- [ ] `CustomerComplaintService` tests: 7 pass (GAP-310 regression guards preserved, new customer validation tests)
- [ ] `prisma validate` passes
- [ ] Server build: 1 pre-existing error (unchanged)
- [ ] Client build: success