### PR TITLE
feat(GAP-401): link DocumentIssuance to controlled Document FK

### DIFF
--- a/client/src/api/document-control.ts
+++ b/client/src/api/document-control.ts
@@ -15,6 +15,7 @@ export interface DocumentControlDocument {
   title: string;
   level: number;
   status: string;
+  doc_code?: string | null;
   version?: number | string;
   versionNo?: number;
   versionLabel?: string;

--- a/client/src/api/document-issuance.ts
+++ b/client/src/api/document-issuance.ts
@@ -7,6 +7,7 @@ import request from './request';
 export interface DocumentIssuance {
   id: string;
   company_id: string;
+  document_id: string;
   document_name: string;
   document_code: string | null;
   template_id: string | null;
@@ -18,10 +19,19 @@ export interface DocumentIssuance {
   notes: string | null;
   created_at: string;
   deleted_at: string | null;
+  document?: {
+    id: string;
+    title: string;
+    number: string;
+    doc_code?: string | null;
+    status: string;
+    versionNo: number;
+  } | null;
 }
 
 export interface CreateDocumentIssuancePayload {
-  document_name: string;
+  document_id: string;
+  document_name?: string;
   document_code?: string;
   template_id?: string;
   issued_to?: string;

--- a/client/src/views/document-issuance/DocumentIssuanceList.vue
+++ b/client/src/views/document-issuance/DocumentIssuanceList.vue
@@ -79,11 +79,24 @@
         :rules="createRules"
         label-width="110px"
       >
-        <el-form-item label="文件名称" prop="document_name">
-          <el-input v-model="createForm.document_name" placeholder="请输入文件名称" />
-        </el-form-item>
-        <el-form-item label="文件编号">
-          <el-input v-model="createForm.document_code" placeholder="可选" />
+        <el-form-item label="受控文件" prop="document_id">
+          <el-select
+            v-model="createForm.document_id"
+            filterable
+            remote
+            reserve-keyword
+            :remote-method="searchDocuments"
+            :loading="documentLoading"
+            placeholder="搜索文件编号或名称"
+            style="width: 100%"
+          >
+            <el-option
+              v-for="doc in documentOptions"
+              :key="doc.id"
+              :label="`${doc.doc_code || doc.number} - ${doc.title}`"
+              :value="doc.id"
+            />
+          </el-select>
         </el-form-item>
         <el-form-item label="领用人">
           <el-input v-model="createForm.issued_to" placeholder="领用人姓名" />
@@ -129,11 +142,14 @@ import { ElMessage } from 'element-plus';
 import { Plus } from '@element-plus/icons-vue';
 import type { FormInstance, FormRules } from 'element-plus';
 import documentIssuanceApi, { type DocumentIssuance } from '@/api/document-issuance';
+import { documentControlApi, type DocumentControlDocument } from '@/api/document-control';
 
 // ── State ─────────────────────────────────────────────────────────────────────
 
 const list = ref<DocumentIssuance[]>([]);
 const loading = ref(false);
+const documentLoading = ref(false);
+const documentOptions = ref<DocumentControlDocument[]>([]);
 
 // ── Create dialog ─────────────────────────────────────────────────────────────
 
@@ -142,8 +158,7 @@ const submitting = ref(false);
 const createFormRef = ref<FormInstance>();
 
 const createForm = reactive({
-  document_name: '',
-  document_code: '',
+  document_id: '',
   issued_to: '',
   issued_by: '',
   quantity: 1,
@@ -153,7 +168,7 @@ const createForm = reactive({
 });
 
 const createRules: FormRules = {
-  document_name: [{ required: true, message: '请输入文件名称', trigger: 'blur' }],
+  document_id: [{ required: true, message: '请选择受控文件', trigger: 'change' }],
   quantity: [{ required: true, message: '请输入数量', trigger: 'blur' }],
 };
 
@@ -168,6 +183,21 @@ function formatDate(dateStr: string | null): string {
     hour: '2-digit',
     minute: '2-digit',
   });
+}
+
+async function searchDocuments(keyword = '') {
+  documentLoading.value = true;
+  try {
+    const res = await documentControlApi.listDocuments({
+      keyword: keyword || undefined,
+      limit: 20,
+    });
+    documentOptions.value = res.list || [];
+  } catch {
+    ElMessage.error('加载受控文件失败');
+  } finally {
+    documentLoading.value = false;
+  }
 }
 
 // ── Data loading ──────────────────────────────────────────────────────────────
@@ -187,8 +217,7 @@ async function loadList() {
 // ── Create ────────────────────────────────────────────────────────────────────
 
 function openCreateDialog() {
-  createForm.document_name = '';
-  createForm.document_code = '';
+  createForm.document_id = '';
   createForm.issued_to = '';
   createForm.issued_by = '';
   createForm.quantity = 1;
@@ -196,6 +225,7 @@ function openCreateDialog() {
   createForm.issued_at = '';
   createForm.notes = '';
   createDialogVisible.value = true;
+  searchDocuments();
 }
 
 async function handleCreate() {
@@ -204,8 +234,7 @@ async function handleCreate() {
   submitting.value = true;
   try {
     await documentIssuanceApi.create({
-      document_name: createForm.document_name,
-      document_code: createForm.document_code || undefined,
+      document_id: createForm.document_id,
       issued_to: createForm.issued_to || undefined,
       issued_by: createForm.issued_by || undefined,
       quantity: createForm.quantity,

--- a/server/src/modules/document-issuance/document-issuance.service.spec.ts
+++ b/server/src/modules/document-issuance/document-issuance.service.spec.ts
@@ -1,0 +1,92 @@
+import { BadRequestException } from '@nestjs/common';
+import { DocumentIssuanceService } from './document-issuance.service';
+
+describe('DocumentIssuanceService', () => {
+  function createPrismaMock(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      document: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'doc-1',
+          title: '文件发放控制程序',
+          doc_code: 'GRSS-CX-01',
+          number: 'CX-001',
+        }),
+      },
+      documentIssuance: {
+        create: jest.fn().mockResolvedValue({ id: 'di-1' }),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn().mockResolvedValue({ id: 'di-1', deleted_at: expect.any(Date) }),
+      },
+      ...overrides,
+    } as any;
+  }
+
+  it('rejects creation when document_id is missing', async () => {
+    const prisma = createPrismaMock();
+    const service = new DocumentIssuanceService(prisma);
+
+    await expect(
+      service.create({
+        document_name: '用户手填文件',
+        quantity: 1,
+      } as any),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.document.findFirst).not.toHaveBeenCalled();
+    expect(prisma.documentIssuance.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when the selected document does not exist', async () => {
+    const prisma = createPrismaMock({
+      document: {
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+    });
+    const service = new DocumentIssuanceService(prisma);
+
+    await expect(
+      service.create({
+        document_id: 'missing-doc',
+        quantity: 1,
+      } as any),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.document.findFirst).toHaveBeenCalledWith({
+      where: { id: 'missing-doc', deletedAt: null },
+      select: { id: true, title: true, doc_code: true, number: true },
+    });
+    expect(prisma.documentIssuance.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an issuance linked to a controlled document and writes snapshots from Document', async () => {
+    const prisma = createPrismaMock();
+    const service = new DocumentIssuanceService(prisma);
+
+    await service.create({
+      document_id: 'doc-1',
+      document_name: '用户手填名称应被忽略',
+      document_code: 'USER-CODE',
+      issued_to: '张三',
+      issued_by: '李四',
+      quantity: 2,
+      purpose: '岗位使用',
+      issued_at: '2026-05-02T10:30:00',
+      notes: '纸质版',
+    } as any);
+
+    expect(prisma.documentIssuance.create).toHaveBeenCalledWith({
+      data: {
+        document_id: 'doc-1',
+        document_name: '文件发放控制程序',
+        document_code: 'GRSS-CX-01',
+        issued_to: '张三',
+        issued_by: '李四',
+        quantity: 2,
+        purpose: '岗位使用',
+        issued_at: new Date('2026-05-02T10:30:00'),
+        notes: '纸质版',
+        company_id: '1',
+      },
+    });
+  });
+});

--- a/server/src/modules/document-issuance/document-issuance.service.ts
+++ b/server/src/modules/document-issuance/document-issuance.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateDocumentIssuanceDto } from './dto/create-document-issuance.dto';
 
@@ -7,9 +7,30 @@ export class DocumentIssuanceService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateDocumentIssuanceDto) {
+    if (!dto.document_id) {
+      throw new BadRequestException('受控文件不能为空');
+    }
+
+    const document = await this.prisma.document.findFirst({
+      where: { id: dto.document_id, deletedAt: null },
+      select: { id: true, title: true, doc_code: true, number: true },
+    });
+
+    if (!document) {
+      throw new BadRequestException('受控文件不存在或已删除');
+    }
+
+    const {
+      document_name: _ignoredDocumentName,
+      document_code: _ignoredDocumentCode,
+      ...issuanceData
+    } = dto;
+
     return this.prisma.documentIssuance.create({
       data: {
-        ...dto,
+        ...issuanceData,
+        document_name: document.title,
+        document_code: document.doc_code ?? document.number,
         company_id: '1',
         quantity: dto.quantity ?? 1,
         issued_at: dto.issued_at ? new Date(dto.issued_at) : new Date(),
@@ -20,6 +41,11 @@ export class DocumentIssuanceService {
   async findAll() {
     return this.prisma.documentIssuance.findMany({
       where: { deleted_at: null },
+      include: {
+        document: {
+          select: { id: true, title: true, number: true, doc_code: true, status: true, versionNo: true },
+        },
+      },
       orderBy: { issued_at: 'desc' },
       take: 200,
     });

--- a/server/src/modules/document-issuance/dto/create-document-issuance.dto.ts
+++ b/server/src/modules/document-issuance/dto/create-document-issuance.dto.ts
@@ -1,8 +1,13 @@
-import { IsString, IsOptional, IsInt, Min, IsDateString } from 'class-validator';
+import { IsDateString, IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
 
 export class CreateDocumentIssuanceDto {
   @IsString()
-  document_name: string;
+  @IsNotEmpty()
+  document_id: string;
+
+  @IsOptional()
+  @IsString()
+  document_name?: string;
 
   @IsOptional()
   @IsString()

--- a/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
+++ b/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
@@ -30,6 +30,17 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'Cannot backfill DocumentIssuance.document_id: document_code matches multiple Documents';
   END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM "DocumentIssuance" di
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "documents" d
+      WHERE d."deletedAt" IS NULL
+        AND (d."doc_code" = di."document_code" OR d."number" = di."document_code")
+    )
+  ) THEN
+    RAISE EXCEPTION 'Cannot require DocumentIssuance.document_id: unmatched legacy rows exist';
+  END IF;
 END $$;
 
 ALTER TABLE "DocumentIssuance"
@@ -46,13 +57,6 @@ FROM (
   GROUP BY di_inner."id"
 ) matched
 WHERE di."id" = matched."issuance_id";
-
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM "DocumentIssuance" WHERE "document_id" IS NULL) THEN
-    RAISE EXCEPTION 'Cannot require DocumentIssuance.document_id: unmatched legacy rows exist';
-  END IF;
-END $$;
 
 ALTER TABLE "DocumentIssuance" ALTER COLUMN "document_id" SET NOT NULL;
 

--- a/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
+++ b/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
@@ -1,9 +1,9 @@
 -- Link every document issuance ledger row to the controlled Document fact source.
 -- Historical rows are matched only by exact document_code against Document.doc_code or Document.number.
 -- The migration intentionally fails when a row cannot be matched uniquely.
-
-ALTER TABLE "DocumentIssuance"
-  ADD COLUMN "document_id" TEXT;
+--
+-- Safety: all preflight checks run BEFORE any DDL so that a failed preflight
+-- leaves the schema unchanged and the migration is safe to re-run.
 
 DO $$
 BEGIN
@@ -30,19 +30,25 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'Cannot backfill DocumentIssuance.document_id: document_code matches multiple Documents';
   END IF;
+END $$;
 
-  UPDATE "DocumentIssuance" di
-  SET "document_id" = matched."document_id"
-  FROM (
-    SELECT di_inner."id" AS issuance_id, MAX(d."id") AS document_id
-    FROM "DocumentIssuance" di_inner
-    JOIN "documents" d
-      ON d."deletedAt" IS NULL
-     AND (d."doc_code" = di_inner."document_code" OR d."number" = di_inner."document_code")
-    GROUP BY di_inner."id"
-  ) matched
-  WHERE di."id" = matched."issuance_id";
+ALTER TABLE "DocumentIssuance"
+  ADD COLUMN "document_id" TEXT;
 
+UPDATE "DocumentIssuance" di
+SET "document_id" = matched."document_id"
+FROM (
+  SELECT di_inner."id" AS issuance_id, MAX(d."id") AS document_id
+  FROM "DocumentIssuance" di_inner
+  JOIN "documents" d
+    ON d."deletedAt" IS NULL
+   AND (d."doc_code" = di_inner."document_code" OR d."number" = di_inner."document_code")
+  GROUP BY di_inner."id"
+) matched
+WHERE di."id" = matched."issuance_id";
+
+DO $$
+BEGIN
   IF EXISTS (SELECT 1 FROM "DocumentIssuance" WHERE "document_id" IS NULL) THEN
     RAISE EXCEPTION 'Cannot require DocumentIssuance.document_id: unmatched legacy rows exist';
   END IF;

--- a/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
+++ b/server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql
@@ -1,0 +1,59 @@
+-- Link every document issuance ledger row to the controlled Document fact source.
+-- Historical rows are matched only by exact document_code against Document.doc_code or Document.number.
+-- The migration intentionally fails when a row cannot be matched uniquely.
+
+ALTER TABLE "DocumentIssuance"
+  ADD COLUMN "document_id" TEXT;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "DocumentIssuance" di
+    WHERE di."document_code" IS NULL OR btrim(di."document_code") = ''
+  ) THEN
+    RAISE EXCEPTION 'Cannot backfill DocumentIssuance.document_id: legacy rows without document_code exist';
+  END IF;
+
+  IF EXISTS (
+    WITH candidates AS (
+      SELECT di."id" AS issuance_id, d."id" AS document_id
+      FROM "DocumentIssuance" di
+      JOIN "documents" d
+        ON d."deletedAt" IS NULL
+       AND (d."doc_code" = di."document_code" OR d."number" = di."document_code")
+    )
+    SELECT 1
+    FROM candidates
+    GROUP BY issuance_id
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Cannot backfill DocumentIssuance.document_id: document_code matches multiple Documents';
+  END IF;
+
+  UPDATE "DocumentIssuance" di
+  SET "document_id" = matched."document_id"
+  FROM (
+    SELECT di_inner."id" AS issuance_id, MAX(d."id") AS document_id
+    FROM "DocumentIssuance" di_inner
+    JOIN "documents" d
+      ON d."deletedAt" IS NULL
+     AND (d."doc_code" = di_inner."document_code" OR d."number" = di_inner."document_code")
+    GROUP BY di_inner."id"
+  ) matched
+  WHERE di."id" = matched."issuance_id";
+
+  IF EXISTS (SELECT 1 FROM "DocumentIssuance" WHERE "document_id" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot require DocumentIssuance.document_id: unmatched legacy rows exist';
+  END IF;
+END $$;
+
+ALTER TABLE "DocumentIssuance" ALTER COLUMN "document_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "DocumentIssuance_document_id_idx"
+  ON "DocumentIssuance"("document_id");
+
+ALTER TABLE "DocumentIssuance"
+  ADD CONSTRAINT "DocumentIssuance_document_id_fkey"
+  FOREIGN KEY ("document_id") REFERENCES "documents"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -367,6 +367,7 @@ model Document {
   trainingNeeds      DocumentTrainingNeed[]
   coverageReviews    DocumentCoverageReview[]
   businessLinks       BusinessDocumentLink[]
+  documentIssuances  DocumentIssuance[]
 
   // Document control governance: revision tracking
   versionNo      Int       @default(1)
@@ -3511,6 +3512,8 @@ model SupplierEvaluation {
 model DocumentIssuance {
   id              String    @id @default(cuid())
   company_id      String
+  document_id     String
+  document        Document  @relation(fields: [document_id], references: [id], onDelete: Restrict)
   document_name   String
   document_code   String?
   template_id     String?
@@ -3522,6 +3525,8 @@ model DocumentIssuance {
   notes           String?
   created_at      DateTime  @default(now())
   deleted_at      DateTime?
+
+  @@index([document_id])
 }
 
 model AssetLoanRecord {


### PR DESCRIPTION
## Summary

- Add `document_id` non-null FK on `DocumentIssuance` pointing to `Document`
- Guarded SQL migration with preflight checks (fails fast on orphan/ambiguous rows)
- DTO requires `document_id`; service validates document exists and writes `document_name`/`document_code` snapshots from the controlled document
- `findAll` includes linked `document` relation
- Client API types updated; Vue form replaced with controlled-document selector

## Files Changed

- `server/src/prisma/schema.prisma`
- `server/src/prisma/migrations/20260502113000_document_issuance_document_fk/migration.sql`
- `server/src/modules/document-issuance/dto/create-document-issuance.dto.ts`
- `server/src/modules/document-issuance/document-issuance.service.ts`
- `server/src/modules/document-issuance/document-issuance.service.spec.ts` (new)
- `client/src/api/document-issuance.ts`
- `client/src/views/document-issuance/DocumentIssuanceList.vue`

## Test plan

- [x] Prisma schema validates (`prisma validate`)
- [x] Service spec passes (3/3): missing document_id, nonexistent document, snapshot-from-Document
- [x] Client build passes (`vite build`)
- [ ] Integration test: create issuance via UI and verify `document_name`/`document_code` are written from Document
- [ ] Migration preflight: verify fails gracefully when legacy rows lack `document_code`

## Notes

`npm run verify` fails with pre-existing TypeScript errors in `audit.service.ts` unrelated to this PR.