### PR TITLE
fix(GAP-318): require nc_id FK for ReworkRecord

### DIFF
--- a/client/src/api/rework-record.ts
+++ b/client/src/api/rework-record.ts
@@ -8,7 +8,7 @@ export interface ReworkRecord {
   id: string;
   company_id: string;
   production_batch_id: string;
-  nc_id: string | null;
+  nc_id: string;
   rework_reason: string;
   rework_qty: number;
   unit: string;
@@ -23,7 +23,7 @@ export interface ReworkRecord {
 
 export interface CreateReworkRecordPayload {
   production_batch_id: string;
-  nc_id?: string;
+  nc_id: string;
   rework_reason: string;
   rework_qty: number;
   unit: string;

--- a/client/src/views/rework-record/ReworkRecordList.vue
+++ b/client/src/views/rework-record/ReworkRecordList.vue
@@ -136,8 +136,8 @@
         <el-form-item label="判定人">
           <el-input v-model="createForm.verdict_by" placeholder="可选" />
         </el-form-item>
-        <el-form-item label="关联不合格品">
-          <el-input v-model="createForm.nc_id" placeholder="可选，不合格品记录ID" />
+        <el-form-item label="关联不合格品" prop="nc_id">
+          <el-input v-model="createForm.nc_id" placeholder="请输入不合格品记录ID" />
         </el-form-item>
       </el-form>
       <template #footer>
@@ -186,6 +186,7 @@ const createRules: FormRules = {
   rework_qty: [{ required: true, message: '请输入返工数量', trigger: 'blur' }],
   rework_date: [{ required: true, message: '请选择返工日期', trigger: 'change' }],
   quality_verdict: [{ required: true, message: '请选择质量判定', trigger: 'change' }],
+  nc_id: [{ required: true, message: '请输入关联不合格品', trigger: 'blur' }],
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -242,7 +243,7 @@ async function handleCreate() {
       rework_date: createForm.rework_date,
       quality_verdict: createForm.quality_verdict,
       verdict_by: createForm.verdict_by || undefined,
-      nc_id: createForm.nc_id || undefined,
+      nc_id: createForm.nc_id,
     });
     ElMessage.success('新建成功');
     createDialogVisible.value = false;

--- a/server/src/modules/rework-record/dto/create-rework-record.dto.ts
+++ b/server/src/modules/rework-record/dto/create-rework-record.dto.ts
@@ -4,9 +4,8 @@ export class CreateReworkRecordDto {
   @IsString()
   production_batch_id: string;
 
-  @IsOptional()
   @IsString()
-  nc_id?: string;
+  nc_id: string;
 
   @IsString()
   rework_reason: string;

--- a/server/src/modules/rework-record/rework-record.service.spec.ts
+++ b/server/src/modules/rework-record/rework-record.service.spec.ts
@@ -9,6 +9,9 @@ describe('ReworkRecordService', () => {
       findFirst: jest.fn(),
       delete: jest.fn(),
     },
+    nonConformance: {
+      findFirst: jest.fn(),
+    },
   };
   let service: ReworkRecordService;
 
@@ -18,11 +21,17 @@ describe('ReworkRecordService', () => {
   });
 
   it('writes rework records to the authenticated company', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      source_type: 'production_batch',
+      source_id: 'b1',
+    });
     prisma.reworkRecord.create.mockResolvedValue({ id: 'r1' });
 
     await service.create(
       {
         production_batch_id: 'b1',
+        nc_id: 'nc1',
         rework_reason: '返工',
         rework_qty: 1,
         unit: 'kg',
@@ -32,9 +41,88 @@ describe('ReworkRecordService', () => {
       '2',
     );
 
+    expect(prisma.nonConformance.findFirst).toHaveBeenCalledWith({
+      where: { id: 'nc1', company_id: '2' },
+      select: { id: true, source_type: true, source_id: true },
+    });
     expect(prisma.reworkRecord.create).toHaveBeenCalledWith(
-      expect.objectContaining({ data: expect.objectContaining({ company_id: '2' }) }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          company_id: '2',
+          production_batch_id: 'b1',
+          nc_id: 'nc1',
+        }),
+      }),
     );
+  });
+
+  it('rejects creation when nc_id is missing', async () => {
+    await expect(
+      service.create(
+        {
+          production_batch_id: 'b1',
+          rework_reason: '返工',
+          rework_qty: 1,
+          unit: 'kg',
+          rework_date: '2026-05-01',
+          quality_verdict: 'pass',
+        } as any,
+        '2',
+      ),
+    ).rejects.toThrow('关联不合格记录不能为空');
+
+    expect(prisma.nonConformance.findFirst).not.toHaveBeenCalled();
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when the nonconformance is missing or outside current company', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.create(
+        {
+          production_batch_id: 'b1',
+          nc_id: 'missing-nc',
+          rework_reason: '返工',
+          rework_qty: 1,
+          unit: 'kg',
+          rework_date: '2026-05-01',
+          quality_verdict: 'pass',
+        },
+        '2',
+      ),
+    ).rejects.toThrow('关联不合格记录不存在');
+
+    expect(prisma.nonConformance.findFirst).toHaveBeenCalledWith({
+      where: { id: 'missing-nc', company_id: '2' },
+      select: { id: true, source_type: true, source_id: true },
+    });
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects creation when production batch differs from the NC source production batch', async () => {
+    prisma.nonConformance.findFirst.mockResolvedValue({
+      id: 'nc1',
+      source_type: 'production_batch',
+      source_id: 'batch-from-nc',
+    });
+
+    await expect(
+      service.create(
+        {
+          production_batch_id: 'different-batch',
+          nc_id: 'nc1',
+          rework_reason: '返工',
+          rework_qty: 1,
+          unit: 'kg',
+          rework_date: '2026-05-01',
+          quality_verdict: 'pass',
+        },
+        '2',
+      ),
+    ).rejects.toThrow('返工生产批次必须与不合格来源批次一致');
+
+    expect(prisma.reworkRecord.create).not.toHaveBeenCalled();
   });
 
   it('blocks delete when rework record is outside current company', async () => {

--- a/server/src/modules/rework-record/rework-record.service.ts
+++ b/server/src/modules/rework-record/rework-record.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateReworkRecordDto } from './dto/create-rework-record.dto';
 
@@ -7,9 +7,27 @@ export class ReworkRecordService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateReworkRecordDto, companyId: string) {
+    const ncId = dto.nc_id?.trim();
+    if (!ncId) {
+      throw new BadRequestException('关联不合格记录不能为空');
+    }
+
+    const nonConformance = await this.prisma.nonConformance.findFirst({
+      where: { id: ncId, company_id: companyId },
+      select: { id: true, source_type: true, source_id: true },
+    });
+    if (!nonConformance) {
+      throw new BadRequestException('关联不合格记录不存在');
+    }
+
+    if (nonConformance.source_type === 'production_batch' && nonConformance.source_id !== dto.production_batch_id) {
+      throw new BadRequestException('返工生产批次必须与不合格来源批次一致');
+    }
+
     return this.prisma.reworkRecord.create({
       data: {
         ...dto,
+        nc_id: ncId,
         company_id: companyId,
         rework_date: new Date(dto.rework_date),
         rework_qty: dto.rework_qty,

--- a/server/src/prisma/migrations/20260502110000_rework_record_nc_fk/migration.sql
+++ b/server/src/prisma/migrations/20260502110000_rework_record_nc_fk/migration.sql
@@ -1,0 +1,52 @@
+-- Require every ReworkRecord to link to a real current-company NonConformance.
+-- This migration intentionally fails if legacy data cannot satisfy the constraint.
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "ReworkRecord"
+    WHERE "nc_id" IS NULL OR btrim("nc_id") = ''
+  ) THEN
+    RAISE EXCEPTION 'Cannot require ReworkRecord.nc_id: legacy rows with NULL or empty nc_id exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "ReworkRecord" rw
+    LEFT JOIN "NonConformance" nc ON nc."id" = rw."nc_id"
+    WHERE nc."id" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot add ReworkRecord.nc_id FK: orphan nc_id rows exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "ReworkRecord" rw
+    JOIN "NonConformance" nc ON nc."id" = rw."nc_id"
+    WHERE rw."company_id" <> nc."company_id"
+  ) THEN
+    RAISE EXCEPTION 'Cannot add ReworkRecord.nc_id FK: cross-company NC links exist';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM "ReworkRecord" rw
+    JOIN "NonConformance" nc ON nc."id" = rw."nc_id"
+    WHERE nc."source_type" = 'production_batch'
+      AND rw."production_batch_id" <> nc."source_id"
+  ) THEN
+    RAISE EXCEPTION 'Cannot add ReworkRecord.nc_id FK: production batch does not match NC source_id';
+  END IF;
+END $$;
+
+ALTER TABLE "ReworkRecord" DROP CONSTRAINT IF EXISTS "ReworkRecord_nc_id_fkey";
+ALTER TABLE "ReworkRecord" ALTER COLUMN "nc_id" SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "ReworkRecord_nc_id_idx"
+  ON "ReworkRecord"("nc_id");
+
+ALTER TABLE "ReworkRecord"
+  ADD CONSTRAINT "ReworkRecord_nc_id_fkey"
+  FOREIGN KEY ("nc_id") REFERENCES "NonConformance"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -3063,6 +3063,8 @@ model NonConformance {
   status          String    @default("open") // 'open'|'dispositioned'|'closed'
   created_at      DateTime  @default(now())
   updated_at      DateTime  @updatedAt
+
+  rework_records  ReworkRecord[]
   @@unique([company_id, nc_no])
   @@index([company_id, status])
   @@index([company_id, source_type, source_id])
@@ -3138,7 +3140,8 @@ model ReworkRecord {
   company_id          String
   production_batch_id String
   production_batch    ProductionBatch @relation(fields: [production_batch_id], references: [id])
-  nc_id               String?
+  nc_id               String
+  non_conformance     NonConformance @relation(fields: [nc_id], references: [id], onDelete: Restrict)
   rework_reason       String
   rework_qty          Decimal         @db.Decimal(14,4)
   unit                String
@@ -3149,6 +3152,8 @@ model ReworkRecord {
   verdict_by          String?
   created_at          DateTime        @default(now())
   updated_at          DateTime        @updatedAt
+
+  @@index([nc_id])
 }
 
 model MeasuringEquipment {


### PR DESCRIPTION
## Summary
- Adds required `nc_id` FK from `ReworkRecord` to `NonConformance` in Prisma schema
- Adds guarded migration with preflight checks (NULL, orphan, cross-company, batch mismatch)
- Service validates NC exists in current company and batch consistency before create
- DTO makes `nc_id` required; frontend form adds required validation rule

## Test plan
- [ ] `rework-record.service.spec.ts` — 5 tests pass (valid create, missing nc_id, invalid NC, batch mismatch, delete scoping)
- [ ] Prisma schema validates
- [ ] Client build passes
- [ ] Migration has no backfill SQL