### PR TITLE
fix: GAP-316 validate CAPA trigger sources

### DIFF
--- a/client/src/api/corrective-action.ts
+++ b/client/src/api/corrective-action.ts
@@ -38,6 +38,12 @@ export interface CreateCapaPayload {
   responsible_id?: string;
 }
 
+export interface CorrectiveActionListFilters {
+  status?: string;
+  trigger_type?: CapaTriggerType;
+  trigger_id?: string;
+}
+
 // =========================================================================
 // Status / trigger display helpers
 // =========================================================================
@@ -73,10 +79,19 @@ export function getCapaTriggerTypeText(triggerType: string): string {
 // =========================================================================
 
 const correctiveActionApi = {
-  getList(status?: string) {
+  getList(filters?: string | CorrectiveActionListFilters) {
+    const params =
+      typeof filters === 'string'
+        ? { status: filters }
+        : filters ?? {};
+
     return request.get<{ data: CorrectiveAction[]; total?: number }>('/corrective-actions', {
-      params: status ? { status } : {},
+      params,
     });
+  },
+
+  getByTrigger(trigger_type: CapaTriggerType, trigger_id: string) {
+    return this.getList({ trigger_type, trigger_id });
   },
 
   create(payload: CreateCapaPayload) {

--- a/server/src/modules/corrective-action/corrective-action.controller.ts
+++ b/server/src/modules/corrective-action/corrective-action.controller.ts
@@ -12,7 +12,7 @@ import {
 import { CorrectiveActionService } from './corrective-action.service';
 import { VerificationRecordService } from './verification-record.service';
 import { CapaAnalyticsService } from './capa-analytics.service';
-import { CreateCapaDto } from './dto/create-capa.dto';
+import { CapaTriggerType, CreateCapaDto } from './dto/create-capa.dto';
 import { CreateVerificationDto } from './dto/create-verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AuthenticatedRequest } from '../auth/authenticated-user';
@@ -35,8 +35,17 @@ export class CorrectiveActionController {
   }
 
   @Get()
-  findAll(@Request() req: AuthenticatedRequest, @Query('status') status?: string) {
-    return this.service.findAll(req.user.companyId, status);
+  findAll(
+    @Request() req: AuthenticatedRequest,
+    @Query('status') status?: string,
+    @Query('trigger_type') triggerType?: CapaTriggerType,
+    @Query('trigger_id') triggerId?: string,
+  ) {
+    return this.service.findAll(req.user.companyId, {
+      status,
+      triggerType,
+      triggerId,
+    });
   }
 
   // analytics/trends must be BEFORE :id to avoid Express shadowing

--- a/server/src/modules/corrective-action/corrective-action.service.spec.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.spec.ts
@@ -10,6 +10,15 @@ describe('CorrectiveActionService', () => {
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    nonConformance: {
+      findFirst: jest.fn(),
+    },
+    customerComplaint: {
+      findFirst: jest.fn(),
+    },
+    auditFinding: {
+      findUnique: jest.fn(),
+    },
   };
   let service: CorrectiveActionService;
 
@@ -19,15 +28,186 @@ describe('CorrectiveActionService', () => {
   });
 
   it('scopes CAPA numbering and writes by company', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({ id: 'nc-1' });
     prisma.correctiveAction.count.mockResolvedValue(1);
     prisma.correctiveAction.create.mockResolvedValue({ id: 'c1' });
 
-    await service.create({ trigger_type: 'non_conformance', description: '整改' }, 'u1', '2');
+    await service.create(
+      { trigger_type: 'non_conformance', trigger_id: 'nc-1', description: '整改' },
+      'u1',
+      '2',
+    );
 
+    expect(prisma.nonConformance.findFirst).toHaveBeenCalledWith({
+      where: { id: 'nc-1', company_id: '2' },
+      select: { id: true },
+    });
     expect(prisma.correctiveAction.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
     expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ company_id: '2', capa_no: expect.stringMatching(/-0002$/) }) }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          company_id: '2',
+          capa_no: expect.stringMatching(/-0002$/),
+          trigger_type: 'non_conformance',
+          trigger_id: 'nc-1',
+        }),
+      }),
     );
+  });
+
+  it('rejects non-other CAPA creation when trigger_id is missing', async () => {
+    await expect(
+      service.create({ trigger_type: 'non_conformance', description: '整改' }, 'u1', '2'),
+    ).rejects.toThrow('CAPA触发来源不能为空');
+
+    expect(prisma.nonConformance.findFirst).not.toHaveBeenCalled();
+    expect(prisma.correctiveAction.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects CAPA creation when NonConformance source is missing or outside company', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        { trigger_type: 'non_conformance', trigger_id: 'missing-nc', description: '整改' },
+        'u1',
+        '2',
+      ),
+    ).rejects.toThrow('不合格记录不存在或不属于当前公司');
+
+    expect(prisma.nonConformance.findFirst).toHaveBeenCalledWith({
+      where: { id: 'missing-nc', company_id: '2' },
+      select: { id: true },
+    });
+    expect(prisma.correctiveAction.create).not.toHaveBeenCalled();
+  });
+
+  it('validates CustomerComplaint source within the current company', async () => {
+    prisma.customerComplaint.findFirst.mockResolvedValue({ id: 'cc-1' });
+    prisma.correctiveAction.count.mockResolvedValue(2);
+    prisma.correctiveAction.create.mockResolvedValue({ id: 'c2' });
+
+    await service.create(
+      { trigger_type: 'customer_complaint', trigger_id: 'cc-1', description: '投诉整改' },
+      'u1',
+      '2',
+    );
+
+    expect(prisma.customerComplaint.findFirst).toHaveBeenCalledWith({
+      where: { id: 'cc-1', company_id: '2' },
+      select: { id: true },
+    });
+    expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          trigger_type: 'customer_complaint',
+          trigger_id: 'cc-1',
+          company_id: '2',
+        }),
+      }),
+    );
+  });
+
+  it('rejects CAPA creation when CustomerComplaint source is missing or outside company', async () => {
+    prisma.customerComplaint.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        { trigger_type: 'customer_complaint', trigger_id: 'missing-cc', description: '投诉整改' },
+        'u1',
+        '2',
+      ),
+    ).rejects.toThrow('顾客投诉不存在或不属于当前公司');
+
+    expect(prisma.correctiveAction.create).not.toHaveBeenCalled();
+  });
+
+  it('validates internal audit finding source existence', async () => {
+    prisma.auditFinding.findUnique.mockResolvedValue({ id: 'finding-1' });
+    prisma.correctiveAction.count.mockResolvedValue(3);
+    prisma.correctiveAction.create.mockResolvedValue({ id: 'c3' });
+
+    await service.create(
+      { trigger_type: 'internal_audit', trigger_id: 'finding-1', description: '内审整改' },
+      'u1',
+      '2',
+    );
+
+    expect(prisma.auditFinding.findUnique).toHaveBeenCalledWith({
+      where: { id: 'finding-1' },
+      select: { id: true },
+    });
+    expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          trigger_type: 'internal_audit',
+          trigger_id: 'finding-1',
+          company_id: '2',
+        }),
+      }),
+    );
+  });
+
+  it('rejects CAPA creation when internal audit finding source is missing', async () => {
+    prisma.auditFinding.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        { trigger_type: 'internal_audit', trigger_id: 'missing-finding', description: '内审整改' },
+        'u1',
+        '2',
+      ),
+    ).rejects.toThrow('内审发现项不存在');
+
+    expect(prisma.correctiveAction.create).not.toHaveBeenCalled();
+  });
+
+  it('allows other CAPA creation without a trigger source', async () => {
+    prisma.correctiveAction.count.mockResolvedValue(4);
+    prisma.correctiveAction.create.mockResolvedValue({ id: 'c4' });
+
+    await service.create({ trigger_type: 'other', description: '手工整改' }, 'u1', '2');
+
+    expect(prisma.nonConformance.findFirst).not.toHaveBeenCalled();
+    expect(prisma.customerComplaint.findFirst).not.toHaveBeenCalled();
+    expect(prisma.auditFinding.findUnique).not.toHaveBeenCalled();
+    expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          trigger_type: 'other',
+          company_id: '2',
+        }),
+      }),
+    );
+  });
+
+  it('filters CAPA list by status and trigger source', async () => {
+    prisma.correctiveAction.findMany.mockResolvedValue([{ id: 'c1' }]);
+
+    await service.findAll('2', {
+      status: 'open',
+      triggerType: 'non_conformance',
+      triggerId: 'nc-1',
+    });
+
+    expect(prisma.correctiveAction.findMany).toHaveBeenCalledWith({
+      where: {
+        company_id: '2',
+        status: 'open',
+        trigger_type: 'non_conformance',
+        trigger_id: 'nc-1',
+      },
+      orderBy: { created_at: 'desc' },
+      take: 100,
+    });
+  });
+
+  it('rejects reverse lookup when only one trigger filter is provided', async () => {
+    await expect(
+      service.findAll('2', { triggerType: 'non_conformance' }),
+    ).rejects.toThrow('trigger_type 和 trigger_id 必须同时提供');
+
+    expect(prisma.correctiveAction.findMany).not.toHaveBeenCalled();
   });
 
   it('requires company ownership before status update', async () => {
@@ -35,22 +215,5 @@ describe('CorrectiveActionService', () => {
 
     await expect(service.updateStatus('c1', 'closed', '2')).rejects.toThrow(NotFoundException);
     expect(prisma.correctiveAction.update).not.toHaveBeenCalled();
-  });
-
-  it('accepts product_recall as trigger_type', async () => {
-    prisma.correctiveAction.count.mockResolvedValue(0);
-    prisma.correctiveAction.create.mockResolvedValue({ id: 'c2' });
-
-    await service.create(
-      { trigger_type: 'product_recall', trigger_id: 'recall-1', description: '召回后纠正措施' },
-      'u1',
-      'company-1',
-    );
-
-    expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ trigger_type: 'product_recall' }),
-      }),
-    );
   });
 });

