### PR TITLE
feat(GAP-315): auto-create ReworkRecord when NC disposed as rework

### DIFF
--- a/client/src/api/rework-record.ts
+++ b/client/src/api/rework-record.ts
@@ -41,10 +41,18 @@ export interface CreateReworkRecordPayload {
 const VERDICT_MAP: Record<string, string> = {
   pass: '合格',
   fail: '不合格',
+  pending: '待判定',
 };
 
 export function getVerdictText(verdict: string): string {
   return VERDICT_MAP[verdict] ?? verdict;
+}
+
+export function getVerdictTagType(verdict: string): 'success' | 'warning' | 'danger' | 'info' {
+  if (verdict === 'pass') return 'success';
+  if (verdict === 'pending') return 'warning';
+  if (verdict === 'fail') return 'danger';
+  return 'info';
 }
 
 // =========================================================================

--- a/client/src/views/rework-record/ReworkRecordList.vue
+++ b/client/src/views/rework-record/ReworkRecordList.vue
@@ -50,7 +50,7 @@
         </el-table-column>
         <el-table-column label="质量判定" width="100">
           <template #default="{ row }">
-            <el-tag :type="row.quality_verdict === 'pass' ? 'success' : 'danger'" effect="light" size="small">
+            <el-tag :type="getVerdictTagType(row.quality_verdict)" effect="light" size="small">
               {{ getVerdictText(row.quality_verdict) }}
             </el-tag>
           </template>
@@ -153,7 +153,7 @@ import { ref, reactive, onMounted } from 'vue';
 import { ElMessage } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import type { FormInstance, FormRules } from 'element-plus';
-import reworkRecordApi, { type ReworkRecord, getVerdictText } from '@/api/rework-record';
+import reworkRecordApi, { type ReworkRecord, getVerdictTagType, getVerdictText } from '@/api/rework-record';
 import ProductionBatchSelect from '@/components/master-data/ProductionBatchSelect.vue';
 
 // ── State ─────────────────────────────────────────────────────────────────────

--- a/server/src/modules/document/services/record-form-landing.service.ts
+++ b/server/src/modules/document/services/record-form-landing.service.ts
@@ -135,7 +135,7 @@ export class RecordFormLandingService {
         targetModule: suggestion.targetModule,
         targetModel: suggestion.targetModel,
         targetRoute: suggestion.targetRoute,
-        targetTemplateId: suggestion.targetTemplateId,
+        targetTemplateId: suggestion.targetTemplateId ?? undefined,
         confirmationStatus: 'confirmed',
         fieldCoverageStatus: (suggestion.fieldCoverageStatus as any) ?? 'unknown',
       }, userId);

