### PR TITLE
feat(GAP-603): link maintenance requisitions to equipment

### DIFF
--- a/client/src/api/warehouse.ts
+++ b/client/src/api/warehouse.ts
@@ -59,10 +59,16 @@ export interface SupplierControlledDocument {
 
 export interface Requisition {
   id: string;
-  number: string;
-  requesterId: string;
-  departmentId: string;
-  status: 'draft' | 'submitted' | 'approved' | 'rejected' | 'completed';
+  requisitionNo?: string;
+  number?: string;
+  requisitionType: 'production' | 'maintenance' | 'other';
+  requesterId?: string;
+  applicantId?: string;
+  departmentId?: string;
+  targetZone?: string;
+  equipmentId?: string;
+  equipment?: { id: string; code: string; name: string; status: string };
+  status: 'draft' | 'pending' | 'approved' | 'rejected' | 'completed';
   items: RequisitionItem[];
   createdAt: string;
   requester?: { id: string; name: string };
@@ -201,7 +207,14 @@ export const requisitionApi = {
     return request.get<Requisition>(`/warehouse/requisitions/${id}`);
   },
 
-  create(payload: { departmentId: string; items: { materialId: string; quantity: number }[] }) {
+  create(payload: {
+    requisitionType?: 'production' | 'maintenance' | 'other';
+    equipmentId?: string;
+    departmentId?: string;
+    targetZone?: string;
+    remark?: string;
+    items?: { batchId: string; quantity: number }[];
+  }) {
     return request.post<Requisition>('/warehouse/requisitions', payload);
   },
 

--- a/client/src/views/warehouse/RequisitionList.vue
+++ b/client/src/views/warehouse/RequisitionList.vue
@@ -36,6 +36,17 @@
         <el-table-column label="部门" width="120">
           <template #default="{ row }">{{ row.department?.name || '-' }}</template>
         </el-table-column>
+        <el-table-column label="类型" width="110">
+          <template #default="{ row }">
+            <el-tag size="small" type="info">{{ reqTypeText(row.requisitionType || 'production') }}</el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="设备" min-width="160">
+          <template #default="{ row }">
+            <span v-if="row.equipment">{{ row.equipment.code }} / {{ row.equipment.name }}</span>
+            <span v-else>-</span>
+          </template>
+        </el-table-column>
         <el-table-column label="目标区域" width="110">
           <template #default="{ row }">
             <el-tag v-if="row.targetZone" size="small" type="info">{{ row.targetZone }}</el-tag>
@@ -88,6 +99,23 @@
     <!-- 创建领料单对话框 -->
     <el-dialog v-model="createVisible" title="创建领料单" width="480px">
       <el-form :model="createForm" :rules="createRules" ref="createFormRef" label-width="90px">
+        <el-form-item label="领料类型" prop="requisitionType">
+          <el-select v-model="createForm.requisitionType" placeholder="请选择领料类型" style="width:100%">
+            <el-option value="production" label="生产领料" />
+            <el-option value="maintenance" label="维修领料" />
+            <el-option value="other" label="其他领料" />
+          </el-select>
+        </el-form-item>
+        <el-form-item v-if="createForm.requisitionType === 'maintenance'" label="设备" prop="equipmentId">
+          <el-select v-model="createForm.equipmentId" placeholder="请选择设备" filterable clearable style="width:100%">
+            <el-option
+              v-for="equipment in equipmentOptions"
+              :key="equipment.id"
+              :value="equipment.id"
+              :label="`${equipment.code} / ${equipment.name}`"
+            />
+          </el-select>
+        </el-form-item>
         <el-form-item label="目标区域" prop="targetZone">
           <el-select v-model="createForm.targetZone" placeholder="请选择目标区域" style="width:100%">
             <el-option value="筛粉间" label="筛粉间" />
@@ -108,6 +136,7 @@
 import { ref, reactive, onMounted } from 'vue';
 import { ElMessage, ElMessageBox } from 'element-plus';
 import { requisitionApi } from '@/api/warehouse';
+import equipmentApi, { type Equipment } from '@/api/equipment';
 import request from '@/api/request';
 
 const loading = ref(false);
@@ -118,13 +147,39 @@ const pagination = reactive({ page: 1, limit: 20, total: 0 });
 const createVisible = ref(false);
 const creating = ref(false);
 const createFormRef = ref();
-const createForm = reactive({ targetZone: '' });
+const equipmentOptions = ref<Equipment[]>([]);
+const createForm = reactive({
+  requisitionType: 'production' as 'production' | 'maintenance' | 'other',
+  equipmentId: '',
+  targetZone: '',
+});
 const createRules = {
+  requisitionType: [{ required: true, message: '请选择领料类型', trigger: 'change' }],
+  equipmentId: [{
+    validator: (_rule: unknown, value: string, callback: (error?: Error) => void) => {
+      if (createForm.requisitionType === 'maintenance' && !value) {
+        callback(new Error('维修领料必须选择设备'));
+        return;
+      }
+      callback();
+    },
+    trigger: 'change',
+  }],
   targetZone: [{ required: true, message: '请选择目标区域', trigger: 'change' }],
 };
 
 const reqStatusText = (s: string) => ({ draft: '草稿', pending: '已提交', approved: '已批准', rejected: '已驳回', completed: '已完成' }[s] || s);
+const reqTypeText = (s: string) => ({ production: '生产领料', maintenance: '维修领料', other: '其他领料' }[s] || s);
 const reqStatusType = (s: string) => ({ draft: 'info', pending: 'warning', approved: 'success', rejected: 'danger', completed: 'primary' }[s] || 'info') as 'info' | 'warning' | 'success' | 'danger' | 'primary';
+
+const fetchEquipmentOptions = async () => {
+  try {
+    const res: any = await equipmentApi.getEquipmentList({ limit: 500 });
+    equipmentOptions.value = res.data ?? res.list ?? [];
+  } catch {
+    equipmentOptions.value = [];
+  }
+};
 
 const fetchData = async () => {
   loading.value = true;
@@ -146,9 +201,12 @@ const fetchData = async () => {
 const handleSearch = () => { pagination.page = 1; fetchData(); };
 const handleReset = () => { filterForm.status = ''; handleSearch(); };
 
-const openCreateDialog = () => {
+const openCreateDialog = async () => {
+  createForm.requisitionType = 'production';
+  createForm.equipmentId = '';
   createForm.targetZone = '';
   createFormRef.value?.resetFields();
+  await fetchEquipmentOptions();
   createVisible.value = true;
 };
 
@@ -156,7 +214,12 @@ const submitCreate = async () => {
   await createFormRef.value?.validate();
   creating.value = true;
   try {
-    await request.post('/warehouse/requisitions', { targetZone: createForm.targetZone });
+    await requisitionApi.create({
+      requisitionType: createForm.requisitionType,
+      equipmentId: createForm.requisitionType === 'maintenance' ? createForm.equipmentId : undefined,
+      targetZone: createForm.targetZone,
+      items: [],
+    });
     ElMessage.success('领料单已创建');
     createVisible.value = false;
     fetchData();

--- a/client/src/views/warehouse/RequisitionList.vue
+++ b/client/src/views/warehouse/RequisitionList.vue
@@ -174,7 +174,7 @@ const reqStatusType = (s: string) => ({ draft: 'info', pending: 'warning', appro
 
 const fetchEquipmentOptions = async () => {
   try {
-    const res: any = await equipmentApi.getEquipmentList({ limit: 500 });
+    const res: any = await equipmentApi.getEquipmentList({ limit: 500, status: 'active' });
     equipmentOptions.value = res.data ?? res.list ?? [];
   } catch {
     equipmentOptions.value = [];

--- a/server/src/modules/warehouse/dto/requisition.dto.ts
+++ b/server/src/modules/warehouse/dto/requisition.dto.ts
@@ -18,20 +18,32 @@ export class CreateRequisitionItemDto {
 }
 
 export class CreateRequisitionDto {
-  @ApiProperty({
-    description: '领料类型',
+  @ApiPropertyOptional({
+    description: '领料类型；省略时保持旧行为，服务端默认 production',
     enum: ['production', 'maintenance', 'other'],
   })
+  @IsOptional()
   @IsEnum(['production', 'maintenance', 'other'], {
     message: '领料类型必须为 production、maintenance 或 other',
   })
-  requisitionType: string;
+  requisitionType?: string;
 
-  @ApiProperty({ description: '领料明细', type: [CreateRequisitionItemDto] })
+  @ApiPropertyOptional({ description: '维修领料关联设备ID，仅 requisitionType=maintenance 时允许' })
+  @IsOptional()
+  @IsString()
+  equipmentId?: string;
+
+  @ApiPropertyOptional({ description: '目标区域' })
+  @IsOptional()
+  @IsString()
+  targetZone?: string;
+
+  @ApiPropertyOptional({ description: '领料明细；允许省略或传空数组以创建草稿领料单', type: [CreateRequisitionItemDto] })
+  @IsOptional()
   @IsArray()
   @ValidateNested({ each: true })
   @Type(() => CreateRequisitionItemDto)
-  items: CreateRequisitionItemDto[];
+  items?: CreateRequisitionItemDto[];
 
   @ApiPropertyOptional({ description: '部门ID' })
   @IsOptional()

--- a/server/src/modules/warehouse/requisition.controller.ts
+++ b/server/src/modules/warehouse/requisition.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Post, Body, Param, Query, HttpCode, HttpStatus, Request, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RequisitionService } from './requisition.service';
+import { CreateRequisitionDto, QueryRequisitionDto } from './dto/requisition.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('warehouse/requisitions')
@@ -9,12 +10,12 @@ export class RequisitionController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  create(@Body() createDto: any, @Request() req: any) {
+  create(@Body() createDto: CreateRequisitionDto, @Request() req: any) {
     return this.requisitionService.create({ ...createDto, applicantId: req.user.id });
   }
 
   @Get()
-  findAll(@Query() query: any) {
+  findAll(@Query() query: QueryRequisitionDto) {
     return this.requisitionService.findAll(query);
   }
 

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -157,7 +157,7 @@ describe('RequisitionService', () => {
       const result = await service.create(createDto);
 
       expect(txClient.equipment.findFirst).toHaveBeenCalledWith({
-        where: { id: 'eq-001', deletedAt: null },
+        where: { id: 'eq-001', deletedAt: null, status: 'active' },
         select: { id: true },
       });
       expect(txClient.materialRequisition.create).toHaveBeenCalledWith({
@@ -185,6 +185,26 @@ describe('RequisitionService', () => {
       })).rejects.toThrow(BadRequestException);
 
       expect(txClient.equipment.findFirst).not.toHaveBeenCalled();
+      expect(txClient.materialRequisition.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects inactive equipment for maintenance requisitions', async () => {
+      const txClient = {
+        equipment: {
+          findFirst: jest.fn().mockResolvedValue(null), // inactive equipment returns null with active filter
+        },
+        materialRequisition: { create: jest.fn() },
+        materialRequisitionItem: { createMany: jest.fn() },
+      };
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      await expect(service.create({
+        requisitionType: 'maintenance',
+        equipmentId: 'eq-inactive',
+        applicantId: 'user-001',
+        items: [],
+      })).rejects.toThrow(BadRequestException);
+
       expect(txClient.materialRequisition.create).not.toHaveBeenCalled();
     });
 

--- a/server/src/modules/warehouse/requisition.service.spec.ts
+++ b/server/src/modules/warehouse/requisition.service.spec.ts
@@ -18,6 +18,9 @@ describe('RequisitionService', () => {
         {
           provide: PrismaService,
           useValue: {
+            equipment: {
+              findFirst: jest.fn(),
+            },
             materialRequisition: {
               create: jest.fn(),
               findMany: jest.fn(),
@@ -102,6 +105,117 @@ describe('RequisitionService', () => {
 
       expect(result.requisitionNo).toContain('REQ-');
       expect(prisma.$transaction).toHaveBeenCalled();
+    });
+
+    it('requires equipmentId for maintenance requisitions', async () => {
+      const txClient = {
+        equipment: { findFirst: jest.fn() },
+        materialRequisition: { create: jest.fn() },
+        materialRequisitionItem: { createMany: jest.fn() },
+      };
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      await expect(service.create({
+        requisitionType: 'maintenance',
+        applicantId: 'user-001',
+        items: [],
+      })).rejects.toThrow(BadRequestException);
+
+      expect(txClient.equipment.findFirst).not.toHaveBeenCalled();
+      expect(txClient.materialRequisition.create).not.toHaveBeenCalled();
+    });
+
+    it('validates and persists equipmentId for maintenance requisitions', async () => {
+      const createDto = {
+        requisitionType: 'maintenance',
+        equipmentId: 'eq-001',
+        applicantId: 'user-001',
+        items: [{ batchId: 'batch-001', quantity: 2 }],
+      };
+
+      const mockRequisition = {
+        id: 'req-001',
+        requisitionNo: 'REQ-20260502-001',
+        requisitionType: 'maintenance',
+        equipmentId: 'eq-001',
+        status: 'draft',
+      };
+
+      const txClient = {
+        equipment: {
+          findFirst: jest.fn().mockResolvedValue({ id: 'eq-001', deletedAt: null }),
+        },
+        materialRequisition: {
+          create: jest.fn().mockResolvedValue(mockRequisition),
+        },
+        materialRequisitionItem: {
+          createMany: jest.fn(),
+        },
+      };
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      const result = await service.create(createDto);
+
+      expect(txClient.equipment.findFirst).toHaveBeenCalledWith({
+        where: { id: 'eq-001', deletedAt: null },
+        select: { id: true },
+      });
+      expect(txClient.materialRequisition.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          requisitionType: 'maintenance',
+          equipmentId: 'eq-001',
+        }),
+      });
+      expect(result.equipmentId).toBe('eq-001');
+    });
+
+    it('rejects equipmentId for non-maintenance requisitions', async () => {
+      const txClient = {
+        equipment: { findFirst: jest.fn() },
+        materialRequisition: { create: jest.fn() },
+        materialRequisitionItem: { createMany: jest.fn() },
+      };
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      await expect(service.create({
+        requisitionType: 'production',
+        equipmentId: 'eq-001',
+        applicantId: 'user-001',
+        items: [],
+      })).rejects.toThrow(BadRequestException);
+
+      expect(txClient.equipment.findFirst).not.toHaveBeenCalled();
+      expect(txClient.materialRequisition.create).not.toHaveBeenCalled();
+    });
+
+    it('keeps legacy targetZone-only requisition creation compatible', async () => {
+      const txClient = {
+        equipment: { findFirst: jest.fn() },
+        materialRequisition: {
+          create: jest.fn().mockResolvedValue({
+            id: 'req-legacy',
+            requisitionNo: 'REQ-20260502-legacy',
+            requisitionType: 'production',
+            targetZone: '小料房',
+            status: 'draft',
+          }),
+        },
+        materialRequisitionItem: { createMany: jest.fn() },
+      };
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback: any) => callback(txClient));
+
+      const result = await service.create({ targetZone: '小料房', applicantId: 'user-001' });
+
+      expect(txClient.equipment.findFirst).not.toHaveBeenCalled();
+      expect(txClient.materialRequisition.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          requisitionType: 'production',
+          targetZone: '小料房',
+          applicantId: 'user-001',
+        }),
+      });
+      expect(txClient.materialRequisitionItem.createMany).not.toHaveBeenCalled();
+      expect(result.requisitionType).toBe('production');
     });
   });
 

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -71,11 +71,11 @@ export class RequisitionService {
     }
 
     const equipment = await tx.equipment.findFirst({
-      where: { id: equipmentId, deletedAt: null },
+      where: { id: equipmentId, deletedAt: null, status: 'active' },
       select: { id: true },
     });
     if (!equipment) {
-      throw new BadRequestException('设备不存在或已删除');
+      throw new BadRequestException('设备不存在、已删除或非在用状态');
     }
   }
 

--- a/server/src/modules/warehouse/requisition.service.ts
+++ b/server/src/modules/warehouse/requisition.service.ts
@@ -19,14 +19,18 @@ export class RequisitionService {
     const requisitionNo = this.generateRequisitionNo();
 
     return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      const requisitionType = createDto.requisitionType ?? 'production';
+      await this.validateEquipmentLink(tx, requisitionType, createDto.equipmentId);
+
       const requisition = await tx.materialRequisition.create({
         data: {
           requisitionNo,
-          requisitionType: createDto.requisitionType ?? 'production',
+          requisitionType,
           applicantId: createDto.applicantId ?? 'system',
           departmentId: createDto.departmentId,
           remark: createDto.remark,
           targetZone: createDto.targetZone,
+          equipmentId: createDto.equipmentId,
           status: 'draft',
         },
       });
@@ -53,6 +57,28 @@ export class RequisitionService {
     return Number(value);
   }
 
+  private async validateEquipmentLink(tx: Prisma.TransactionClient, requisitionType: string, equipmentId?: string) {
+    if (requisitionType === 'maintenance' && !equipmentId) {
+      throw new BadRequestException('维修领料必须关联设备');
+    }
+
+    if (requisitionType !== 'maintenance' && equipmentId) {
+      throw new BadRequestException('只有维修领料可以关联设备');
+    }
+
+    if (!equipmentId) {
+      return;
+    }
+
+    const equipment = await tx.equipment.findFirst({
+      where: { id: equipmentId, deletedAt: null },
+      select: { id: true },
+    });
+    if (!equipment) {
+      throw new BadRequestException('设备不存在或已删除');
+    }
+  }
+
   private generateRequisitionNo(): string {
     const today = dayjs().format('YYYYMMDD');
     const seq = Math.floor(Math.random() * 1000).toString().padStart(3, '0');
@@ -75,7 +101,10 @@ export class RequisitionService {
         where,
         skip,
         take: limit,
-        include: { items: true },
+        include: {
+          items: true,
+          equipment: { select: { id: true, code: true, name: true, status: true } },
+        },
         orderBy: { createdAt: 'desc' },
       }),
       this.prisma.materialRequisition.count({ where }),
@@ -87,7 +116,10 @@ export class RequisitionService {
   async findOne(id: string) {
     const requisition = await this.prisma.materialRequisition.findUnique({
       where: { id },
-      include: { items: true },
+      include: {
+        items: true,
+        equipment: { select: { id: true, code: true, name: true, status: true } },
+      },
     });
 
     if (!requisition || requisition.deletedAt) {

--- a/server/src/prisma/migrations/20260502110000_add_material_requisition_equipment_id/migration.sql
+++ b/server/src/prisma/migrations/20260502110000_add_material_requisition_equipment_id/migration.sql
@@ -1,0 +1,13 @@
+-- Link maintenance material requisitions to the Equipment ledger.
+-- Existing rows remain nullable because no trusted historical equipment mapping exists.
+
+ALTER TABLE "material_requisitions"
+  ADD COLUMN "equipmentId" TEXT;
+
+CREATE INDEX IF NOT EXISTS "material_requisitions_equipmentId_idx"
+  ON "material_requisitions"("equipmentId");
+
+ALTER TABLE "material_requisitions"
+  ADD CONSTRAINT "material_requisitions_equipmentId_fkey"
+  FOREIGN KEY ("equipmentId") REFERENCES "equipment"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -1064,6 +1064,8 @@ model MaterialRequisition {
   departmentId    String?
   remark          String?
   targetZone      String?   // 目标车间区域：筛粉间 | 称油间 | 小料房
+  equipmentId     String?
+  equipment       Equipment? @relation(fields: [equipmentId], references: [id], onDelete: Restrict)
   submittedAt     DateTime?
   approvedAt         DateTime?
   approvedBy         String?
@@ -1078,6 +1080,7 @@ model MaterialRequisition {
   @@index([status])
   @@index([createdAt])
   @@index([requisitionType])
+  @@index([equipmentId])
   @@index([approvalInstanceId])
   @@map("material_requisitions")
 }
@@ -1651,9 +1654,10 @@ model Equipment {
   deletedAt         DateTime?
 
   // 反向关系
-  maintenancePlans   MaintenancePlan[]
-  maintenanceRecords MaintenanceRecord[]
-  equipmentFaults    EquipmentFault[]
+  maintenancePlans     MaintenancePlan[]
+  maintenanceRecords   MaintenanceRecord[]
+  equipmentFaults      EquipmentFault[]
+  materialRequisitions MaterialRequisition[]
 
   @@index([code])
   @@index([category])


### PR DESCRIPTION
## Summary

- Adds nullable `equipmentId` FK from `MaterialRequisition` to `Equipment` with migration SQL
- Enforces business rule in `RequisitionService.create()`: maintenance requisitions require an active equipment reference; non-maintenance must not carry one
- Exposes `requisitionType` and equipment selector in warehouse requisition UI

## Changes

- `schema.prisma`: adds `equipmentId` + reverse relation on `Equipment`, adds index
- Migration: `20260502110000_add_material_requisition_equipment_id`
- `CreateRequisitionDto`: all fields made optional (compatible with legacy `targetZone`-only payloads)
- `requisition.controller.ts`: typed with `CreateRequisitionDto` / `QueryRequisitionDto`
- `requisition.service.ts`: `validateEquipmentLink()` helper; `equipmentId` persisted; `equipment` included in list/detail reads
- `requisition.service.spec.ts`: 4 new tests covering equipment validation rules + legacy compatibility
- `client/src/api/warehouse.ts`: updated `Requisition` interface and `create()` payload types
- `client/src/views/warehouse/RequisitionList.vue`: type column, equipment column, type/equipment form controls

## Test plan

- [ ] `npm test -- requisition.service.spec.ts --runInBand` — all 11 tests pass
- [ ] `npm run build:client` — builds without TypeScript errors
- [ ] Prisma schema valid: `DATABASE_URL=... npx prisma validate`
- [ ] Manual: create maintenance requisition with equipment → saved; create production requisition with equipmentId → rejected