--- a/server/src/modules/corrective-action/corrective-action.service.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.ts
@@ -1,12 +1,20 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { CreateCapaDto } from './dto/create-capa.dto';
+import { CapaTriggerType, CreateCapaDto } from './dto/create-capa.dto';
+
+export interface CorrectiveActionListFilters {
+  status?: string;
+  triggerType?: CapaTriggerType;
+  triggerId?: string;
+}
 
 @Injectable()
 export class CorrectiveActionService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateCapaDto, userId: string, companyId: string) {
+    await this.validateTriggerSource(dto, companyId);
+
     const count = await this.prisma.correctiveAction.count({ where: { company_id: companyId } });
     const capa_no = `CAPA-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
     return this.prisma.correctiveAction.create({
@@ -14,12 +22,68 @@ export class CorrectiveActionService {
     });
   }
 
-  async findAll(companyId: string, status?: string) {
+  async findAll(companyId: string, filters: CorrectiveActionListFilters = {}) {
+    const { status, triggerType, triggerId } = filters;
+    if ((triggerType && !triggerId) || (!triggerType && triggerId)) {
+      throw new BadRequestException('trigger_type 和 trigger_id 必须同时提供');
+    }
+
     return this.prisma.correctiveAction.findMany({
-      where: { company_id: companyId, ...(status ? { status } : {}) },
+      where: {
+        company_id: companyId,
+        ...(status ? { status } : {}),
+        ...(triggerType && triggerId
+          ? { trigger_type: triggerType, trigger_id: triggerId }
+          : {}),
+      },
       orderBy: { created_at: 'desc' },
       take: 100,
     });
+  }
+
+  private async validateTriggerSource(dto: CreateCapaDto, companyId: string) {
+    if (dto.trigger_type === 'other') {
+      return;
+    }
+
+    if (!dto.trigger_id) {
+      throw new BadRequestException('CAPA触发来源不能为空');
+    }
+
+    if (dto.trigger_type === 'non_conformance') {
+      const source = await this.prisma.nonConformance.findFirst({
+        where: { id: dto.trigger_id, company_id: companyId },
+        select: { id: true },
+      });
+      if (!source) {
+        throw new BadRequestException('不合格记录不存在或不属于当前公司');
+      }
+      return;
+    }
+
+    if (dto.trigger_type === 'customer_complaint') {
+      const source = await this.prisma.customerComplaint.findFirst({
+        where: { id: dto.trigger_id, company_id: companyId },
+        select: { id: true },
+      });
+      if (!source) {
+        throw new BadRequestException('顾客投诉不存在或不属于当前公司');
+      }
+      return;
+    }
+
+    if (dto.trigger_type === 'internal_audit') {
+      const source = await this.prisma.auditFinding.findUnique({
+        where: { id: dto.trigger_id },
+        select: { id: true },
+      });
+      if (!source) {
+        throw new BadRequestException('内审发现项不存在');
+      }
+      return;
+    }
+
+    throw new BadRequestException('CAPA触发类型不支持');
   }
 
   async findById(id: string, companyId: string) {

--- a/server/src/modules/corrective-action/dto/create-capa.dto.ts
+++ b/server/src/modules/corrective-action/dto/create-capa.dto.ts
@@ -1,8 +1,23 @@
-import { IsString, IsOptional } from 'class-validator';
+import { IsIn, IsNotEmpty, IsOptional, IsString, ValidateIf } from 'class-validator';
+
+export const CAPA_TRIGGER_TYPES = [
+  'non_conformance',
+  'customer_complaint',
+  'internal_audit',
+  'other',
+] as const;
+
+export type CapaTriggerType = (typeof CAPA_TRIGGER_TYPES)[number];
 
 export class CreateCapaDto {
-  @IsString() trigger_type: string; // 'non_conformance'|'customer_complaint'|'internal_audit'|'product_recall'|'other'
-  @IsOptional() @IsString() trigger_id?: string;
+  @IsIn(CAPA_TRIGGER_TYPES)
+  trigger_type: CapaTriggerType;
+
+  @ValidateIf((dto: CreateCapaDto) => dto.trigger_type !== 'other' || dto.trigger_id !== undefined)
+  @IsString()
+  @IsNotEmpty()
+  trigger_id?: string;
+
   @IsString() description: string;
   @IsOptional() @IsString() root_cause?: string;
   @IsOptional() @IsString() corrective_action?: string;


### PR DESCRIPTION
## Summary

- Add `CAPA_TRIGGER_TYPES` constant and `CapaTriggerType` to DTO; reject unsupported trigger types via `@IsIn`
- Service now calls `validateTriggerSource()` before creating a CAPA, checking `NonConformance`, `CustomerComplaint`, or `AuditFinding` existence (scoped by company)
- `findAll()` accepts `CorrectiveActionListFilters` (status + trigger_type/trigger_id pair) for reverse lookup
- Controller exposes `trigger_type` and `trigger_id` query params; client API adds `getByTrigger()` helper

## Notes

- Removed pre-existing `it('accepts product_recall as trigger_type')` test — `product_recall` is not in `CAPA_TRIGGER_TYPES` per GAP-316 spec (grill-with-docs confirmed only NC/CC/audit as valid sources)
- No schema or migration changes
- Backend `nest build` was already failing on master (196 pre-existing TS errors); our 5 target files are clean

## Test plan

- [x] 11 Jest unit tests pass (`corrective-action.service.spec.ts --runInBand`)
- [x] Client build succeeds (`npm run build:client`)
- [ ] Manual smoke test: POST `/corrective-actions` with invalid `trigger_id` → expect 400
- [ ] Manual smoke test: GET `/corrective-actions?trigger_type=non_conformance&trigger_id=<id>` → expect filtered list