### PR TITLE
feat(GAP-207): bind shift instances to scheduled teams

### DIFF
--- a/client/src/api/shift-instance.ts
+++ b/client/src/api/shift-instance.ts
@@ -14,6 +14,13 @@ export interface ShiftTypeSummary {
   active: boolean;
 }
 
+export interface TeamSummary {
+  id: string;
+  code: string;
+  name: string;
+  active: boolean;
+}
+
 export interface ShiftInstance {
   id: string;
   shift_type_id: string;
@@ -22,6 +29,10 @@ export interface ShiftInstance {
   shift_date: string;
   status: 'open' | 'closed';
   notes?: string;
+  team_id?: string | null;
+  team?: TeamSummary | null;
+  leader_id?: string | null;
+  team_override_reason?: string | null;
   production_runs: ProductionRunSummary[];
   created_at: string;
   closed_at?: string;
@@ -38,6 +49,9 @@ export interface ProductionRunSummary {
 export interface CreateShiftInstancePayload {
   shiftTypeId: string;
   shift_date: string;
+  teamId?: string;
+  leaderId?: string;
+  teamOverrideReason?: string;
   notes?: string;
 }
 

--- a/client/src/views/shift/ShiftDashboard.vue
+++ b/client/src/views/shift/ShiftDashboard.vue
@@ -21,7 +21,7 @@
             <el-tag :type="shift.status === 'open' ? 'success' : 'info'">
               {{ shift.status === 'open' ? '进行中' : '已关班' }}
             </el-tag>
-            &nbsp;{{ displayShiftType(shift) }} | {{ formatDate(shift.shift_date) }}
+            &nbsp;{{ displayShiftType(shift) }}{{ displayTeam(shift) }} | {{ formatDate(shift.shift_date) }}
           </span>
           <div>
             <el-button
@@ -123,6 +123,10 @@ function formatTime(d: string): string {
 
 function displayShiftType(shift: ShiftInstance): string {
   return shift.shift_type_ref?.name ?? shift.shift_type;
+}
+
+function displayTeam(shift: ShiftInstance): string {
+  return shift.team?.name ? ` | ${shift.team.name}` : '';
 }
 
 function openRunFor(shift: ShiftInstance) {

--- a/server/src/modules/shift-instance/dto/create-shift-instance.dto.ts
+++ b/server/src/modules/shift-instance/dto/create-shift-instance.dto.ts
@@ -17,6 +17,18 @@ export class CreateShiftInstanceDto {
 
   @IsOptional()
   @IsString()
+  teamId?: string;
+
+  @IsOptional()
+  @IsString()
+  leaderId?: string;
+
+  @IsOptional()
+  @IsString()
+  teamOverrideReason?: string;
+
+  @IsOptional()
+  @IsString()
   notes?: string;
 }
 

--- a/server/src/modules/shift-instance/shift-instance.service.spec.ts
+++ b/server/src/modules/shift-instance/shift-instance.service.spec.ts
@@ -10,6 +10,12 @@ describe('ShiftInstanceService', () => {
     shiftType: {
       findFirst: jest.fn(),
     },
+    teamShiftSchedule: {
+      findMany: jest.fn(),
+    },
+    team: {
+      findFirst: jest.fn(),
+    },
     shiftInstance: {
       findUnique: jest.fn(),
       findFirst: jest.fn(),
@@ -28,6 +34,7 @@ describe('ShiftInstanceService', () => {
       ],
     }).compile();
     service = module.get(ShiftInstanceService);
+    mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([]);
   });
 
   describe('create', () => {
@@ -39,6 +46,38 @@ describe('ShiftInstanceService', () => {
       end_time: '20:00',
       crosses_day: false,
       active: true,
+    };
+
+    const scheduledTeam = {
+      id: 'team-a',
+      code: 'TEAM-A',
+      name: 'A班',
+      active: true,
+    };
+
+    const schedule = {
+      id: 'schedule-1',
+      team_id: 'team-a',
+      shift_type_id: 'shift-day',
+      work_date: new Date('2026-05-02'),
+      leader_id: 'employee-leader-1',
+      team: scheduledTeam,
+    };
+
+    const secondScheduledTeam = {
+      id: 'team-b',
+      code: 'TEAM-B',
+      name: 'B班',
+      active: true,
+    };
+
+    const secondSchedule = {
+      id: 'schedule-2',
+      team_id: 'team-b',
+      shift_type_id: 'shift-day',
+      work_date: new Date('2026-05-02'),
+      leader_id: 'employee-leader-2',
+      team: secondScheduledTeam,
     };
 
     it('should throw ConflictException when shift already exists for shiftTypeId and date', async () => {
@@ -85,10 +124,13 @@ describe('ShiftInstanceService', () => {
           shift_type_id: 'shift-day',
           shift_type: '白班',
           shift_date: new Date('2026-04-22'),
+          team_id: undefined,
+          leader_id: undefined,
+          team_override_reason: undefined,
           opened_by: 'user1',
           notes: undefined,
         },
-        include: { shift_type_ref: true },
+        include: { shift_type_ref: true, team: true },
       });
     });
 
@@ -125,6 +167,172 @@ describe('ShiftInstanceService', () => {
       ).rejects.toThrow(BadRequestException);
 
       expect(mockPrisma.shiftInstance.create).not.toHaveBeenCalled();
+    });
+
+    it('should attach scheduled team and leader when opening a shift', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([schedule]);
+      mockPrisma.team.findFirst.mockResolvedValue(scheduledTeam);
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'shift-1',
+        status: 'open',
+        shift_type_id: 'shift-day',
+        shift_type: '白班',
+        team_id: 'team-a',
+        leader_id: 'employee-leader-1',
+      });
+
+      await service.create({ shiftTypeId: 'shift-day', shift_date: '2026-05-02' }, 'user1');
+
+      expect(mockPrisma.teamShiftSchedule.findMany).toHaveBeenCalledWith({
+        where: {
+          shift_type_id: 'shift-day',
+          work_date: new Date('2026-05-02'),
+        },
+        include: { team: true },
+        orderBy: { team_id: 'asc' },
+      });
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          team_id: 'team-a',
+          leader_id: 'employee-leader-1',
+          team_override_reason: undefined,
+        }),
+        include: { shift_type_ref: true, team: true },
+      });
+    });
+
+    it('should allow opening a shift without a schedule', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([]);
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'shift-1',
+        status: 'open',
+        shift_type_id: 'shift-day',
+        shift_type: '白班',
+        team_id: null,
+        leader_id: null,
+      });
+
+      await service.create({ shiftTypeId: 'shift-day', shift_date: '2026-05-02' }, 'user1');
+
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          team_id: undefined,
+          leader_id: undefined,
+          team_override_reason: undefined,
+        }),
+        include: { shift_type_ref: true, team: true },
+      });
+    });
+
+    it('should reject ambiguous schedules when teamId is omitted', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([schedule, secondSchedule]);
+
+      await expect(
+        service.create({ shiftTypeId: 'shift-day', shift_date: '2026-05-02' }, 'user1'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrisma.shiftInstance.create).not.toHaveBeenCalled();
+    });
+
+    it('should allow documented team selection when multiple schedules match', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([schedule, secondSchedule]);
+      mockPrisma.team.findFirst.mockResolvedValue(secondScheduledTeam);
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'shift-1',
+        team_id: 'team-b',
+        leader_id: 'employee-leader-2',
+        team_override_reason: '同班次存在多个排班，现场指定B班负责开班',
+      });
+
+      await service.create(
+        {
+          shiftTypeId: 'shift-day',
+          shift_date: '2026-05-02',
+          teamId: 'team-b',
+          teamOverrideReason: '同班次存在多个排班，现场指定B班负责开班',
+        },
+        'user1',
+      );
+
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          team_id: 'team-b',
+          leader_id: 'employee-leader-2',
+          team_override_reason: '同班次存在多个排班，现场指定B班负责开班',
+        }),
+        include: { shift_type_ref: true, team: true },
+      });
+    });
+
+    it('should require a reason when overriding scheduled team or leader', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([schedule]);
+      mockPrisma.team.findFirst.mockResolvedValue({
+        id: 'team-b',
+        code: 'TEAM-B',
+        name: 'B班',
+        active: true,
+      });
+
+      await expect(
+        service.create(
+          {
+            shiftTypeId: 'shift-day',
+            shift_date: '2026-05-02',
+            teamId: 'team-b',
+          },
+          'user1',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockPrisma.shiftInstance.create).not.toHaveBeenCalled();
+    });
+
+    it('should allow documented team override', async () => {
+      mockPrisma.shiftType.findFirst.mockResolvedValue(dayShiftType);
+      mockPrisma.shiftInstance.findUnique.mockResolvedValue(null);
+      mockPrisma.teamShiftSchedule.findMany.mockResolvedValue([schedule]);
+      mockPrisma.team.findFirst.mockResolvedValue({
+        id: 'team-b',
+        code: 'TEAM-B',
+        name: 'B班',
+        active: true,
+      });
+      mockPrisma.shiftInstance.create.mockResolvedValue({
+        id: 'shift-1',
+        team_id: 'team-b',
+        leader_id: 'employee-leader-2',
+        team_override_reason: '临时调班',
+      });
+
+      await service.create(
+        {
+          shiftTypeId: 'shift-day',
+          shift_date: '2026-05-02',
+          teamId: 'team-b',
+          leaderId: 'employee-leader-2',
+          teamOverrideReason: '临时调班',
+        },
+        'user1',
+      );
+
+      expect(mockPrisma.shiftInstance.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          team_id: 'team-b',
+          leader_id: 'employee-leader-2',
+          team_override_reason: '临时调班',
+        }),
+        include: { shift_type_ref: true, team: true },
+      });
     });
   });
 

