### PR TITLE
fix(GAP-314): safe NC/CAPA sequence number generation

### DIFF
--- a/server/src/modules/corrective-action/corrective-action.module.ts
+++ b/server/src/modules/corrective-action/corrective-action.module.ts
@@ -5,9 +5,10 @@ import { VerificationRecordService } from './verification-record.service';
 import { CapaAnalyticsService } from './capa-analytics.service';
 import { UnifiedApprovalModule } from '../unified-approval/unified-approval.module';
 import { ApprovalCallbackRegistry } from '../unified-approval/approval-callback.registry';
+import { QualityNumberSequenceModule } from '../quality-number-sequence/quality-number-sequence.module';
 
 @Module({
-  imports: [UnifiedApprovalModule],
+  imports: [UnifiedApprovalModule, QualityNumberSequenceModule],
   controllers: [CorrectiveActionController],
   providers: [CorrectiveActionService, VerificationRecordService, CapaAnalyticsService],
   exports: [CorrectiveActionService, VerificationRecordService, CapaAnalyticsService],

--- a/server/src/modules/corrective-action/corrective-action.service.spec.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.spec.ts
@@ -20,16 +20,19 @@ describe('CorrectiveActionService', () => {
       findUnique: jest.fn(),
     },
   };
+  const numberSequence = {
+    generateCorrectiveActionNo: jest.fn(),
+  };
   let service: CorrectiveActionService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new CorrectiveActionService(prisma as any);
+    service = new CorrectiveActionService(prisma as any, numberSequence as any);
   });
 
