### PR TITLE
feat: GAP-313 NC source validation and workflow trigger guard

### DIFF
--- a/server/src/modules/ccp/ccp.service.ts
+++ b/server/src/modules/ccp/ccp.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { NonConformanceService } from '../non-conformance/non-conformance.service';
 import { CreateCcpRecordDto } from './dto/create-ccp-record.dto';
@@ -31,7 +32,7 @@ export class CcpService {
       });
     }
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       const ccpRecord = await tx.cCPRecord.create({
         data: createData,
         include: { ccp_point: true },
@@ -69,7 +70,7 @@ export class CcpService {
       where: { production_batch_id: productionBatchId, company_id: companyId },
       select: { ccp_point_id: true },
     });
-    const filledIds = new Set(records.map((r) => r.ccp_point_id));
+    const filledIds = new Set(records.map((r: { ccp_point_id: string }) => r.ccp_point_id));
 
     const expectedCCPs = await this.prisma.cCPPoint.findMany({
       where: {
@@ -84,6 +85,6 @@ export class CcpService {
       orderBy: [{ ccp_no: 'asc' }, { created_at: 'asc' }],
     });
 
-    return expectedCCPs.filter((ccp) => !filledIds.has(ccp.id));
+    return expectedCCPs.filter((ccp: { id: string }) => !filledIds.has(ccp.id));
   }
 }

--- a/server/src/modules/non-conformance/dto/create-nc.dto.ts
+++ b/server/src/modules/non-conformance/dto/create-nc.dto.ts
@@ -1,15 +1,37 @@
-import { IsString, IsOptional, IsNumber } from 'class-validator';
+import { IsIn, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export const NC_SOURCE_TYPES = ['material_batch', 'production_batch', 'product'] as const;
+export type NcSourceType = (typeof NC_SOURCE_TYPES)[number];
 
 export class CreateNcDto {
-  @IsString() source_type: string; // 'material_batch'|'production_batch'|'product'
-  @IsString() source_id: string;
-  @IsString() description: string;
-  @IsOptional() @IsString() nc_type?: string;
-  @IsOptional() @IsNumber() qty?: number;
-  @IsOptional() @IsString() unit?: string;
-  @IsOptional() @IsString() disposition?: string;
+  @IsIn(NC_SOURCE_TYPES)
+  source_type: NcSourceType;
+
+  @IsString()
+  @IsNotEmpty()
+  source_id: string;
+
+  @IsString()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  nc_type?: string;
+
+  @IsOptional()
+  @IsNumber()
+  qty?: number;
+
+  @IsOptional()
+  @IsString()
+  unit?: string;
+
+  @IsOptional()
+  @IsString()
+  disposition?: string;
 }
 
 export class DisposeNcDto {
-  @IsString() disposition: string; // 'rework'|'destroy'|'concession'|'return'
+  @IsString()
+  disposition: string; // 'rework'|'destroy'|'concession'|'return'
 }

--- a/server/src/modules/non-conformance/non-conformance.service.spec.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.spec.ts
@@ -38,7 +38,7 @@ describe('NonConformanceService', () => {
   });
 
   it('validates source and uses shared sequence service for NC numbering', async () => {
-    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'b1', productId: 'prod-1' });
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'b1', productId: 'prod-1', deletedAt: null });
     prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
     numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0004');
     prisma.nonConformance.create.mockResolvedValue({ id: 'nc1' });