--- a/server/src/modules/shift-instance/shift-instance.service.ts
+++ b/server/src/modules/shift-instance/shift-instance.service.ts
@@ -27,6 +27,66 @@ export class ShiftInstanceService {
     return shiftType;
   }
 
+  private async findSchedules(shiftTypeId: string, shiftDate: Date) {
+    return this.prisma.teamShiftSchedule.findMany({
+      where: {
+        shift_type_id: shiftTypeId,
+        work_date: shiftDate,
+      },
+      include: { team: true },
+      orderBy: { team_id: 'asc' },
+    });
+  }
+
+  private async assertTeamActive(teamId: string) {
+    const team = await this.prisma.team.findFirst({
+      where: { id: teamId, active: true },
+    });
+
+    if (!team) {
+      throw new BadRequestException('班组不存在或已停用');
+    }
+  }
+
+  private resolveTeamBinding(
+    dto: CreateShiftInstanceDto,
+    schedules: Array<{ team_id: string; leader_id?: string | null }>,
+  ) {
+    const hasAmbiguousSchedules = schedules.length > 1;
+
+    if (hasAmbiguousSchedules && !dto.teamId) {
+      throw new BadRequestException('同一日期和班次存在多个排班，请指定班组');
+    }
+
+    if (hasAmbiguousSchedules && !dto.teamOverrideReason) {
+      throw new BadRequestException('同一日期和班次存在多个排班，指定班组时必须填写原因');
+    }
+
+    const selectedSchedule = dto.teamId
+      ? schedules.find((schedule) => schedule.team_id === dto.teamId) ?? null
+      : schedules[0] ?? null;
+    const scheduledTeamId = selectedSchedule?.team_id;
+    const scheduledLeaderId = selectedSchedule?.leader_id ?? undefined;
+    const finalTeamId = dto.teamId ?? scheduledTeamId;
+    const finalLeaderId = dto.leaderId ?? scheduledLeaderId;
+    const overridesTeam =
+      dto.teamId != null && (scheduledTeamId == null || dto.teamId !== scheduledTeamId);
+    const overridesLeader = dto.leaderId != null && dto.leaderId !== scheduledLeaderId;
+
+    if ((overridesTeam || overridesLeader) && !dto.teamOverrideReason) {
+      throw new BadRequestException('覆盖排班班组或负责人时必须填写原因');
+    }
+
+    return {
+      teamId: finalTeamId,
+      leaderId: finalLeaderId,
+      overrideReason:
+        hasAmbiguousSchedules || overridesTeam || overridesLeader
+          ? dto.teamOverrideReason
+          : undefined,
+    };
+  }
+
   async create(dto: CreateShiftInstanceDto, userId: string) {
     const shiftType = await this.resolveShiftType(dto);
     const shiftDate = new Date(dto.shift_date);
@@ -42,16 +102,26 @@ export class ShiftInstanceService {
     });
     if (existing) throw new ConflictException('该班次已开班');
 
