### PR TITLE
fix(GAP-302): link EnvironmentRecord to WorkshopArea location FK

### DIFF
--- a/client/src/api/environment-record.ts
+++ b/client/src/api/environment-record.ts
@@ -10,6 +10,7 @@ export interface EnvironmentRecord {
   id: string;
   company_id: string;
   production_batch_id: string;
+  location_id: string | null;
   location: string;
   record_type: RecordType;
   temperature: number | null;
@@ -23,7 +24,7 @@ export interface EnvironmentRecord {
 }
 
 export interface CreateEnvironmentRecordPayload {
-  location: string;
+  location_id: string;
   record_type: RecordType;
   temperature?: number;
   humidity?: number;

--- a/client/src/views/environment-record/EnvironmentRecordList.vue
+++ b/client/src/views/environment-record/EnvironmentRecordList.vue
@@ -80,8 +80,15 @@
         :rules="createRules"
         label-width="110px"
       >
-        <el-form-item label="监测位置" prop="location">
-          <el-input v-model="createForm.location" placeholder="例如：生产车间A区" />
+        <el-form-item label="监测位置" prop="location_id">
+          <el-select v-model="createForm.location_id" placeholder="请选择监测位置" filterable style="width: 100%">
+            <el-option
+              v-for="area in areas"
+              :key="area.id"
+              :label="area.name"
+              :value="area.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="记录类型" prop="record_type">
           <el-select v-model="createForm.record_type" placeholder="请选择" style="width: 100%">
@@ -153,12 +160,14 @@ import environmentRecordApi, {
   type RecordType,
   getRecordTypeText,
 } from '@/api/environment-record';
+import { workshopAreaApi, type WorkshopArea } from '@/api/workshop-area';
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
 const list = ref<EnvironmentRecord[]>([]);
 const loading = ref(false);
 const dateRange = ref<[string, string] | null>(null);
+const areas = ref<WorkshopArea[]>([]);
 
 // ── Create dialog ─────────────────────────────────────────────────────────────
 
@@ -167,7 +176,7 @@ const submitting = ref(false);
 const createFormRef = ref<FormInstance>();
 
 const createForm = reactive({
-  location: '',
+  location_id: '',
   record_type: '' as RecordType | '',
   temperature: undefined as number | undefined,
   humidity: undefined as number | undefined,
@@ -178,7 +187,7 @@ const createForm = reactive({
 });
 
 const createRules: FormRules = {
-  location: [{ required: true, message: '请输入监测位置', trigger: 'blur' }],
+  location_id: [{ required: true, message: '请选择监测位置', trigger: 'change' }],
   record_type: [{ required: true, message: '请选择记录类型', trigger: 'change' }],
   is_within_spec: [{ required: true, message: '请选择是否达标', trigger: 'change' }],
   production_batch_id: [{ required: true, message: '请选择生产批次', trigger: 'change' }],
@@ -199,6 +208,15 @@ function formatDate(dateStr: string | null): string {
 
 // ── Data loading ──────────────────────────────────────────────────────────────
 
+async function loadAreas() {
+  try {
+    const res = await workshopAreaApi.getList();
+    areas.value = (res as unknown as WorkshopArea[]) ?? [];
+  } catch {
+    ElMessage.error('加载监测位置列表失败');
+  }
+}
+
 async function loadList() {
   loading.value = true;
   try {
@@ -215,7 +233,7 @@ async function loadList() {
 // ── Create ────────────────────────────────────────────────────────────────────
 
 function openCreateDialog() {
-  createForm.location = '';
+  createForm.location_id = '';
   createForm.record_type = '';
   createForm.temperature = undefined;
   createForm.humidity = undefined;
@@ -231,7 +249,7 @@ async function handleCreate() {
   submitting.value = true;
   try {
     await environmentRecordApi.create({
-      location: createForm.location,
+      location_id: createForm.location_id,
       record_type: createForm.record_type as RecordType,
       temperature: createForm.temperature,
       humidity: createForm.humidity,
@@ -254,6 +272,7 @@ async function handleCreate() {
 
 onMounted(() => {
   loadList();
+  loadAreas();
 });
 </script>
 

--- a/server/src/modules/environment-record/dto/create-environment-record.dto.ts
+++ b/server/src/modules/environment-record/dto/create-environment-record.dto.ts
@@ -2,7 +2,12 @@ import { IsString, IsOptional, IsBoolean, IsNumber, IsNotEmpty } from 'class-val
 
 export class CreateEnvironmentRecordDto {
   @IsString()
-  location: string;
+  @IsNotEmpty()
+  location_id: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
 
   @IsString()
   record_type: string; // 'temperature_humidity'|'pressure_differential'|'other'

--- a/server/src/modules/environment-record/environment-record.service.spec.ts
+++ b/server/src/modules/environment-record/environment-record.service.spec.ts
@@ -2,21 +2,33 @@ import { BadRequestException } from '@nestjs/common';
 import { EnvironmentRecordService } from './environment-record.service';
 
 describe('EnvironmentRecordService', () => {
+  function createPrismaMock(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      productionBatch: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1' }),
+      },
+      workshopArea: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'area-1', name: '生产车间A区' }),
+      },
+      environmentRecord: {
+        create: jest.fn().mockResolvedValue({ id: 'er-1' }),
+      },
+      ...overrides,
+    } as any;
+  }
+
   it('rejects creation when the production batch does not exist', async () => {
-    const prisma: any = {
+    const prisma = createPrismaMock({
       productionBatch: {
         findUnique: jest.fn().mockResolvedValue(null),
       },
-      environmentRecord: {
-        create: jest.fn(),
-      },
-    };
+    });
     const service = new EnvironmentRecordService(prisma);
 
     await expect(
       service.create(
         {
-          location: '生产车间A区',
+          location_id: 'area-1',
           record_type: 'temperature_humidity',
           temperature: 25.5,
           humidity: 61,
@@ -31,23 +43,51 @@ describe('EnvironmentRecordService', () => {
       where: { id: 'missing-batch' },
       select: { id: true },
     });
+    expect(prisma.workshopArea.findFirst).not.toHaveBeenCalled();
     expect(prisma.environmentRecord.create).not.toHaveBeenCalled();
   });
 
-  it('creates an environment record linked to an existing production batch', async () => {
-    const prisma: any = {
-      productionBatch: {
-        findUnique: jest.fn().mockResolvedValue({ id: 'batch-1' }),
+  it('rejects creation when the monitoring location does not exist or is inactive', async () => {
+    const prisma = createPrismaMock({
+      workshopArea: {
+        findFirst: jest.fn().mockResolvedValue(null),
       },
-      environmentRecord: {
-        create: jest.fn().mockResolvedValue({ id: 'er-1' }),
+    });
+    const service = new EnvironmentRecordService(prisma);
+
+    await expect(
+      service.create(
+        {
+          location_id: 'missing-area',
+          record_type: 'temperature_humidity',
+          temperature: 25.5,
+          humidity: 61,
+          is_within_spec: true,
+          production_batch_id: 'batch-1',
+        },
+        'user-1',
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.workshopArea.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'missing-area',
+        company_id: '1',
+        status: 'active',
+        deleted_at: null,
       },
-    };
+      select: { id: true, name: true },
+    });
+    expect(prisma.environmentRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an environment record linked to an existing production batch and location', async () => {
+    const prisma = createPrismaMock();
     const service = new EnvironmentRecordService(prisma);
 
     await service.create(
       {
-        location: '生产车间A区',
+        location_id: 'area-1',
         record_type: 'temperature_humidity',
         temperature: 25.5,
         humidity: 61,
@@ -59,6 +99,7 @@ describe('EnvironmentRecordService', () => {
 
     expect(prisma.environmentRecord.create).toHaveBeenCalledWith({
       data: {
+        location_id: 'area-1',
         location: '生产车间A区',
         record_type: 'temperature_humidity',
         temperature: 25.5,

--- a/server/src/modules/environment-record/environment-record.service.ts
+++ b/server/src/modules/environment-record/environment-record.service.ts
@@ -16,9 +16,27 @@ export class EnvironmentRecordService {
       throw new BadRequestException('生产批次不存在');
     }
 
+    const location = await this.prisma.workshopArea.findFirst({
+      where: {
+        id: dto.location_id,
+        company_id: '1',
+        status: 'active',
+        deleted_at: null,
+      },
+      select: { id: true, name: true },
+    });
+
+    if (!location) {
+      throw new BadRequestException('监测位置不存在或已停用');
+    }
+
+    const { location: _ignoredLocation, location_id, ...recordData } = dto;
+
     return this.prisma.environmentRecord.create({
       data: {
-        ...dto,
+        ...recordData,
+        location_id,
+        location: location.name,
         company_id: '1',
         operator_id: userId,
         measured_at: new Date(),

--- a/server/src/prisma/migrations/20260502110000_environment_record_location_id/migration.sql
+++ b/server/src/prisma/migrations/20260502110000_environment_record_location_id/migration.sql
@@ -1,0 +1,16 @@
+-- Add a controlled area reference for EnvironmentRecord while preserving legacy location snapshots.
+-- Existing rows keep location_id NULL; historical text mapping requires a separate data governance task.
+
+ALTER TABLE "EnvironmentRecord"
+  ADD COLUMN "location_id" TEXT;
+
+CREATE INDEX "EnvironmentRecord_location_id_idx"
+  ON "EnvironmentRecord"("location_id");
+
+CREATE INDEX "EnvironmentRecord_company_id_location_id_measured_at_idx"
+  ON "EnvironmentRecord"("company_id", "location_id", "measured_at");
+
+ALTER TABLE "EnvironmentRecord"
+  ADD CONSTRAINT "EnvironmentRecord_location_id_fkey"
+  FOREIGN KEY ("location_id") REFERENCES "workshop_areas"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -2812,11 +2812,12 @@ model WorkshopArea {
   updated_at  DateTime @updatedAt
   deleted_at  DateTime?
 
-  recipeLines      RecipeLine[]          @relation("RecipeLineArea")
-  materialUsages   BatchMaterialUsage[]  @relation("BatchUsageArea")
-  stagingStocks    StagingAreaStock[]
-  stocktakes       StagingAreaStocktake[]
-  mixingExecutions MixingExecution[]
+  recipeLines        RecipeLine[]          @relation("RecipeLineArea")
+  materialUsages     BatchMaterialUsage[]  @relation("BatchUsageArea")
+  stagingStocks      StagingAreaStock[]
+  stocktakes         StagingAreaStocktake[]
+  mixingExecutions   MixingExecution[]
+  environmentRecords EnvironmentRecord[]   @relation("EnvironmentRecordLocation")
 
   @@unique([company_id, code])
   @@unique([company_id, name])
@@ -3188,6 +3189,8 @@ model EnvironmentRecord {
   company_id          String
   production_batch_id String
   production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id], onDelete: Restrict)
+  location_id         String?
+  location_ref        WorkshopArea?   @relation("EnvironmentRecordLocation", fields: [location_id], references: [id], onDelete: Restrict)
   location            String
   record_type         String          // 'temperature_humidity'|'pressure_differential'|'other'
   temperature         Decimal?        @db.Decimal(8,2)
@@ -3200,6 +3203,8 @@ model EnvironmentRecord {
   created_at          DateTime        @default(now())
 
   @@index([production_batch_id])
+  @@index([location_id])
+  @@index([company_id, location_id, measured_at])
 }
 
 model ProcessMonitorRecord {


### PR DESCRIPTION
## Summary

- Adds `location_id` FK on `EnvironmentRecord` referencing `WorkshopArea` (GAP-302)
- On create, validates the `WorkshopArea` is active and writes `location` snapshot from `WorkshopArea.name`
- Replaces free-text location input in `EnvironmentRecordList.vue` with an `el-select` backed by the `/workshop-areas` API
- Migration: `20260502110000_environment_record_location_id` — adds nullable `location_id` column + FK + indexes; existing rows keep `NULL` (no back-fill)

## Files changed

- `server/src/prisma/schema.prisma` — `location_id` + reverse relation on `WorkshopArea`
- `server/src/prisma/migrations/20260502110000_environment_record_location_id/migration.sql`
- `server/src/modules/environment-record/dto/create-environment-record.dto.ts` — `location_id` required, `location` optional
- `server/src/modules/environment-record/environment-record.service.ts` — validate batch + active area, write name snapshot
- `server/src/modules/environment-record/environment-record.service.spec.ts` — 3 focused tests (RED→GREEN)
- `client/src/api/environment-record.ts` — add `location_id` to response type, replace payload `location` with `location_id`
- `client/src/views/environment-record/EnvironmentRecordList.vue` — selector component + `loadAreas()`

## Test plan

- [ ] Server focused tests pass: `(cd server && npm test -- environment-record.service.spec.ts --runInBand)`
- [ ] Prisma schema validates: `DATABASE_URL=... npx prisma validate --schema server/src/prisma/schema.prisma`
- [ ] Client builds without errors: `npm run build -w client`
- [ ] Manual: creating an environment record via the UI should show a dropdown of workshop areas
- [ ] Manual: selecting an inactive or missing area ID should return 400 from the API