@@ -47,7 +47,7 @@ describe('NonConformanceService', () => {
 
     expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'b1' },
-      select: { id: true, productId: true },
+      select: { id: true, productId: true, deletedAt: true },
     });
     expect(prisma.product.findFirst).toHaveBeenCalledWith({
       where: { id: 'prod-1', company_id: '2', deleted_at: null },
@@ -92,14 +92,14 @@ describe('NonConformanceService', () => {
 
     expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'missing-batch' },
-      select: { id: true, productId: true },
+      select: { id: true, productId: true, deletedAt: true },
     });
     expect(prisma.product.findFirst).not.toHaveBeenCalled();
     expect(prisma.nonConformance.create).not.toHaveBeenCalled();
   });
 
   it('rejects a production batch source outside the current company', async () => {
-    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'other-company-batch', productId: 'prod-other' });
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'other-company-batch', productId: 'prod-other', deletedAt: null });
     prisma.product.findFirst.mockResolvedValue(null);
 
     await expect(
@@ -108,7 +108,7 @@ describe('NonConformanceService', () => {
 
     expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'other-company-batch' },
-      select: { id: true, productId: true },
+      select: { id: true, productId: true, deletedAt: true },
     });
     expect(prisma.product.findFirst).toHaveBeenCalledWith({
       where: { id: 'prod-other', company_id: '2', deleted_at: null },
@@ -126,7 +126,7 @@ describe('NonConformanceService', () => {
 
     expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'missing-material-batch' },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
     expect(prisma.nonConformance.create).not.toHaveBeenCalled();
   });
@@ -154,7 +154,7 @@ describe('NonConformanceService', () => {
 
     expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'mb1' },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
     expect(prisma.nonConformance.create).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -340,7 +340,7 @@ describe('NonConformanceService', () => {
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-1' }),
       },
       productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1' }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1', deletedAt: null }),
       },
       product: {
         findFirst: jest.fn().mockResolvedValue({ id: 'prod-1' }),
@@ -368,7 +368,7 @@ describe('NonConformanceService', () => {
 
     expect(tx.productionBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'batch-1' },
-      select: { id: true, productId: true },
+      select: { id: true, productId: true, deletedAt: true },
     });
     expect(tx.product.findFirst).toHaveBeenCalledWith({
       where: { id: 'prod-1', company_id: '2', deleted_at: null },
@@ -400,7 +400,7 @@ describe('NonConformanceService', () => {
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-2' }),
       },
       productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1' }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1', deletedAt: null }),
       },
       product: {
         findFirst: jest.fn().mockResolvedValue({ id: 'prod-1' }),
@@ -433,6 +433,39 @@ describe('NonConformanceService', () => {
     expect(data.description).toContain('未填写');
   });
 
+  it('rejects a soft-deleted material batch as NC source', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb-deleted', deletedAt: new Date('2025-01-01') });
+
+    await expect(
+      service.create({ source_type: 'material_batch', source_id: 'mb-deleted', description: '来料不合格' }, 'u1', '2'),
+    ).rejects.toThrow('物料批次来源不存在');
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'mb-deleted' },
+      select: { id: true, deletedAt: true },
+    });
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a soft-deleted production batch as NC source', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({
+      id: 'pb-deleted',
+      productId: 'prod-1',
+      deletedAt: new Date('2025-01-01'),
+    });
+
+    await expect(
+      service.create({ source_type: 'production_batch', source_id: 'pb-deleted', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('生产批次来源不存在');
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'pb-deleted' },
+      select: { id: true, productId: true, deletedAt: true },
+    });
+    expect(prisma.product.findFirst).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
   it('rejects CCP deviation NonConformance creation when the production batch belongs to another company', async () => {
     const tx: any = {
       nonConformance: {
@@ -440,7 +473,7 @@ describe('NonConformanceService', () => {
         create: jest.fn(),
       },
       productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({ id: 'batch-other', productId: 'prod-other' }),
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-other', productId: 'prod-other', deletedAt: null }),
       },
       product: {
         findFirst: jest.fn().mockResolvedValue(null),
@@ -469,7 +502,7 @@ describe('NonConformanceService', () => {
 
     expect(tx.productionBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'batch-other' },
-      select: { id: true, productId: true },
+      select: { id: true, productId: true, deletedAt: true },
     });
     expect(tx.product.findFirst).toHaveBeenCalledWith({
       where: { id: 'prod-other', company_id: '2', deleted_at: null },

--- a/server/src/modules/non-conformance/non-conformance.service.spec.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.spec.ts
@@ -11,7 +11,14 @@ describe('NonConformanceService', () => {
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    materialBatch: {
+      findUnique: jest.fn(),
+    },
     productionBatch: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    product: {
       findFirst: jest.fn(),
     },
     reworkRecord: {
@@ -30,12 +37,22 @@ describe('NonConformanceService', () => {
     service = new NonConformanceService(prisma as any, numberSequence as any);
   });
 
-  it('uses the shared sequence service and writes by company', async () => {
+  it('validates source and uses shared sequence service for NC numbering', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'b1', productId: 'prod-1' });
+    prisma.product.findFirst.mockResolvedValue({ id: 'prod-1' });
     numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0004');
     prisma.nonConformance.create.mockResolvedValue({ id: 'nc1' });
 
     await service.create({ source_type: 'production_batch', source_id: 'b1', description: '偏差' }, 'u1', '2');
 
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'b1' },
+      select: { id: true, productId: true },
+    });
+    expect(prisma.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-1', company_id: '2', deleted_at: null },
+      select: { id: true },
+    });
     expect(prisma.nonConformance.count).not.toHaveBeenCalled();
     expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2');
     expect(prisma.nonConformance.create).toHaveBeenCalledWith(
@@ -44,6 +61,107 @@ describe('NonConformanceService', () => {
           company_id: '2',
           nc_no: 'NC-2026-0004',
           discovered_by: 'u1',
+        }),
+      }),
+    );
+  });
+
+  it('rejects unsupported source_type before creating a record', async () => {
+    await expect(
+      service.create({ source_type: 'unknown', source_id: 'x1', description: '偏差' } as any, 'u1', '2'),
+    ).rejects.toThrow('不支持的不合格来源类型');
+
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects blank source_id before creating a record', async () => {
+    await expect(
+      service.create({ source_type: 'production_batch', source_id: ' ', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('不合格来源不能为空');
+
+    expect(prisma.productionBatch.findUnique).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing production batch source', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.create({ source_type: 'production_batch', source_id: 'missing-batch', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('生产批次来源不存在');
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-batch' },
+      select: { id: true, productId: true },
+    });
+    expect(prisma.product.findFirst).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a production batch source outside the current company', async () => {
+    prisma.productionBatch.findUnique.mockResolvedValue({ id: 'other-company-batch', productId: 'prod-other' });
+    prisma.product.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create({ source_type: 'production_batch', source_id: 'other-company-batch', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('生产批次来源不存在');
+
+    expect(prisma.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'other-company-batch' },
+      select: { id: true, productId: true },
+    });
+    expect(prisma.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-other', company_id: '2', deleted_at: null },
+      select: { id: true },
+    });
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing material batch source', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.create({ source_type: 'material_batch', source_id: 'missing-material-batch', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('物料批次来源不存在');
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-material-batch' },
+      select: { id: true },
+    });
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a product source outside the current company', async () => {
+    prisma.product.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create({ source_type: 'product', source_id: 'product-1', description: '偏差' }, 'u1', '2'),
+    ).rejects.toThrow('产品来源不存在');
+
+    expect(prisma.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'product-1', company_id: '2', deleted_at: null },
+      select: { id: true },
+    });
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('allows a valid material batch source', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb1' });
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0001');
+    prisma.nonConformance.create.mockResolvedValue({ id: 'nc-material' });
+
+    await service.create({ source_type: 'material_batch', source_id: 'mb1', description: '来料不合格' }, 'u1', '2');
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'mb1' },
+      select: { id: true },
+    });
+    expect(prisma.nonConformance.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          source_type: 'material_batch',
+          source_id: 'mb1',
+          company_id: '2',
         }),
       }),
     );