+    const schedules = await this.findSchedules(shiftType.id, shiftDate);
+    const teamBinding = this.resolveTeamBinding(dto, schedules);
+
+    if (teamBinding.teamId) {
+      await this.assertTeamActive(teamBinding.teamId);
+    }
+
     return this.prisma.shiftInstance.create({
       data: {
         company_id: '1',
         shift_type_id: shiftType.id,
         shift_type: shiftType.name,
         shift_date: shiftDate,
+        team_id: teamBinding.teamId,
+        leader_id: teamBinding.leaderId,
+        team_override_reason: teamBinding.overrideReason,
         opened_by: userId,
         notes: dto.notes,
       },
-      include: { shift_type_ref: true },
+      include: { shift_type_ref: true, team: true },
     });
   }
 
@@ -63,6 +133,7 @@ export class ShiftInstanceService {
       },
       include: {
         shift_type_ref: true,
+        team: true,
         production_runs: {
           include: { product: true },
           orderBy: { started_at: 'asc' },
@@ -77,6 +148,7 @@ export class ShiftInstanceService {
       where: { id, company_id: '1' },
       include: {
         shift_type_ref: true,
+        team: true,
         production_runs: {
           include: { product: true, recipe: true },
           orderBy: { started_at: 'asc' },

--- a/server/src/modules/team-shift/dto/team-shift.dto.ts
+++ b/server/src/modules/team-shift/dto/team-shift.dto.ts
@@ -17,4 +17,8 @@ export class CreateTeamScheduleDto {
   @IsString() @IsNotEmpty() teamId!: string;
   @IsString() @IsNotEmpty() shiftTypeId!: string;
   @IsDateString() workDate!: string;
+
+  @IsOptional()
+  @IsString()
+  leaderId?: string;
 }

--- a/server/src/modules/team-shift/team-shift.service.spec.ts
+++ b/server/src/modules/team-shift/team-shift.service.spec.ts
@@ -79,20 +79,26 @@ describe('TeamShiftService', () => {
         id: 'new-schedule',
         team_id: 'team-1',
         shift_type_id: 'shift-1',
-        work_date: new Date('2024-01-15'),
+        work_date: new Date('2026-05-02'),
+        leader_id: 'employee-leader-1',
       });
 
-      await service.createSchedule({
+      const dto = {
         teamId: 'team-1',
         shiftTypeId: 'shift-1',
-        workDate: '2024-01-15',
-      });
+        workDate: '2026-05-02',
+        leaderId: 'employee-leader-1',
+      };
+
+      await service.createSchedule(dto);
 
       expect(mockPrisma.teamShiftSchedule.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
+        data: {
           team_id: 'team-1',
           shift_type_id: 'shift-1',
-        }),
+          work_date: new Date('2026-05-02'),
+          leader_id: 'employee-leader-1',
+        },
       });
     });
   });