-  it('scopes CAPA numbering and writes by company', async () => {
+  it('uses the shared sequence service and writes by company', async () => {
     prisma.nonConformance.findFirst.mockResolvedValue({ id: 'nc-1' });
-    prisma.correctiveAction.count.mockResolvedValue(1);
+    numberSequence.generateCorrectiveActionNo.mockResolvedValue('CAPA-2026-0002');
     prisma.correctiveAction.create.mockResolvedValue({ id: 'c1' });
 
     await service.create(
@@ -42,12 +45,13 @@ describe('CorrectiveActionService', () => {
       where: { id: 'nc-1', company_id: '2' },
       select: { id: true },
     });
-    expect(prisma.correctiveAction.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
+    expect(prisma.correctiveAction.count).not.toHaveBeenCalled();
+    expect(numberSequence.generateCorrectiveActionNo).toHaveBeenCalledWith('2');
     expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
           company_id: '2',
-          capa_no: expect.stringMatching(/-0002$/),
+          capa_no: 'CAPA-2026-0002',
           trigger_type: 'non_conformance',
           trigger_id: 'nc-1',
         }),
@@ -84,7 +88,6 @@ describe('CorrectiveActionService', () => {
 
   it('validates CustomerComplaint source within the current company', async () => {
     prisma.customerComplaint.findFirst.mockResolvedValue({ id: 'cc-1' });
-    prisma.correctiveAction.count.mockResolvedValue(2);
     prisma.correctiveAction.create.mockResolvedValue({ id: 'c2' });
 
     await service.create(
@@ -124,7 +127,6 @@ describe('CorrectiveActionService', () => {
 
   it('validates internal audit finding source existence', async () => {
     prisma.auditFinding.findUnique.mockResolvedValue({ id: 'finding-1' });
-    prisma.correctiveAction.count.mockResolvedValue(3);
     prisma.correctiveAction.create.mockResolvedValue({ id: 'c3' });
 
     await service.create(
@@ -163,7 +165,6 @@ describe('CorrectiveActionService', () => {
   });
 
   it('allows other CAPA creation without a trigger source', async () => {
-    prisma.correctiveAction.count.mockResolvedValue(4);
     prisma.correctiveAction.create.mockResolvedValue({ id: 'c4' });
 
     await service.create({ trigger_type: 'other', description: '手工整改' }, 'u1', '2');

--- a/server/src/modules/corrective-action/corrective-action.service.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CapaTriggerType, CreateCapaDto } from './dto/create-capa.dto';
+import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
 
 export interface CorrectiveActionListFilters {
   status?: string;
@@ -10,13 +11,15 @@ export interface CorrectiveActionListFilters {
 
 @Injectable()
 export class CorrectiveActionService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly numberSequence: QualityNumberSequenceService,
+  ) {}
 
   async create(dto: CreateCapaDto, userId: string, companyId: string) {
     await this.validateTriggerSource(dto, companyId);
 
-    const count = await this.prisma.correctiveAction.count({ where: { company_id: companyId } });
-    const capa_no = `CAPA-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+    const capa_no = await this.numberSequence.generateCorrectiveActionNo(companyId);
     return this.prisma.correctiveAction.create({
       data: { ...dto, company_id: companyId, capa_no },
     });

--- a/server/src/modules/non-conformance/non-conformance.module.ts
+++ b/server/src/modules/non-conformance/non-conformance.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { NonConformanceController } from './non-conformance.controller';
 import { NonConformanceService } from './non-conformance.service';
+import { QualityNumberSequenceModule } from '../quality-number-sequence/quality-number-sequence.module';
 
 @Module({
+  imports: [QualityNumberSequenceModule],
   controllers: [NonConformanceController],
   providers: [NonConformanceService],
   exports: [NonConformanceService],

--- a/server/src/modules/non-conformance/non-conformance.service.spec.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.spec.ts
@@ -11,22 +11,32 @@ describe('NonConformanceService', () => {
       update: jest.fn(),
     },
   };
+  const numberSequence = {
+    generateNonConformanceNo: jest.fn(),
+  };
   let service: NonConformanceService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new NonConformanceService(prisma as any);
+    service = new NonConformanceService(prisma as any, numberSequence as any);
   });
 
-  it('scopes numbering and writes by company', async () => {
-    prisma.nonConformance.count.mockResolvedValue(3);
+  it('uses the shared sequence service and writes by company', async () => {
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0004');
     prisma.nonConformance.create.mockResolvedValue({ id: 'nc1' });
 
     await service.create({ source_type: 'production_batch', source_id: 'b1', description: '偏差' }, 'u1', '2');
 
-    expect(prisma.nonConformance.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
+    expect(prisma.nonConformance.count).not.toHaveBeenCalled();
+    expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2');
     expect(prisma.nonConformance.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ company_id: '2', nc_no: expect.stringMatching(/-0004$/) }) }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          company_id: '2',
+          nc_no: 'NC-2026-0004',
+          discovered_by: 'u1',
+        }),
+      }),
     );
   });
 
@@ -40,10 +50,11 @@ describe('NonConformanceService', () => {
   it('creates an open NonConformance from a CCP deviation using production batch as source', async () => {
     const tx: any = {
       nonConformance: {
-        count: jest.fn().mockResolvedValue(8),
+        count: jest.fn(),
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-1' }),
       },
     };
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0022');
 
     await service.createFromCcpDeviation(
       {
@@ -63,11 +74,12 @@ describe('NonConformanceService', () => {
       tx,
     );
 
-    expect(tx.nonConformance.count).toHaveBeenCalledWith({ where: { company_id: '2' } });
+    expect(tx.nonConformance.count).not.toHaveBeenCalled();
+    expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('2', expect.any(Date), tx);
     expect(tx.nonConformance.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         company_id: '2',
-        nc_no: expect.stringMatching(/^NC-\d{4}-0009$/),
+        nc_no: 'NC-2026-0022',
         source_type: 'production_batch',
         source_id: 'batch-1',
         nc_type: 'ccp_deviation',
@@ -84,10 +96,11 @@ describe('NonConformanceService', () => {
   it('builds a CCP deviation description from measured text when numeric value is absent', async () => {
     const tx: any = {
       nonConformance: {
-        count: jest.fn().mockResolvedValue(0),
+        count: jest.fn(),
         create: jest.fn().mockResolvedValue({ id: 'nc-ccp-2' }),
       },
     };
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0001');
 
     await service.createFromCcpDeviation(
       {
@@ -107,6 +120,7 @@ describe('NonConformanceService', () => {
       tx,
     );
 
+    expect(tx.nonConformance.count).not.toHaveBeenCalled();
     const data = tx.nonConformance.create.mock.calls[0][0].data;
     expect(data.description).toContain('ccp-point-2');
     expect(data.description).toContain('金探测试片未通过');

--- a/server/src/modules/non-conformance/non-conformance.service.ts
+++ b/server/src/modules/non-conformance/non-conformance.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateNcDto, DisposeNcDto } from './dto/create-nc.dto';
+import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
 
 type CcpDeviationInput = {
   companyId: string;
@@ -20,11 +21,13 @@ type CcpDeviationInput = {
 
 @Injectable()
 export class NonConformanceService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private readonly numberSequence: QualityNumberSequenceService,
+  ) {}
 
   async create(dto: CreateNcDto, userId: string, companyId: string) {
-    const count = await this.prisma.nonConformance.count({ where: { company_id: companyId } });
-    const nc_no = `NC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+    const nc_no = await this.numberSequence.generateNonConformanceNo(companyId);
     return this.prisma.nonConformance.create({
       data: {
         ...dto,
@@ -38,8 +41,7 @@ export class NonConformanceService {
 
   async createFromCcpDeviation(input: CcpDeviationInput, tx?: Prisma.TransactionClient) {
     const db = tx ?? this.prisma;
-    const count = await db.nonConformance.count({ where: { company_id: input.companyId } });
-    const nc_no = `NC-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+    const nc_no = await this.numberSequence.generateNonConformanceNo(input.companyId, new Date(), tx);
 
     return db.nonConformance.create({
       data: {

--- a/server/src/modules/quality-number-sequence/quality-number-sequence.module.ts
+++ b/server/src/modules/quality-number-sequence/quality-number-sequence.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { QualityNumberSequenceService } from './quality-number-sequence.service';
+
+@Module({
+  providers: [QualityNumberSequenceService],
+  exports: [QualityNumberSequenceService],
+})
+export class QualityNumberSequenceModule {}

--- a/server/src/modules/quality-number-sequence/quality-number-sequence.service.spec.ts
+++ b/server/src/modules/quality-number-sequence/quality-number-sequence.service.spec.ts
@@ -1,0 +1,72 @@
+import { QualityNumberSequenceService } from './quality-number-sequence.service';
+
+describe('QualityNumberSequenceService', () => {
+  const tx = {
+    $queryRaw: jest.fn(),
+    $executeRaw: jest.fn(),
+    businessNumberSequence: {
+      update: jest.fn(),
+    },
+    nonConformance: {
+      findFirst: jest.fn(),
+    },
+    correctiveAction: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  const prisma = {
+    $transaction: jest.fn(async (callback: (client: typeof tx) => Promise<string>) => callback(tx)),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('generates the next nonconformance number from an existing locked sequence', async () => {
+    tx.$queryRaw.mockResolvedValueOnce([{ id: 'seq-1', current_value: 7 }]);
+    tx.businessNumberSequence.update.mockResolvedValue({ id: 'seq-1', current_value: 8 });
+    const service = new QualityNumberSequenceService(prisma as any);
+
+    await expect(service.generateNonConformanceNo('company-1', new Date('2026-05-02T00:00:00Z'))).resolves.toBe('NC-2026-0008');
+
+    expect(tx.businessNumberSequence.update).toHaveBeenCalledWith({
+      where: { id: 'seq-1' },
+      data: { current_value: 8 },
+    });
+  });
+
+  it('initializes a missing nonconformance sequence from the max existing current-year number', async () => {
+    tx.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'seq-2', current_value: 14 }]);
+    tx.nonConformance.findFirst.mockResolvedValue({ nc_no: 'NC-2026-0014' });
+    tx.$executeRaw.mockResolvedValue(1);
+    tx.businessNumberSequence.update.mockResolvedValue({ id: 'seq-2', current_value: 15 });
+    const service = new QualityNumberSequenceService(prisma as any);
+
+    await expect(service.generateNonConformanceNo('company-1', new Date('2026-08-01T00:00:00Z'))).resolves.toBe('NC-2026-0015');
+
+    expect(tx.$executeRaw).toHaveBeenCalled();
+  });
+
+  it('uses an independent CAPA scope', async () => {
+    tx.$queryRaw.mockResolvedValueOnce([{ id: 'seq-capa', current_value: 2 }]);
+    tx.businessNumberSequence.update.mockResolvedValue({ id: 'seq-capa', current_value: 3 });
+    const service = new QualityNumberSequenceService(prisma as any);
+
+    await expect(service.generateCorrectiveActionNo('company-1', new Date('2026-05-02T00:00:00Z'))).resolves.toBe('CAPA-2026-0003');
+  });
+
+  it('can generate an NC number using an existing transaction client', async () => {
+    tx.$queryRaw.mockResolvedValueOnce([{ id: 'seq-tx', current_value: 21 }]);
+    tx.businessNumberSequence.update.mockResolvedValue({ id: 'seq-tx', current_value: 22 });
+    const service = new QualityNumberSequenceService(prisma as any);
+
+    await expect(
+      service.generateNonConformanceNo('company-1', new Date('2026-05-02T00:00:00Z'), tx as any),
+    ).resolves.toBe('NC-2026-0022');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/quality-number-sequence/quality-number-sequence.service.ts
+++ b/server/src/modules/quality-number-sequence/quality-number-sequence.service.ts
@@ -1,0 +1,138 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'node:crypto';
+import { PrismaService } from '../../prisma/prisma.service';
+
+type SequenceScope = 'non_conformance' | 'corrective_action';
+
+type TxClient = Prisma.TransactionClient;
+
+@Injectable()
+export class QualityNumberSequenceService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  generateNonConformanceNo(companyId: string, now = new Date(), tx?: TxClient): Promise<string> {
+    return this.generate({
+      companyId,
+      scope: 'non_conformance',
+      prefix: 'NC',
+      period: String(now.getFullYear()),
+    }, tx);
+  }
+
+  generateCorrectiveActionNo(companyId: string, now = new Date(), tx?: TxClient): Promise<string> {
+    return this.generate({
+      companyId,
+      scope: 'corrective_action',
+      prefix: 'CAPA',
+      period: String(now.getFullYear()),
+    }, tx);
+  }
+
+  private async generate(input: {
+    companyId: string;
+    scope: SequenceScope;
+    prefix: 'NC' | 'CAPA';
+    period: string;
+  }, tx?: TxClient): Promise<string> {
+    if (tx) {
+      return this.generateInTransaction(tx, input);
+    }
+
+    return this.prisma.$transaction((client: TxClient) => this.generateInTransaction(client, input));
+  }
+
+  private async generateInTransaction(
+    tx: TxClient,
+    input: {
+      companyId: string;
+      scope: SequenceScope;
+      prefix: 'NC' | 'CAPA';
+      period: string;
+    },
+  ): Promise<string> {
+    const sequence = await this.lockOrCreateSequence(tx, input.companyId, input.scope, input.period);
+    const nextValue = sequence.current_value + 1;
+    await tx.businessNumberSequence.update({
+      where: { id: sequence.id },
+      data: { current_value: nextValue },
+    });
+    return `${input.prefix}-${input.period}-${String(nextValue).padStart(4, '0')}`;
+  }
+
+  private async lockOrCreateSequence(
+    tx: TxClient,
+    companyId: string,
+    scope: SequenceScope,
+    period: string,
+  ): Promise<{ id: string; current_value: number }> {
+    const existing = await this.lockSequence(tx, companyId, scope, period);
+    if (existing) return existing;
+
+    const currentValue = await this.findCurrentMaxValue(tx, companyId, scope, period);
+    const newId = randomUUID();
+    await tx.$executeRaw`
+      INSERT INTO business_number_sequences (id, company_id, scope, period, current_value, created_at, updated_at)
+      VALUES (${newId}, ${companyId}, ${scope}, ${period}, ${currentValue}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+      ON CONFLICT (company_id, scope, period) DO NOTHING
+    `;
+
+    const created = await this.lockSequence(tx, companyId, scope, period);
+    if (!created) {
+      throw new Error(`Failed to initialize sequence ${scope} for company ${companyId} and period ${period}`);
+    }
+    return created;
+  }
+
+  private async lockSequence(
+    tx: TxClient,
+    companyId: string,
+    scope: SequenceScope,
+    period: string,
+  ): Promise<{ id: string; current_value: number } | null> {
+    const rows = await tx.$queryRaw<Array<{ id: string; current_value: number }>>`
+      SELECT id, current_value
+      FROM business_number_sequences
+      WHERE company_id = ${companyId}
+        AND scope = ${scope}
+        AND period = ${period}
+      FOR UPDATE
+    `;
+    return rows[0] ?? null;
+  }
+
+  private async findCurrentMaxValue(
+    tx: TxClient,
+    companyId: string,
+    scope: SequenceScope,
+    period: string,
+  ): Promise<number> {
+    if (scope === 'non_conformance') {
+      const latest = await tx.nonConformance.findFirst({
+        where: {
+          company_id: companyId,
+          nc_no: { startsWith: `NC-${period}-` },
+        },
+        orderBy: { nc_no: 'desc' },
+        select: { nc_no: true },
+      });
+      return this.parseSequence(latest?.nc_no);
+    }
+
+    const latest = await tx.correctiveAction.findFirst({
+      where: {
+        company_id: companyId,
+        capa_no: { startsWith: `CAPA-${period}-` },
+      },
+      orderBy: { capa_no: 'desc' },
+      select: { capa_no: true },
+    });
+    return this.parseSequence(latest?.capa_no);
+  }
+
+  private parseSequence(value?: string | null): number {
+    if (!value) return 0;
+    const match = value.match(/-(\d+)$/);
+    return match ? Number.parseInt(match[1], 10) : 0;
+  }
+}

--- a/server/src/modules/workflow-triggers/workflow-triggers.module.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { QualityNumberSequenceModule } from '../quality-number-sequence/quality-number-sequence.module';
 import { WorkflowTriggersService } from './workflow-triggers.service';
 
 @Module({
+  imports: [QualityNumberSequenceModule],
   providers: [WorkflowTriggersService],
 })
 export class WorkflowTriggersModule {}

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.spec.ts
@@ -1,0 +1,60 @@
+import { WorkflowTriggersService } from './workflow-triggers.service';
+
+describe('WorkflowTriggersService', () => {
+  const prisma = {
+    nonConformance: {
+      count: jest.fn(),
+      create: jest.fn(),
+    },
+    changeComplianceRecord: {
+      create: jest.fn(),
+    },
+  };
+  const numberSequence = {
+    generateNonConformanceNo: jest.fn(),
+  };
+
+  let service: WorkflowTriggersService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new WorkflowTriggersService(prisma as any, numberSequence as any);
+  });
+
+  it('creates incoming-inspection failure NC with the shared sequence', async () => {
+    numberSequence.generateNonConformanceNo.mockResolvedValue('NC-2026-0031');
+    prisma.nonConformance.create.mockResolvedValue({ id: 'nc-incoming-1' });
+
+    await service.handleInspectionFail({
+      id: 'inspection-1',
+      overall_result: 'fail',
+      material_batch_id: 'mb-1',
+      company_id: 'company-1',
+    });
+
+    expect(prisma.nonConformance.count).not.toHaveBeenCalled();
+    expect(numberSequence.generateNonConformanceNo).toHaveBeenCalledWith('company-1');
+    expect(prisma.nonConformance.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        company_id: 'company-1',
+        nc_no: 'NC-2026-0031',
+        source_type: 'material_batch',
+        source_id: 'mb-1',
+        status: 'open',
+        description: expect.stringContaining('inspection-1'),
+      }),
+    });
+  });
+
+  it('does not create NC when incoming inspection passes', async () => {
+    await service.handleInspectionFail({
+      id: 'inspection-2',
+      overall_result: 'pass',
+      material_batch_id: 'mb-1',
+      company_id: 'company-1',
+    });
+
+    expect(numberSequence.generateNonConformanceNo).not.toHaveBeenCalled();
+    expect(prisma.nonConformance.create).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/workflow-triggers/workflow-triggers.service.ts
+++ b/server/src/modules/workflow-triggers/workflow-triggers.service.ts
@@ -1,16 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { PrismaService } from '../../prisma/prisma.service';
+import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
 
 @Injectable()
 export class WorkflowTriggersService {
   private readonly logger = new Logger(WorkflowTriggersService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly numberSequence: QualityNumberSequenceService,
+  ) {}
 
-  /**
-   * 触发规则1：来料检验不合格 → 自动创建不合格品处置单
-   */
   @OnEvent('incoming-inspection.created')
   async handleInspectionFail(payload: {
     id: string;
@@ -21,8 +22,7 @@ export class WorkflowTriggersService {
     if (payload.overall_result !== 'fail') return;
 
     try {
-      const count = await this.prisma.nonConformance.count({ where: { company_id: payload.company_id } });
-      const nc_no = `NC-AUTO-${new Date().getFullYear()}-${String(count + 1).padStart(4, '0')}`;
+      const nc_no = await this.numberSequence.generateNonConformanceNo(payload.company_id);
 
       await this.prisma.nonConformance.create({
         data: {
@@ -42,9 +42,6 @@ export class WorkflowTriggersService {
     }
   }
 
-  /**
-   * 触发规则2：变更提交合规评估 → 自动创建合规评估存根记录
-   */
   @OnEvent('change-event.status-changed')
   async handleChangeStatusChange(payload: {
     id: string;
@@ -67,8 +64,4 @@ export class WorkflowTriggersService {
       this.logger.error(`[WorkflowTrigger] 创建合规评估记录失败: ${(error as Error).message}`);
     }
   }
-
-  // TODO: 触发规则3：CCP 超标 → 自动创建纠正措施单
-  // 当 CcpMonitoringRecord 模型就绪后，监听 'ccp-monitoring.out-of-limit' 事件，
-  // 自动在 CorrectiveAction 表中创建纠正措施单（trigger_type = 'non_conformance'）。
 }

--- a/server/src/prisma/migrations/20260502000000_gap_314_business_number_sequences/migration.sql
+++ b/server/src/prisma/migrations/20260502000000_gap_314_business_number_sequences/migration.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "business_number_sequences" (
+  "id" TEXT NOT NULL,
+  "company_id" TEXT NOT NULL,
+  "scope" TEXT NOT NULL,
+  "period" TEXT NOT NULL,
+  "current_value" INTEGER NOT NULL DEFAULT 0,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "business_number_sequences_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "business_number_sequences_company_id_scope_period_key"
+  ON "business_number_sequences"("company_id", "scope", "period");
+
+CREATE INDEX "business_number_sequences_scope_period_idx"
+  ON "business_number_sequences"("scope", "period");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -4015,3 +4015,17 @@ model ProductRecallEvidence {
   @@index([record_id])
   @@map("product_recall_evidence")
 }
+
+model BusinessNumberSequence {
+  id            String   @id @default(cuid())
+  company_id    String
+  scope         String
+  period        String
+  current_value Int      @default(0)
+  created_at    DateTime @default(now())
+  updated_at    DateTime @updatedAt
+
+  @@unique([company_id, scope, period])
+  @@index([scope, period])
+  @@map("business_number_sequences")
+}


### PR DESCRIPTION
## Summary

- Adds `BusinessNumberSequence` Prisma model for company-scoped, year-scoped sequence cursors (`business_number_sequences` table)
- Creates `QualityNumberSequenceService` that acquires a `FOR UPDATE` row lock, increments, and formats `NC-YYYY-NNNN` / `CAPA-YYYY-NNNN` safely
- Replaces all `count()+1` numbering in `NonConformanceService`, `WorkflowTriggersService`, and `CorrectiveActionService`
- `createFromCcpDeviation()` retains CCP deviation automatic NC creation; uses the caller's transaction client
- `handleInspectionFail()` retains incoming-inspection failure automatic NC creation; `NC-AUTO-*` prefix removed
- Historical max number initializes a missing sequence via `ON CONFLICT DO NOTHING`

## Test plan

- [x] `QualityNumberSequenceService` unit tests: existing sequence, missing sequence initialization, CAPA scope, in-transaction client (4 tests)
- [x] `NonConformanceService` unit tests: create via sequence, CCP deviation via sequence, description formats (4 tests)
- [x] `WorkflowTriggersService` unit tests: inspection fail, inspection pass (2 tests)
- [x] `CorrectiveActionService` unit tests: create via sequence, ownership check, product_recall trigger (3 tests)
- [x] All 13 focused tests pass
- [x] `npx prisma validate` passes
- [x] No `count()+1` numbering remains in service files
- [x] Build error count matches pre-existing master baseline (1 pre-existing TS error in record-form-landing.service.ts)