@@ -221,6 +339,12 @@ describe('NonConformanceService', () => {
         count: jest.fn(),
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-1' }),
       },
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1' }),
+      },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'prod-1' }),
+      },
     };
     numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0022');
 
@@ -242,6 +366,14 @@ describe('NonConformanceService', () => {
       tx,
     );
 
+    expect(tx.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'batch-1' },
+      select: { id: true, productId: true },
+    });
+    expect(tx.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-1', company_id: '2', deleted_at: null },
+      select: { id: true },
+    });
     expect(tx.nonConformance.count).not.toHaveBeenCalled();
     expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2', expect.any(Date), tx);
     expect(tx.nonConformance.create).toHaveBeenCalledWith({
@@ -266,6 +398,12 @@ describe('NonConformanceService', () => {
       nonConformance: {
         count: jest.fn(),
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-2' }),
+      },
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1', productId: 'prod-1' }),
+      },
+      product: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'prod-1' }),
       },
     };
     numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0001');
@@ -293,5 +431,51 @@ describe('NonConformanceService', () => {
     expect(data.description).toContain('ccp-point-2');
     expect(data.description).toContain('金探测试片未通过');
     expect(data.description).toContain('未填写');
+  });
+
+  it('rejects CCP deviation NonConformance creation when the production batch belongs to another company', async () => {
+    const tx: any = {
+      nonConformance: {
+        count: jest.fn(),
+        create: jest.fn(),
+      },
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-other', productId: 'prod-other' }),
+      },
+      product: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    };
+
+    await expect(
+      service.createFromCcpDeviation(
+        {
+          companyId: '2',
+          userId: 'operator-1',
+          ccpRecord: {
+            id: 'ccp-record-1',
+            production_batch_id: 'batch-other',
+            ccp_point_id: 'ccp-point-1',
+            measured_value: 93.5,
+            measured_text: null,
+            unit: 'C',
+            deviation_action: '隔离待评审',
+            ccp_point: { ccp_no: 'CCP-BAKE-01' },
+          },
+        },
+        tx,
+      ),
+    ).rejects.toThrow('生产批次来源不存在');
+
+    expect(tx.productionBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'batch-other' },
+      select: { id: true, productId: true },
+    });
+    expect(tx.product.findFirst).toHaveBeenCalledWith({
+      where: { id: 'prod-other', company_id: '2', deleted_at: null },
+      select: { id: true },
+    });
+    expect(tx.nonConformance.count).not.toHaveBeenCalled();
+    expect(tx.nonConformance.create).not.toHaveBeenCalled();
   });
 });

