### PR TITLE
feat(GAP-410): link verified audit findings to CAPA

### DIFF
--- a/server/src/modules/corrective-action/corrective-action.service.spec.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.spec.ts
@@ -46,7 +46,7 @@ describe('CorrectiveActionService', () => {
       select: { id: true },
     });
     expect(prisma.correctiveAction.count).not.toHaveBeenCalled();
-    expect(numberSequence.generateCorrectiveActionNo).toHaveBeenCalledWith('2');
+    expect(numberSequence.generateCorrectiveActionNo).toHaveBeenCalledWith('2', expect.any(Date), undefined);
     expect(prisma.correctiveAction.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/server/src/modules/corrective-action/corrective-action.service.ts
+++ b/server/src/modules/corrective-action/corrective-action.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CapaTriggerType, CreateCapaDto } from './dto/create-capa.dto';
 import { QualityNumberSequenceService } from '../quality-number-sequence/quality-number-sequence.service';
@@ -16,11 +17,21 @@ export class CorrectiveActionService {
     private readonly numberSequence: QualityNumberSequenceService,
   ) {}
 
-  async create(dto: CreateCapaDto, userId: string, companyId: string) {
-    await this.validateTriggerSource(dto, companyId);
+  async create(
+    dto: CreateCapaDto,
+    userId: string,
+    companyId: string,
+    tx?: Prisma.TransactionClient,
+  ) {
+    const client = tx ?? this.prisma;
+    await this.validateTriggerSource(dto, companyId, client);
 
-    const capa_no = await this.numberSequence.generateCorrectiveActionNo(companyId);
-    return this.prisma.correctiveAction.create({
+    const capa_no = await this.numberSequence.generateCorrectiveActionNo(
+      companyId,
+      new Date(),
+      tx,
+    );
+    return client.correctiveAction.create({
       data: { ...dto, company_id: companyId, capa_no },
     });
   }
@@ -44,7 +55,11 @@ export class CorrectiveActionService {
     });
   }
 
-  private async validateTriggerSource(dto: CreateCapaDto, companyId: string) {
+  private async validateTriggerSource(
+    dto: CreateCapaDto,
+    companyId: string,
+    client: PrismaService | Prisma.TransactionClient,
+  ) {
     if (dto.trigger_type === 'other') {
       return;
     }
@@ -54,7 +69,7 @@ export class CorrectiveActionService {
     }
 
     if (dto.trigger_type === 'non_conformance') {
-      const source = await this.prisma.nonConformance.findFirst({
+      const source = await client.nonConformance.findFirst({
         where: { id: dto.trigger_id, company_id: companyId },
         select: { id: true },
       });
@@ -65,7 +80,7 @@ export class CorrectiveActionService {
     }
 
     if (dto.trigger_type === 'customer_complaint') {
-      const source = await this.prisma.customerComplaint.findFirst({
+      const source = await client.customerComplaint.findFirst({
         where: { id: dto.trigger_id, company_id: companyId },
         select: { id: true },
       });
@@ -76,7 +91,7 @@ export class CorrectiveActionService {
     }
 
     if (dto.trigger_type === 'internal_audit') {
-      const source = await this.prisma.auditFinding.findUnique({
+      const source = await client.auditFinding.findUnique({
         where: { id: dto.trigger_id },
         select: { id: true },
       });

--- a/server/src/modules/internal-audit/verification/verification.controller.ts
+++ b/server/src/modules/internal-audit/verification/verification.controller.ts
@@ -26,6 +26,7 @@ interface AuthenticatedRequest extends ExpressRequest {
     userId: string;
     username: string;
     role: string;
+    companyId: string;
   };
 }
 
@@ -79,6 +80,7 @@ export class VerificationController {
       id,
       verifyDto,
       req.user.userId,
+      req.user.companyId,
     );
 
     await this.logSensitiveOperation(

--- a/server/src/modules/internal-audit/verification/verification.module.ts
+++ b/server/src/modules/internal-audit/verification/verification.module.ts
@@ -7,6 +7,7 @@ import { AuditModule } from '../../audit/audit.module';
 import { UserPermissionModule } from '../../user-permission/user-permission.module';
 import { RedisModule } from '../../redis/redis.module';
 import { UnifiedApprovalModule } from '../../unified-approval/unified-approval.module';
+import { CorrectiveActionModule } from '../../corrective-action/corrective-action.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UnifiedApprovalModule } from '../../unified-approval/unified-approval.m
     UserPermissionModule,
     RedisModule,
     UnifiedApprovalModule,
+    CorrectiveActionModule,
   ],
   controllers: [VerificationController],
   providers: [VerificationService],

--- a/server/src/modules/internal-audit/verification/verification.service.spec.ts
+++ b/server/src/modules/internal-audit/verification/verification.service.spec.ts
@@ -55,6 +55,7 @@ describe('VerificationService', () => {
         findMany: jest.fn(),
         findUnique: jest.fn(),
         update: jest.fn(),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
       todoTask: {
         updateMany: jest.fn(),
@@ -123,9 +124,7 @@ describe('VerificationService', () => {
 
     it('should verify rectification successfully', async () => {
       const compliantFinding = { ...mockFinding, auditResult: '符合' };
-      const updatedFinding = { ...compliantFinding, status: 'verified' };
       mockPrismaService.auditFinding.findUnique.mockResolvedValue(compliantFinding);
-      mockPrismaService.auditFinding.update.mockResolvedValue(updatedFinding);
       mockPrismaService.todoTask.updateMany.mockResolvedValue({ count: 1 });
 
       const result = await service.verifyRectification(
@@ -135,9 +134,14 @@ describe('VerificationService', () => {
         'company-1',
       );
 
-      expect(result).toEqual(updatedFinding);
-      expect(mockPrismaService.auditFinding.update).toHaveBeenCalledWith({
-        where: { id: 'finding-1' },
+      expect(result).toMatchObject({
+        id: 'finding-1',
+        status: 'verified',
+        verifiedBy: 'auditor-1',
+        verifiedAt: expect.any(Date),
+      });
+      expect(mockPrismaService.auditFinding.updateMany).toHaveBeenCalledWith({
+        where: { id: 'finding-1', status: 'pending_verification' },
         data: {
           status: 'verified',
           verifiedBy: 'auditor-1',
@@ -209,7 +213,6 @@ describe('VerificationService', () => {
         document: { id: 'doc-1', title: '培训记录控制程序', number: 'DOC-001' },
         plan: { auditorId: 'auditor-1' },
       });
-      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
       mockPrismaService.correctiveAction.findFirst.mockResolvedValue(null);
       correctiveActionService.create.mockResolvedValue({ id: 'capa-1' });
 
@@ -242,7 +245,7 @@ describe('VerificationService', () => {
       );
     });
 
-    it('does not create duplicate CAPA when one already exists for the finding', async () => {
+    it('does not create duplicate CAPA when one already exists for the finding (serial safety net)', async () => {
       mockPrismaService.auditFinding.findUnique.mockResolvedValue({
         ...mockFinding,
         auditResult: '不符合',
@@ -250,7 +253,6 @@ describe('VerificationService', () => {
         document: { id: 'doc-1', title: '内审文件', number: 'DOC-002' },
         plan: { auditorId: 'auditor-1' },
       });
-      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
       mockPrismaService.correctiveAction.findFirst.mockResolvedValue({ id: 'existing-capa' });
 
       await service.verifyRectification(
@@ -263,6 +265,27 @@ describe('VerificationService', () => {
       expect(correctiveActionService.create).not.toHaveBeenCalled();
     });
 
+    it('concurrent second call does not create duplicate CAPA when updateMany returns count=0', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '不符合',
+        description: '并发第二个请求不得创建第二条 CAPA',
+        document: { id: 'doc-1', title: '内审文件', number: 'DOC-002' },
+        plan: { auditorId: 'auditor-1' },
+      });
+      // Simulate the concurrent case: the atomic updateMany wins for the first caller
+      // but returns count=0 for the second caller (finding status already changed)
+      mockPrismaService.auditFinding.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrismaService.correctiveAction.findFirst).not.toHaveBeenCalled();
+      expect(correctiveActionService.create).not.toHaveBeenCalled();
+      expect(mockPrismaService.todoTask.updateMany).not.toHaveBeenCalled();
+    });
+
     it('does not create CAPA for compliant audit finding', async () => {
       mockPrismaService.auditFinding.findUnique.mockResolvedValue({
         ...mockFinding,
@@ -270,8 +293,6 @@ describe('VerificationService', () => {
         document: { id: 'doc-1', title: '内审文件', number: 'DOC-003' },
         plan: { auditorId: 'auditor-1' },
       });
-      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
-
       await service.verifyRectification(
         'finding-1',
         verifyDto,
@@ -296,13 +317,14 @@ describe('VerificationService', () => {
         service.verifyRectification('finding-1', verifyDto, 'auditor-1', undefined as any),
       ).rejects.toThrow('Missing companyId for audit CAPA creation');
 
-      expect(mockPrismaService.auditFinding.update).not.toHaveBeenCalled();
+      // updateMany ran to atomically claim the finding, but the transaction rolls back
+      expect(mockPrismaService.auditFinding.updateMany).toHaveBeenCalled();
       expect(mockPrismaService.todoTask.updateMany).not.toHaveBeenCalled();
       expect(mockPrismaService.correctiveAction.findFirst).not.toHaveBeenCalled();
       expect(correctiveActionService.create).not.toHaveBeenCalled();
     });
 
-    it('does not mark finding verified or complete todo when CAPA creation fails', async () => {
+    it('does not complete todo when CAPA creation fails (transaction rolls back)', async () => {
       mockPrismaService.auditFinding.findUnique.mockResolvedValue({
         ...mockFinding,
         auditResult: '不符合',
@@ -317,11 +339,7 @@ describe('VerificationService', () => {
         service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
       ).rejects.toThrow('内审发现项不存在');
 
-      expect(mockPrismaService.auditFinding.update).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ status: 'verified' }),
-        }),
-      );
+      // todoTask.updateMany is never reached because CAPA creation throws first
       expect(mockPrismaService.todoTask.updateMany).not.toHaveBeenCalled();
     });
   });

--- a/server/src/modules/internal-audit/verification/verification.service.spec.ts
+++ b/server/src/modules/internal-audit/verification/verification.service.spec.ts
@@ -7,12 +7,14 @@ import {
 import { VerificationService } from './verification.service';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { OperationLogService } from '../../operation-log/operation-log.service';
+import { CorrectiveActionService } from '../../corrective-action/corrective-action.service';
 import { VerifyRectificationDto, RejectRectificationDto } from './dto';
 
 describe('VerificationService', () => {
   let service: VerificationService;
   let mockPrismaService: any;
   let mockOperationLogService: any;
+  let correctiveActionService: any;
 
   const mockAuditor = {
     userId: 'auditor-1',
@@ -43,10 +45,12 @@ describe('VerificationService', () => {
       title: 'Q1 2024 Internal Audit',
       auditorId: 'auditor-1',
     },
+    document: { id: 'doc-1', title: '内审文件', number: 'DOC-001' },
   };
 
   beforeEach(async () => {
     mockPrismaService = {
+      $transaction: jest.fn(async (callback) => callback(mockPrismaService)),
       auditFinding: {
         findMany: jest.fn(),
         findUnique: jest.fn(),
@@ -55,10 +59,17 @@ describe('VerificationService', () => {
       todoTask: {
         updateMany: jest.fn(),
       },
+      correctiveAction: {
+        findFirst: jest.fn(),
+      },
     };
 
     mockOperationLogService = {
       log: jest.fn(),
+    };
+
+    correctiveActionService = {
+      create: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -66,6 +77,7 @@ describe('VerificationService', () => {
         VerificationService,
         { provide: PrismaService, useValue: mockPrismaService },
         { provide: OperationLogService, useValue: mockOperationLogService },
+        { provide: CorrectiveActionService, useValue: correctiveActionService },
       ],
     }).compile();
 
@@ -110,8 +122,9 @@ describe('VerificationService', () => {
     };
 
     it('should verify rectification successfully', async () => {
-      const updatedFinding = { ...mockFinding, status: 'verified' };
-      mockPrismaService.auditFinding.findUnique.mockResolvedValue(mockFinding);
+      const compliantFinding = { ...mockFinding, auditResult: '符合' };
+      const updatedFinding = { ...compliantFinding, status: 'verified' };
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue(compliantFinding);
       mockPrismaService.auditFinding.update.mockResolvedValue(updatedFinding);
       mockPrismaService.todoTask.updateMany.mockResolvedValue({ count: 1 });
 
@@ -119,6 +132,7 @@ describe('VerificationService', () => {
         'finding-1',
         verifyDto,
         'auditor-1',
+        'company-1',
       );
 
       expect(result).toEqual(updatedFinding);
@@ -139,13 +153,15 @@ describe('VerificationService', () => {
           status: 'completed',
         },
       });
+      expect(mockPrismaService.correctiveAction.findFirst).not.toHaveBeenCalled();
+      expect(correctiveActionService.create).not.toHaveBeenCalled();
     });
 
     it('should throw NotFoundException if finding not found', async () => {
       mockPrismaService.auditFinding.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.verifyRectification('finding-1', verifyDto, 'auditor-1'),
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -156,7 +172,7 @@ describe('VerificationService', () => {
       });
 
       await expect(
-        service.verifyRectification('finding-1', verifyDto, 'auditor-1'),
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
       ).rejects.toThrow(ForbiddenException);
     });
 
@@ -167,7 +183,7 @@ describe('VerificationService', () => {
       });
 
       await expect(
-        service.verifyRectification('finding-1', verifyDto, 'auditor-1'),
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -178,8 +194,135 @@ describe('VerificationService', () => {
       });
 
       await expect(
-        service.verifyRectification('finding-1', verifyDto, 'auditor-1'),
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('creates CAPA for verified non-conforming audit finding', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '不符合',
+        issueType: '需要修改',
+        description: '受控文件培训记录缺少签字确认',
+        assigneeId: 'assignee-1',
+        dueDate: new Date('2026-05-31T00:00:00.000Z'),
+        document: { id: 'doc-1', title: '培训记录控制程序', number: 'DOC-001' },
+        plan: { auditorId: 'auditor-1' },
+      });
+      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
+      mockPrismaService.correctiveAction.findFirst.mockResolvedValue(null);
+      correctiveActionService.create.mockResolvedValue({ id: 'capa-1' });
+
+      await service.verifyRectification(
+        'finding-1',
+        verifyDto,
+        'auditor-1',
+        'company-1',
+      );
+
+      expect(mockPrismaService.correctiveAction.findFirst).toHaveBeenCalledWith({
+        where: {
+          company_id: 'company-1',
+          trigger_type: 'internal_audit',
+          trigger_id: 'finding-1',
+        },
+        select: { id: true },
+      });
+      expect(correctiveActionService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trigger_type: 'internal_audit',
+          trigger_id: 'finding-1',
+          description: expect.stringContaining('受控文件培训记录缺少签字确认'),
+          responsible_id: 'assignee-1',
+          due_date: '2026-05-31',
+        }),
+        'auditor-1',
+        'company-1',
+        mockPrismaService,
+      );
+    });
+
+    it('does not create duplicate CAPA when one already exists for the finding', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '不符合',
+        description: '内审发现项已有关联 CAPA',
+        document: { id: 'doc-1', title: '内审文件', number: 'DOC-002' },
+        plan: { auditorId: 'auditor-1' },
+      });
+      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
+      mockPrismaService.correctiveAction.findFirst.mockResolvedValue({ id: 'existing-capa' });
+
+      await service.verifyRectification(
+        'finding-1',
+        verifyDto,
+        'auditor-1',
+        'company-1',
+      );
+
+      expect(correctiveActionService.create).not.toHaveBeenCalled();
+    });
+
+    it('does not create CAPA for compliant audit finding', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '符合',
+        document: { id: 'doc-1', title: '内审文件', number: 'DOC-003' },
+        plan: { auditorId: 'auditor-1' },
+      });
+      mockPrismaService.auditFinding.update.mockResolvedValue({ ...mockFinding, status: 'verified' });
+
+      await service.verifyRectification(
+        'finding-1',
+        verifyDto,
+        'auditor-1',
+        'company-1',
+      );
+
+      expect(mockPrismaService.correctiveAction.findFirst).not.toHaveBeenCalled();
+      expect(correctiveActionService.create).not.toHaveBeenCalled();
+    });
+
+    it('requires companyId before creating audit-triggered CAPA', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '不符合',
+        description: '缺少内审整改证据复核记录',
+        document: { id: 'doc-1', title: '内审文件', number: 'DOC-004' },
+        plan: { auditorId: 'auditor-1' },
+      });
+
+      await expect(
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', undefined as any),
+      ).rejects.toThrow('Missing companyId for audit CAPA creation');
+
+      expect(mockPrismaService.auditFinding.update).not.toHaveBeenCalled();
+      expect(mockPrismaService.todoTask.updateMany).not.toHaveBeenCalled();
+      expect(mockPrismaService.correctiveAction.findFirst).not.toHaveBeenCalled();
+      expect(correctiveActionService.create).not.toHaveBeenCalled();
+    });
+
+    it('does not mark finding verified or complete todo when CAPA creation fails', async () => {
+      mockPrismaService.auditFinding.findUnique.mockResolvedValue({
+        ...mockFinding,
+        auditResult: '不符合',
+        description: 'CAPA 创建失败时不能完成内审验证',
+        document: { id: 'doc-1', title: '内审文件', number: 'DOC-005' },
+        plan: { auditorId: 'auditor-1' },
+      });
+      mockPrismaService.correctiveAction.findFirst.mockResolvedValue(null);
+      correctiveActionService.create.mockRejectedValue(new BadRequestException('内审发现项不存在'));
+
+      await expect(
+        service.verifyRectification('finding-1', verifyDto, 'auditor-1', 'company-1'),
+      ).rejects.toThrow('内审发现项不存在');
+
+      expect(mockPrismaService.auditFinding.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'verified' }),
+        }),
+      );
+      expect(mockPrismaService.todoTask.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/server/src/modules/internal-audit/verification/verification.service.ts
+++ b/server/src/modules/internal-audit/verification/verification.service.ts
@@ -5,9 +5,11 @@ import {
   BadRequestException,
   Optional,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../../prisma/prisma.service';
 import { OperationLogService } from '../../operation-log/operation-log.service';
 import { ApprovalEngineService } from '../../unified-approval/approval-engine.service';
+import { CorrectiveActionService } from '../../corrective-action/corrective-action.service';
 import { VerifyRectificationDto, RejectRectificationDto } from './dto';
 
 @Injectable()
@@ -15,6 +17,7 @@ export class VerificationService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly operationLogService: OperationLogService,
+    private readonly correctiveActionService: CorrectiveActionService,
     @Optional() private readonly approvalEngine?: ApprovalEngineService,
   ) {}
 
@@ -36,12 +39,14 @@ export class VerificationService {
     findingId: string,
     dto: VerifyRectificationDto,
     userId: string,
+    companyId: string,
   ) {
     // 1. Validate finding exists
     const finding = await this.prisma.auditFinding.findUnique({
       where: { id: findingId },
       include: {
         plan: { select: { auditorId: true } },
+        document: { select: { id: true, title: true, number: true } },
       },
     });
 
@@ -83,27 +88,32 @@ export class VerificationService {
       }
     } catch { /* no definition = skip */ }
 
-    const updatedFinding = await this.prisma.auditFinding.update({
-      where: { id: findingId },
-      data: {
-        status: 'verified',
-        verifiedBy: userId,
-        verifiedAt: new Date(),
-      },
+    const updatedFinding = await this.prisma.$transaction(async (tx) => {
+      await this.createCapaForVerifiedFinding(finding, userId, companyId, tx);
+
+      const verifiedFinding = await tx.auditFinding.update({
+        where: { id: findingId },
+        data: {
+          status: 'verified',
+          verifiedBy: userId,
+          verifiedAt: new Date(),
+        },
+      });
+
+      await tx.todoTask.updateMany({
+        where: {
+          type: 'audit_rectification',
+          relatedId: findingId,
+        },
+        data: {
+          status: 'completed',
+        },
+      });
+
+      return verifiedFinding;
     });
 
-    // 6. Update TodoTask status (audit_rectification → completed)
-    await this.prisma.todoTask.updateMany({
-      where: {
-        type: 'audit_rectification',
-        relatedId: findingId,
-      },
-      data: {
-        status: 'completed',
-      },
-    });
-
-    // 7. Log operation
+    // 6. Log operation
     await this.operationLogService.log({
       userId,
       action: 'verify_rectification',
@@ -116,6 +126,59 @@ export class VerificationService {
     });
 
     return updatedFinding;
+  }
+
+  private async createCapaForVerifiedFinding(
+    finding: any,
+    userId: string,
+    companyId: string,
+    tx: Prisma.TransactionClient,
+  ) {
+    if (finding.auditResult !== '不符合') {
+      return;
+    }
+
+    if (!companyId) {
+      throw new BadRequestException('Missing companyId for audit CAPA creation');
+    }
+
+    const existing = await tx.correctiveAction.findFirst({
+      where: {
+        company_id: companyId,
+        trigger_type: 'internal_audit',
+        trigger_id: finding.id,
+      },
+      select: { id: true },
+    });
+
+    if (existing) {
+      return;
+    }
+
+    const documentLabel = [finding.document?.number, finding.document?.title]
+      .filter(Boolean)
+      .join(' ');
+    const descriptionParts = [
+      '内审不符合项CAPA',
+      finding.issueType ? `问题类型：${finding.issueType}` : undefined,
+      documentLabel ? `文件：${documentLabel}` : undefined,
+      finding.description ? `描述：${finding.description}` : undefined,
+    ].filter(Boolean);
+
+    await this.correctiveActionService.create(
+      {
+        trigger_type: 'internal_audit',
+        trigger_id: finding.id,
+        description: descriptionParts.join('；'),
+        responsible_id: finding.assigneeId ?? undefined,
+        due_date: finding.dueDate
+          ? finding.dueDate.toISOString().slice(0, 10)
+          : undefined,
+      },
+      userId,
+      companyId,
+      tx,
+    );
   }
 
   async rejectRectification(

--- a/server/src/modules/internal-audit/verification/verification.service.ts
+++ b/server/src/modules/internal-audit/verification/verification.service.ts
@@ -88,17 +88,29 @@ export class VerificationService {
       }
     } catch { /* no definition = skip */ }
 
-    const updatedFinding = await this.prisma.$transaction(async (tx) => {
-      await this.createCapaForVerifiedFinding(finding, userId, companyId, tx);
-
-      const verifiedFinding = await tx.auditFinding.update({
-        where: { id: findingId },
+    const now = new Date();
+    const updatedFinding = await this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      // Atomically claim the finding by conditionally updating its status.
+      // Only one concurrent caller can win this update; the loser gets count=0.
+      const { count } = await tx.auditFinding.updateMany({
+        where: {
+          id: findingId,
+          status: 'pending_verification',
+        },
         data: {
           status: 'verified',
           verifiedBy: userId,
-          verifiedAt: new Date(),
+          verifiedAt: now,
         },
       });
+
+      if (count === 0) {
+        throw new BadRequestException(
+          'Finding has already been verified or is no longer pending verification',
+        );
+      }
+
+      await this.createCapaForVerifiedFinding(finding, userId, companyId, tx);
 
       await tx.todoTask.updateMany({
         where: {
@@ -110,7 +122,7 @@ export class VerificationService {
         },
       });
 
-      return verifiedFinding;
+      return { ...finding, status: 'verified' as const, verifiedBy: userId, verifiedAt: now };
     });
 
     // 6. Log operation


### PR DESCRIPTION
## Summary
- Auto-create idempotent CAPA when internal audit non-conformance is verified (`verifyRectification`)
- CAPA creation, `AuditFinding.status='verified'`, and `audit_rectification` Todo completion now run in one Prisma transaction
- `CorrectiveActionService.create()` accepts optional `tx` parameter for caller-supplied transaction client

## Files changed
- `verification.service.ts` — added `companyId` param, transaction boundary, `createCapaForVerifiedFinding` helper
- `verification.controller.ts` — passes `req.user.companyId` to service
- `verification.module.ts` — imports `CorrectiveActionModule`
- `corrective-action.service.ts` — optional `tx` param on `create()` and `validateTriggerSource()`
- `verification.service.spec.ts` — 6 new tests (create, idempotency, skip compliant, missing companyId, CAPA failure atomicity)
- `corrective-action.service.spec.ts` — updated assertion to match new `generateCorrectiveActionNo` call signature

## Test plan
- [ ] `verification.service.spec.ts` — 17 tests pass
- [ ] `corrective-action.service.spec.ts` — 11 tests pass
- [ ] Build errors are pre-existing (187 errors on base branch before this PR)