--- a/server/src/modules/non-conformance/non-conformance.service.spec.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.spec.ts
@@ -2,7 +2,8 @@ import { NotFoundException } from '@nestjs/common';
 import { NonConformanceService } from './non-conformance.service';
 
 describe('NonConformanceService', () => {
-  const prisma = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const prisma: any = {
     nonConformance: {
       count: jest.fn(),
       create: jest.fn(),
@@ -10,10 +11,18 @@ describe('NonConformanceService', () => {
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    productionBatch: {
+      findFirst: jest.fn(),
+    },
+    reworkRecord: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+    },
   };
   const numberSequence = {
     generateNonConformanceNo: jest.fn(),
   };
+  prisma.$transaction = jest.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(prisma));
   let service: NonConformanceService;
 
   beforeEach(() => {
@@ -45,6 +54,165 @@ describe('NonConformanceService', () => {
 
     await expect(service.dispose('nc1', { disposition: 'rework' }, 'u1', '2')).rejects.toThrow(NotFoundException);
     expect(prisma.nonConformance.update).not.toHaveBeenCalled();
+  });
+
+  it('auto-creates one pending ReworkRecord when disposing a production-batch NC as rework', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      company_id: '2',
+      nc_no: 'NC-2026-0001',
+      source_type: 'production_batch',
+      source_id: 'batch-1',
+      description: '烘烤不足，需要返工',
+      qty: 12.5,
+      unit: 'kg',
+    });
+    prisma.productionBatch.findFirst.mockResolvedValue({ id: 'batch-1' });
+    prisma.reworkRecord.findFirst.mockResolvedValue(null);
+    prisma.nonConformance.update.mockResolvedValue({ id: 'nc1', disposition: 'rework' });
+    prisma.reworkRecord.create.mockResolvedValue({ id: 'rw1' });
+
+    await service.dispose('nc1', { disposition: 'rework' }, 'u1', '2');
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.productionBatch.findFirst).toHaveBeenCalledWith({
+      where: { id: 'batch-1', product: { company_id: '2' } },
+      select: { id: true },
+    });
+    expect(prisma.reworkRecord.findFirst).toHaveBeenCalledWith({
+      where: { company_id: '2', nc_id: 'nc1' },
+      select: { id: true },
+    });
+    expect(prisma.reworkRecord.create).toHaveBeenCalledWith({
+      data: {
+        company_id: '2',
+        production_batch_id: 'batch-1',
+        nc_id: 'nc1',
+        rework_reason: '烘烤不足，需要返工',
+        rework_qty: 12.5,
+        unit: 'kg',
+        rework_date: expect.any(Date),
+        operator_id: 'u1',
+        quality_verdict: 'pending',
+      },
+    });
+    expect(prisma.nonConformance.update).toHaveBeenCalledWith({
+      where: { id: 'nc1' },
+      data: {
+        disposition: 'rework',
+        disposition_by: 'u1',
+        disposition_at: expect.any(Date),
+        status: 'dispositioned',
+      },
+    });
+  });
+
+  it('does not create a duplicate ReworkRecord when one already exists for the NC', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      company_id: '2',
+      nc_no: 'NC-2026-0001',
+      source_type: 'production_batch',
+      source_id: 'batch-1',
+      description: '烘烤不足，需要返工',
+      qty: 12.5,
+      unit: 'kg',
+    });
+    prisma.productionBatch.findFirst.mockResolvedValue({ id: 'batch-1' });
+    prisma.reworkRecord.findFirst.mockResolvedValue({ id: 'rw-existing' });
+    prisma.nonConformance.update.mockResolvedValue({ id: 'nc1', disposition: 'rework' });
+
+    await service.dispose('nc1', { disposition: 'rework' }, 'u1', '2');
+
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.update).toHaveBeenCalled();
+  });
+
+  it('rejects rework disposition when NC source is not a production batch', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc-material',
+      company_id: '2',
+      source_type: 'material_batch',
+      source_id: 'material-batch-1',
+      description: '原料异常',
+      qty: 1,
+      unit: 'kg',
+    });
+
+    await expect(service.dispose('nc-material', { disposition: 'rework' }, 'u1', '2')).rejects.toThrow(
+      '返工处置仅支持来源为生产批次的不合格记录',
+    );
+
+    expect(prisma.nonConformance.update).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects rework disposition when NC quantity or unit is missing', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc-no-qty',
+      company_id: '2',
+      source_type: 'production_batch',
+      source_id: 'batch-1',
+      description: '未填写数量',
+      qty: null,
+      unit: 'kg',
+    });
+
+    await expect(service.dispose('nc-no-qty', { disposition: 'rework' }, 'u1', '2')).rejects.toThrow(
+      '返工处置需要不合格数量和单位',
+    );
+
+    expect(prisma.productionBatch.findFirst).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.update).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects rework disposition when the production batch is missing or outside company', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      company_id: '2',
+      source_type: 'production_batch',
+      source_id: 'missing-batch',
+      description: '批次不存在',
+      qty: 1,
+      unit: 'kg',
+    });
+    prisma.productionBatch.findFirst.mockResolvedValue(null);
+
+    await expect(service.dispose('nc1', { disposition: 'rework' }, 'u1', '2')).rejects.toThrow(
+      '返工处置的生产批次不存在或不属于当前公司',
+    );
+
+    expect(prisma.nonConformance.update).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('does not touch ReworkRecord when disposition is not rework', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      company_id: '2',
+      source_type: 'production_batch',
+      source_id: 'batch-1',
+      description: '让步接收',
+      qty: 1,
+      unit: 'kg',
+    });
+    prisma.nonConformance.update.mockResolvedValue({ id: 'nc1', disposition: 'concession' });
+
+    await service.dispose('nc1', { disposition: 'concession' }, 'u1', '2');
+
+    expect(prisma.productionBatch.findFirst).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.findFirst).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.update).toHaveBeenCalledWith({
+      where: { id: 'nc1' },
+      data: {
+        disposition: 'concession',
+        disposition_by: 'u1',
+        disposition_at: expect.any(Date),
+        status: 'dispositioned',
+      },
+    });
   });
 
   it('creates an open NonConformance from a CCP deviation using production batch as source', async () => {

--- a/server/src/modules/non-conformance/non-conformance.service.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { NonConformance, Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateNcDto, DisposeNcDto } from './dto/create-nc.dto';
 import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
@@ -77,18 +77,67 @@ export class NonConformanceService {
   }
 
   async dispose(id: string, dto: DisposeNcDto, userId: string, companyId: string) {
-    const record = await this.prisma.nonConformance.findFirst({
-      where: { id, company_id: companyId },
-    });
-    if (!record) throw new NotFoundException('不合格记录不存在');
+    return this.prisma.$transaction(async (tx) => {
+      const record = await tx.nonConformance.findFirst({
+        where: { id, company_id: companyId },
+      });
+      if (!record) throw new NotFoundException('不合格记录不存在');
 
-    return this.prisma.nonConformance.update({
-      where: { id },
+      if (dto.disposition === 'rework') {
+        await this.ensureReworkRecordForDisposition(record, userId, companyId, tx);
+      }
+
+      return tx.nonConformance.update({
+        where: { id },
+        data: {
+          disposition: dto.disposition,
+          disposition_by: userId,
+          disposition_at: new Date(),
+          status: 'dispositioned',
+        },
+      });
+    });
+  }
+
+  private async ensureReworkRecordForDisposition(
+    record: NonConformance,
+    userId: string,
+    companyId: string,
+    tx: Prisma.TransactionClient,
+  ) {
+    if (record.source_type !== 'production_batch') {
+      throw new BadRequestException('返工处置仅支持来源为生产批次的不合格记录');
+    }
+
+    if (record.qty == null || !record.unit?.trim()) {
+      throw new BadRequestException('返工处置需要不合格数量和单位');
+    }
+
+    const productionBatch = await tx.productionBatch.findFirst({
+      where: { id: record.source_id, product: { company_id: companyId } },
+      select: { id: true },
+    });
+    if (!productionBatch) {
+      throw new BadRequestException('返工处置的生产批次不存在或不属于当前公司');
+    }
+
+    const existingReworkRecord = await tx.reworkRecord.findFirst({
+      where: { company_id: companyId, nc_id: record.id },
+      select: { id: true },
+    });
+    if (existingReworkRecord) return;
+
+    await tx.reworkRecord.create({
       data: {
-        disposition: dto.disposition,
-        disposition_by: userId,
-        disposition_at: new Date(),
-        status: 'dispositioned',
+        company_id: companyId,
+        production_batch_id: record.source_id,
+        nc_id: record.id,
+        rework_reason: record.description,
+        rework_qty: record.qty,
+        unit: record.unit.trim(),
+        rework_date: new Date(),
+        operator_id: userId,
+        quality_verdict: 'pending',
       },
     });
   }


### PR DESCRIPTION
## Summary

- Wrap `NonConformanceService.dispose()` in a Prisma transaction that auto-creates a pending `ReworkRecord` when disposition is `rework`
- Validates NC must point to a `production_batch`, have qty/unit set, and the batch must belong to current company
- Idempotent: skips creation if a `ReworkRecord` with matching `nc_id` already exists
- Adds `pending` verdict option to frontend (`getVerdictTagType` helper) displayed as warning tag in `ReworkRecordList`

## Test plan

- [x] `NonConformanceService` happy-path: auto-creates pending ReworkRecord in transaction
- [x] Duplicate protection: does not create second ReworkRecord if one already exists
- [x] Rejects rework if source is not `production_batch`
- [x] Rejects rework if NC qty or unit is missing
- [x] Rejects rework if production batch not found or outside company
- [x] Non-rework dispositions (e.g. `concession`) do not touch ReworkRecord
- [x] `ReworkRecordService` manual create/delete tests still pass
- [x] Client build passes with new `pending` verdict display