--- a/server/src/modules/non-conformance/non-conformance.service.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { NonConformance, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreateNcDto, DisposeNcDto } from './dto/create-nc.dto';
+import { CreateNcDto, DisposeNcDto, NcSourceType } from './dto/create-nc.dto';
 import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
 
 type CcpDeviationInput = {
@@ -27,10 +27,13 @@ export class NonConformanceService {
   ) {}
 
   async create(dto: CreateNcDto, userId: string, companyId: string) {
+    await this.validateSourceExists(dto.source_type, dto.source_id, companyId);
+
     const nc_no = await this.numberSequence.generateNonConformanceNo(companyId);
     return this.prisma.nonConformance.create({
       data: {
         ...dto,
+        source_id: dto.source_id.trim(),
         company_id: companyId,
         nc_no,
         discovered_by: userId,
@@ -41,6 +44,8 @@ export class NonConformanceService {
 
   async createFromCcpDeviation(input: CcpDeviationInput, tx?: Prisma.TransactionClient) {
     const db = tx ?? this.prisma;
+    await this.validateSourceExists('production_batch', input.ccpRecord.production_batch_id, input.companyId, db);
+
     const nc_no = await this.numberSequence.generateNonConformanceNo(input.companyId, new Date(), tx);
 
     return db.nonConformance.create({
@@ -55,6 +60,61 @@ export class NonConformanceService {
         discovered_at: new Date(),
       },
     });
+  }
+
+  private async validateSourceExists(
+    sourceType: NcSourceType,
+    sourceId: string,
+    companyId: string,
+    db: Prisma.TransactionClient | PrismaService = this.prisma,
+  ) {
+    const trimmedSourceId = sourceId?.trim();
+    if (!trimmedSourceId) {
+      throw new BadRequestException('不合格来源不能为空');
+    }
+
+    if (sourceType === 'material_batch') {
+      const materialBatch = await db.materialBatch.findUnique({
+        where: { id: trimmedSourceId },
+        select: { id: true },
+      });
+      if (!materialBatch) {
+        throw new BadRequestException('物料批次来源不存在');
+      }
+      return;
+    }
+
+    if (sourceType === 'production_batch') {
+      const productionBatch = await db.productionBatch.findUnique({
+        where: { id: trimmedSourceId },
+        select: { id: true, productId: true },
+      });
+      if (!productionBatch?.productId) {
+        throw new BadRequestException('生产批次来源不存在');
+      }
+
+      const product = await db.product.findFirst({
+        where: { id: productionBatch.productId, company_id: companyId, deleted_at: null },
+        select: { id: true },
+      });
+      if (!product) {
+        throw new BadRequestException('生产批次来源不存在');
+      }
+      return;
+    }
+
+    if (sourceType === 'product') {
+      const product = await db.product.findFirst({
+        where: { id: trimmedSourceId, company_id: companyId, deleted_at: null },
+        select: { id: true },
+      });
+      if (!product) {
+        throw new BadRequestException('产品来源不存在');
+      }
+      return;
+    }
+
+    throw new BadRequestException('不支持的不合格来源类型');
   }
 
   private buildCcpDeviationDescription(record: CcpDeviationInput['ccpRecord']) {

--- a/server/src/modules/non-conformance/non-conformance.service.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.ts
@@ -76,9 +76,9 @@ export class NonConformanceService {
     if (sourceType === 'material_batch') {
       const materialBatch = await db.materialBatch.findUnique({
         where: { id: trimmedSourceId },
-        select: { id: true },
+        select: { id: true, deletedAt: true },
       });
-      if (!materialBatch) {
+      if (!materialBatch || materialBatch.deletedAt != null) {
         throw new BadRequestException('物料批次来源不存在');
       }
       return;
@@ -87,9 +87,9 @@ export class NonConformanceService {
     if (sourceType === 'production_batch') {
       const productionBatch = await db.productionBatch.findUnique({
         where: { id: trimmedSourceId },
-        select: { id: true, productId: true },
+        select: { id: true, productId: true, deletedAt: true },
       });
-      if (!productionBatch?.productId) {
+      if (!productionBatch?.productId || productionBatch.deletedAt != null) {
         throw new BadRequestException('生产批次来源不存在');
       }
 

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
@@ -2,6 +2,9 @@ import { WorkflowTriggersService } from './workflow-triggers.service';
 
 describe('WorkflowTriggersService', () => {
   const prisma = {
+    materialBatch: {
+      findUnique: jest.fn(),
+    },
     nonConformance: {
       count: jest.fn(),
       create: jest.fn(),
@@ -21,40 +24,65 @@ describe('WorkflowTriggersService', () => {
     service = new WorkflowTriggersService(prisma as any, numberSequence as any);
   });
 
-  it('creates incoming-inspection failure NC with the shared sequence', async () => {
-    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0031');
-    prisma.nonConformance.create.mockResolvedValue({ id: 'nc-incoming-1' });
-
+  it('does not create a NonConformance for passing incoming inspections', async () => {
     await service.handleInspectionFail({
       id: 'inspection-1',
-      overall_result: 'fail',
-      material_batch_id: 'mb-1',
-      company_id: 'company-1',
-    });
-
-    expect(prisma.nonConformance.count).not.toHaveBeenCalled();
-    expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('company-1');
-    expect(prisma.nonConformance.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        company_id: 'company-1',
-        nc_no: 'NC-2026-0031',
-        source_type: 'material_batch',
-        source_id: 'mb-1',
-        status: 'open',
-        description: expect.stringContaining('inspection-1'),
-      }),
-    });
-  });
-
-  it('does not create NC when incoming inspection passes', async () => {
-    await service.handleInspectionFail({
-      id: 'inspection-2',
       overall_result: 'pass',
-      material_batch_id: 'mb-1',
-      company_id: 'company-1',
+      material_batch_id: 'mb1',
+      company_id: '2',
     });
 
+    expect(prisma.materialBatch.findUnique).not.toHaveBeenCalled();
     expect(numberSequence.generateNonConformanceNo).not.toHaveBeenCalled();
     expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('does not create a NonConformance when the material batch source is missing', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue(null);
+
+    await service.handleInspectionFail({
+      id: 'inspection-2',
+      overall_result: 'fail',
+      material_batch_id: 'missing-mb',
+      company_id: '2',
+    });
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'missing-mb' },
+      select: { id: true },
+    });
+    expect(numberSequence.generateNonConformanceNo).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a NonConformance with shared sequence when a failed inspection has a valid material batch', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb1' });
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0031');
+    prisma.nonConformance.create.mockResolvedValue({ id: 'nc-auto-1' });
+
+    await service.handleInspectionFail({
+      id: 'inspection-3',
+      overall_result: 'fail',
+      material_batch_id: 'mb1',
+      company_id: '2',
+    });
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'mb1' },
+      select: { id: true },
+    });
+    expect(prisma.nonConformance.count).not.toHaveBeenCalled();
+    expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2');
+    expect(prisma.nonConformance.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        company_id: '2',
+        nc_no: 'NC-2026-0031',
+        source_type: 'material_batch',
+        source_id: 'mb1',
+        status: 'open',
+        description: expect.stringContaining('inspection-3'),
+        discovered_at: expect.any(Date),
+      }),
+    });
   });
 });

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
@@ -49,14 +49,31 @@ describe('WorkflowTriggersService', () => {
 
     expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'missing-mb' },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
+    });
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+
+  it('does not create a NonConformance when the material batch source is soft-deleted', async () => {
+    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb-deleted', deletedAt: new Date('2025-01-01') });
+
+    await service.handleInspectionFail({
+      id: 'inspection-4',
+      overall_result: 'fail',
+      material_batch_id: 'mb-deleted',
+      company_id: '2',
+    });
+
+    expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
+      where: { id: 'mb-deleted' },
+      select: { id: true, deletedAt: true },
     });
     expect(numberSequence.generateNonConformanceNo).not.toHaveBeenCalled();
     expect(prisma.nonConformance.create).not.toHaveBeenCalled();
   });
 
   it('creates a NonConformance with shared sequence when a failed inspection has a valid material batch', async () => {
-    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb1' });
+    prisma.materialBatch.findUnique.mockResolvedValue({ id: 'mb1', deletedAt: null });
     numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0031');
     prisma.nonConformance.create.mockResolvedValue({ id: 'nc-auto-1' });
 
@@ -69,7 +86,7 @@ describe('WorkflowTriggersService', () => {
 
     expect(prisma.materialBatch.findUnique).toHaveBeenCalledWith({
       where: { id: 'mb1' },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
     expect(prisma.nonConformance.count).not.toHaveBeenCalled();
     expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2');

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.ts
@@ -21,6 +21,18 @@ export class WorkflowTriggersService {
   }) {
     if (payload.overall_result !== 'fail') return;
 
+    const materialBatch = await this.prisma.materialBatch.findUnique({
+      where: { id: payload.material_batch_id },
+      select: { id: true },
+    });
+
+    if (!materialBatch) {
+      this.logger.error(
+        `[WorkflowTrigger] 来料检验不合格未创建不合格品处置单：物料批次不存在 ${payload.material_batch_id}`,
+      );
+      return;
+    }
+
     try {
       const nc_no = await this.numberSequence.generateNonConformanceNo(payload.company_id);
 

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.ts
@@ -23,10 +23,10 @@ export class WorkflowTriggersService {
 
     const materialBatch = await this.prisma.materialBatch.findUnique({
       where: { id: payload.material_batch_id },
-      select: { id: true },
+      select: { id: true, deletedAt: true },
     });
 
-    if (!materialBatch) {
+    if (!materialBatch || materialBatch.deletedAt != null) {
       this.logger.error(
         `[WorkflowTrigger] 来料检验不合格未创建不合格品处置单：物料批次不存在 ${payload.material_batch_id}`,
       );


### PR DESCRIPTION
## Summary

- Add `validateSourceExists()` to `NonConformanceService` covering `material_batch`, `production_batch` (via `productId -> Product.company_id` chain), and `product` source types
- Guard `NonConformanceService.create()` and `createFromCcpDeviation()` before numbering/write; validator accepts optional `TransactionClient` so CCP deviation path stays atomic
- Guard `WorkflowTriggersService.handleInspectionFail()`: skip NC creation when `material_batch` source is missing (log error and return)
- Tighten `CreateNcDto` with `NC_SOURCE_TYPES` const enum and `@IsIn` validator
- Verify `@@index([company_id, source_type, source_id])` already present in `schema.prisma`; no migration needed
- 12 focused unit tests in `non-conformance.service.spec.ts`, 3 in `workflow-triggers.service.spec.ts`

## Test plan

- [ ] `non-conformance.service.spec.ts` — 12 tests pass (rejection + success paths)
- [ ] `ccp.service.spec.ts` — 6 tests pass (transaction handoff guard)
- [ ] `workflow-triggers.service.spec.ts` — 3 tests pass (pass/missing-batch/valid-batch paths)
- [ ] `prisma validate` passes
- [ ] No changes to client, traceability, corrective-action, or rework-record modules