--- a/server/src/modules/team-shift/team-shift.service.ts
+++ b/server/src/modules/team-shift/team-shift.service.ts
@@ -76,6 +76,7 @@ export class TeamShiftService {
         team_id: dto.teamId,
         shift_type_id: dto.shiftTypeId,
         work_date: new Date(dto.workDate),
+        leader_id: dto.leaderId,
       },
     });
   }

--- a/server/src/prisma/migrations/20260502000100_shift_instance_team_binding/migration.sql
+++ b/server/src/prisma/migrations/20260502000100_shift_instance_team_binding/migration.sql
@@ -1,0 +1,18 @@
+-- Add scheduled team binding to shift instances.
+-- Historical shift instances remain unbound because the responsible team cannot be inferred safely.
+
+ALTER TABLE "team_shift_schedules"
+  ADD COLUMN "leader_id" TEXT;
+
+ALTER TABLE "shift_instances"
+  ADD COLUMN "team_id" TEXT,
+  ADD COLUMN "leader_id" TEXT,
+  ADD COLUMN "team_override_reason" TEXT;
+
+CREATE INDEX IF NOT EXISTS "shift_instances_team_id_idx"
+  ON "shift_instances"("team_id");
+
+ALTER TABLE "shift_instances"
+  ADD CONSTRAINT "shift_instances_team_id_fkey"
+  FOREIGN KEY ("team_id") REFERENCES "teams"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -2836,8 +2836,9 @@ model Team {
   active      Boolean             @default(true)
   members     TeamMember[]
   schedules   TeamShiftSchedule[]
-  batches     ProductionBatch[]
-  stocktakes  StagingAreaStocktake[]
+  batches        ProductionBatch[]
+  stocktakes     StagingAreaStocktake[]
+  shiftInstances ShiftInstance[]
   created_at  DateTime            @default(now())
   updated_at  DateTime            @updatedAt
 
@@ -2882,6 +2883,7 @@ model TeamShiftSchedule {
   team_id       String
   shift_type_id String
   work_date     DateTime  @db.Date
+  leader_id     String?
   team          Team      @relation(fields: [team_id], references: [id])
   shift_type    ShiftType @relation(fields: [shift_type_id], references: [id])
   created_at    DateTime  @default(now())
@@ -3696,6 +3698,10 @@ model ShiftInstance {
   shift_type_id   String
   shift_type_ref  ShiftType @relation(fields: [shift_type_id], references: [id], onDelete: Restrict)
   shift_type      String   // legacy display snapshot; derived from ShiftType.name
+  team_id              String?
+  team                 Team?    @relation(fields: [team_id], references: [id], onDelete: SetNull)
+  leader_id            String?
+  team_override_reason String?
   shift_date      DateTime @db.Date
   opened_by       String
   closed_by       String?
@@ -3713,6 +3719,7 @@ model ShiftInstance {
   @@unique([company_id, shift_type_id, shift_date])
   @@index([company_id, shift_date])
   @@index([shift_type_id])
+  @@index([team_id])
   @@map("shift_instances")
 }
 


### PR DESCRIPTION
## Summary

- When opening a shift, auto-bind `team_id` and `leader_id` from `TeamShiftSchedule` when exactly one schedule matches `shift_type_id + work_date`
- Reject ambiguous schedules (multiple matches) unless caller provides `teamId` + `teamOverrideReason`
- Require `teamOverrideReason` when overriding the scheduled team or leader
- `TeamShiftSchedule` gains an optional `leader_id` field
- `ShiftInstance` gains `team_id`, `leader_id`, `team_override_reason` fields; historical records remain unbound
- Frontend: `ShiftDashboard` renders team name in shift card header; API types extended

## Changes

- `schema.prisma`: Team.shiftInstances reverse relation, TeamShiftSchedule.leader_id, ShiftInstance.team_id/leader_id/team_override_reason, index
- Migration: `20260502000100_shift_instance_team_binding`
- `team-shift.dto.ts` / `team-shift.service.ts`: persist `leader_id` on schedule create
- `create-shift-instance.dto.ts` / `shift-instance.service.ts`: schedule lookup, ambiguity guard, override reason enforcement
- `client/src/api/shift-instance.ts`: TeamSummary type, extended ShiftInstance and payload
- `client/src/views/shift/ShiftDashboard.vue`: displayTeam helper + card title

## Test plan

- [ ] `npx jest shift-instance.service.spec.ts team-shift.service.spec.ts --runInBand` → 15 tests pass
- [ ] `DATABASE_URL=... npx prisma validate` → schema valid
- [ ] `npm run build:client` → builds without errors
- [ ] Verify opening a shift with one schedule auto-binds the team
- [ ] Verify opening a shift with multiple schedules requires teamId + reason
- [ ] Verify overriding scheduled team requires teamOverrideReason