### PR TITLE
fix(GAP-204): link MixingExecution to ShiftType FK

### DIFF
--- a/client/src/api/mixing.ts
+++ b/client/src/api/mixing.ts
@@ -12,6 +12,7 @@ export interface CreateMixingExecutionPayload {
   recipeId: string;
   productId: string;
   areaId: string;
+  shiftTypeId?: string;
   workDate: string;
   actualWeight: number;
   lines: MixingLineInput[];

--- a/client/src/views/mixing/MixingWorkbench.vue
+++ b/client/src/views/mixing/MixingWorkbench.vue
@@ -23,6 +23,16 @@
             <el-option v-for="area in areas" :key="area.id" :label="area.name" :value="area.id" />
           </el-select>
         </el-form-item>
+        <el-form-item label="班次类型">
+          <el-select v-model="form.shiftTypeId" placeholder="选择班次类型（可选）" style="width: 100%" clearable>
+            <el-option
+              v-for="shiftType in shiftTypes"
+              :key="shiftType.id"
+              :label="`${shiftType.name} ${shiftType.start_time}-${shiftType.end_time}`"
+              :value="shiftType.id"
+            />
+          </el-select>
+        </el-form-item>
         <el-form-item label="工作日期">
           <el-date-picker v-model="form.workDate" type="date" value-format="YYYY-MM-DD" />
         </el-form-item>
@@ -79,6 +89,7 @@ import { mixingApi } from '@/api/mixing';
 import { productApi, type Product } from '@/api/product';
 import { recipeApi, type Recipe } from '@/api/recipe';
 import { workshopAreaApi, type WorkshopArea } from '@/api/workshop-area';
+import { teamShiftApi } from '@/api/team-shift';
 
 interface MixingLine {
   recipeLineId: string;
@@ -96,6 +107,7 @@ const loadingRecipes = ref(false);
 const products = ref<Product[]>([]);
 const recipes = ref<Recipe[]>([]);
 const areas = ref<WorkshopArea[]>([]);
+const shiftTypes = ref<any[]>([]);
 
 const activeRecipes = computed(() => recipes.value.filter((r) => r.status === 'active'));
 
@@ -103,6 +115,7 @@ const form = ref({
   productId: '',
   recipeId: '',
   areaId: '',
+  shiftTypeId: '',
   workDate: '',
   actualWeight: 0,
   lines: [] as MixingLine[],
@@ -209,6 +222,7 @@ const submitExecution = async () => {
       recipeId: form.value.recipeId,
       productId: form.value.productId,
       areaId: form.value.areaId,
+      ...(form.value.shiftTypeId ? { shiftTypeId: form.value.shiftTypeId } : {}),
       workDate: form.value.workDate,
       actualWeight: form.value.actualWeight,
       lines: form.value.lines.map(({ recipeLineId, materialBatchId, actualQuantity, manualOverride, overrideReason }) => ({
@@ -229,12 +243,14 @@ const submitExecution = async () => {
 
 onMounted(async () => {
   try {
-    const [productsRes, areasRes]: [any, any] = await Promise.all([
+    const [productsRes, areasRes, shiftRes]: [any, any, any] = await Promise.all([
       productApi.getList(),
       workshopAreaApi.getList(),
+      teamShiftApi.listShiftTypes(),
     ]);
     products.value = Array.isArray(productsRes.data) ? productsRes.data : (Array.isArray(productsRes) ? productsRes : []);
     areas.value = Array.isArray(areasRes.data) ? areasRes.data : (Array.isArray(areasRes) ? areasRes : []);
+    shiftTypes.value = Array.isArray(shiftRes.data) ? shiftRes.data : (Array.isArray(shiftRes) ? shiftRes : []);
   } catch {
     ElMessage.error('加载基础数据失败');
   }

--- a/server/src/modules/mixing/dto/mixing.dto.ts
+++ b/server/src/modules/mixing/dto/mixing.dto.ts
@@ -53,6 +53,7 @@ export class ListMixingExecutionsDto {
   @IsOptional() @IsString() recipeId?: string;
   @IsOptional() @IsString() areaId?: string;
   @IsOptional() @IsString() status?: string;
+  @IsOptional() @IsString() shiftTypeId?: string;
   @IsOptional() @IsDateString() dateFrom?: string;
   @IsOptional() @IsDateString() dateTo?: string;
 }
@@ -69,6 +70,11 @@ export class CreateMixingExecutionDto {
   @IsString()
   @IsNotEmpty()
   areaId!: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  shiftTypeId?: string;
 
   @IsDateString()
   workDate!: string;

--- a/server/src/modules/mixing/mixing.service.spec.ts
+++ b/server/src/modules/mixing/mixing.service.spec.ts
@@ -15,6 +15,7 @@ describe('MixingService', () => {
         update: jest.fn(),
         updateMany: jest.fn(),
       },
+      shiftType: { findFirst: jest.fn() },
       recipe: { findFirst: jest.fn() },
       recipeLine: { findMany: jest.fn() },
       mixingExecution: { create: jest.fn(), findUnique: jest.fn(), count: jest.fn() },
@@ -99,6 +100,65 @@ describe('MixingService', () => {
         where: { id: 'stock-1', quantity: { gte: 50 } },
         data: { quantity: { decrement: 50 } },
       });
+    });
+
+    it('validates and persists shiftTypeId when provided', async () => {
+      prisma.$transaction.mockImplementation((cb: any) => cb(prisma));
+      prisma.recipe.findFirst.mockResolvedValue({ id: 'recipe-1', product_id: 'product-1', status: 'active' });
+      prisma.recipeLine.findMany.mockResolvedValue([
+        { id: 'line-flour', material_id: 'mat-flour', qty_per_batch: 50 },
+      ]);
+      prisma.shiftType.findFirst.mockResolvedValue({ id: 'shift-day', active: true, name: '白班' });
+      prisma.mixingExecution.count.mockResolvedValue(0);
+      prisma.mixingExecution.create.mockResolvedValue({ id: 'mix-1' });
+      prisma.stagingAreaStock.findFirst.mockResolvedValue({
+        id: 'stock-1',
+        batchId: 'mb-old',
+        quantity: 80,
+        batch: { materialId: 'mat-flour' },
+      });
+      prisma.stagingAreaStock.updateMany.mockResolvedValue({ count: 1 });
+      prisma.mixingExecution.findUnique.mockResolvedValue({ id: 'mix-1', shift_type_id: 'shift-day', lines: [] });
+
+      await service.createExecution({
+        recipeId: 'recipe-1',
+        productId: 'product-1',
+        areaId: 'area-small',
+        shiftTypeId: 'shift-day',
+        workDate: '2026-05-02',
+        actualWeight: 50,
+        lines: [{ recipeLineId: 'line-flour', materialBatchId: 'mb-old', actualQuantity: 50, manualOverride: false }],
+      });
+
+      expect(prisma.shiftType.findFirst).toHaveBeenCalledWith({
+        where: { id: 'shift-day', active: true },
+        select: { id: true },
+      });
+      expect(prisma.mixingExecution.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          shift_type_id: 'shift-day',
+        }),
+      });
+    });
+
+    it('rejects invalid shiftTypeId before decrementing staging stock', async () => {
+      prisma.$transaction.mockImplementation((cb: any) => cb(prisma));
+      prisma.recipe.findFirst.mockResolvedValue({ id: 'recipe-1', product_id: 'product-1', status: 'active' });
+      prisma.shiftType.findFirst.mockResolvedValue(null);
+
+      await expect(service.createExecution({
+        recipeId: 'recipe-1',
+        productId: 'product-1',
+        areaId: 'area-small',
+        shiftTypeId: 'missing-shift',
+        workDate: '2026-05-02',
+        actualWeight: 50,
+        lines: [{ recipeLineId: 'line-flour', materialBatchId: 'mb-old', actualQuantity: 50, manualOverride: false }],
+      })).rejects.toThrow(BadRequestException);
+
+      expect(prisma.recipeLine.findMany).not.toHaveBeenCalled();
+      expect(prisma.stagingAreaStock.updateMany).not.toHaveBeenCalled();
+      expect(prisma.mixingExecution.create).not.toHaveBeenCalled();
     });
 
     it('rejects when the conditional decrement matches zero rows (concurrent overdraw)', async () => {

--- a/server/src/modules/mixing/mixing.service.ts
+++ b/server/src/modules/mixing/mixing.service.ts
@@ -18,6 +18,7 @@ export class MixingService {
         ...(dto.recipeId && { recipeId: dto.recipeId }),
         ...(dto.areaId && { area_id: dto.areaId }),
         ...(dto.status && { status: dto.status as any }),
+        ...(dto.shiftTypeId && { shift_type_id: dto.shiftTypeId }),
         ...(dto.dateFrom || dto.dateTo
           ? {
               work_date: {
@@ -27,7 +28,11 @@ export class MixingService {
             }
           : {}),
       },
-      include: { area: true, lines: { include: { material: true, materialBatch: true } } },
+      include: {
+        area: true,
+        shift_type: true,
+        lines: { include: { material: true, materialBatch: true } },
+      },
       orderBy: { work_date: 'desc' },
       take: 100,
     });
@@ -112,6 +117,16 @@ export class MixingService {
           throw new BadRequestException('配方与产品不匹配或配方未启用');
         }
 
+        if (dto.shiftTypeId) {
+          const shiftType = await tx.shiftType.findFirst({
+            where: { id: dto.shiftTypeId, active: true },
+            select: { id: true },
+          });
+          if (!shiftType) {
+            throw new BadRequestException('班次类型不存在或已停用');
+          }
+        }
+
         const recipeLines = await tx.recipeLine.findMany({
           where: { recipe_id: dto.recipeId },
         });
@@ -123,6 +138,7 @@ export class MixingService {
             recipeId: dto.recipeId,
             productId: dto.productId,
             area_id: dto.areaId,
+            shift_type_id: dto.shiftTypeId,
             work_date: new Date(dto.workDate),
             actual_weight: dto.actualWeight,
             status: 'confirmed',
@@ -175,7 +191,7 @@ export class MixingService {
 
         return tx.mixingExecution.findUnique({
           where: { id: execution.id },
-          include: { lines: true },
+          include: { shift_type: true, lines: true },
         });
       });
     } catch (error) {

--- a/server/src/prisma/migrations/20260502110000_add_mixing_execution_shift_type_fk/migration.sql
+++ b/server/src/prisma/migrations/20260502110000_add_mixing_execution_shift_type_fk/migration.sql
@@ -1,0 +1,22 @@
+-- Link MixingExecution.shift_type_id to ShiftType without guessing historical values.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "mixing_executions" me
+    LEFT JOIN "shift_types" st ON st."id" = me."shift_type_id"
+    WHERE me."shift_type_id" IS NOT NULL
+      AND st."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add MixingExecution.shift_type_id FK: orphan shift_type_id rows exist';
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "mixing_executions_shift_type_id_idx"
+  ON "mixing_executions"("shift_type_id");
+
+ALTER TABLE "mixing_executions"
+  ADD CONSTRAINT "mixing_executions_shift_type_id_fkey"
+  FOREIGN KEY ("shift_type_id") REFERENCES "shift_types"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1252,6 +1252,7 @@ model MixingExecution {
   recipe         Recipe                @relation(fields: [recipeId], references: [id])
   product        Product               @relation(fields: [productId], references: [id])
   area           WorkshopArea          @relation(fields: [area_id], references: [id])
+  shift_type     ShiftType?            @relation(fields: [shift_type_id], references: [id], onDelete: SetNull)
   lines          MixingExecutionLine[]
   aggregations   BatchMixingAggregation[]
   createdAt      DateTime              @default(now())
@@ -1259,6 +1260,7 @@ model MixingExecution {
 
   @@index([work_date, area_id])
   @@index([recipeId])
+  @@index([shift_type_id])
   @@map("mixing_executions")
 }
 
@@ -2864,7 +2866,8 @@ model ShiftType {
   schedules   TeamShiftSchedule[]
   batches        ProductionBatch[]
   records        StagingAreaStocktake[]
-  shiftInstances ShiftInstance[]
+  shiftInstances  ShiftInstance[]
+  mixingExecutions MixingExecution[]
   created_at  DateTime             @default(now())
   updated_at  DateTime             @updatedAt
 


### PR DESCRIPTION
## Summary
- Added Prisma FK relation from `MixingExecution.shift_type_id` to `ShiftType` with `onDelete: SetNull`
- Added guarded migration SQL with orphan-row preflight check before adding the FK constraint
- Extended `CreateMixingExecutionDto` and `ListMixingExecutionsDto` with optional `shiftTypeId`
- Service validates shift type exists and is active before decrementing staging stock, and persists `shift_type_id` on create
- Frontend mixing workbench now loads and displays a clearable 班次类型 selector, submitting the value when selected

## Verification
- Prisma schema: PASS (`The schema at src/prisma/schema.prisma is valid`)
- Jest (mixing.service.spec.ts): 9/9 PASS including 2 new shift-type tests
- Client build: PASS
- GAP-204 E2E 未配置，已用 Prisma validate + mixing service Jest + client build 作为替代验证

## Notes
- Only used `superpowers:executing-plans` for this implementation
- Migration includes a DO $$ block that raises EXCEPTION if orphan shift_type_id rows exist, preventing silent data corruption