### PR TITLE
feat(GAP-406): document version lifecycle

### DIFF
--- a/client/components.d.ts
+++ b/client/components.d.ts
@@ -118,6 +118,7 @@ declare module 'vue' {
     LogDetailDialog: typeof import('./src/components/audit/LogDetailDialog.vue')['default']
     MarkdownEditor: typeof import('./src/components/documents/MarkdownEditor.vue')['default']
     MarkdownViewer: typeof import('./src/components/documents/MarkdownViewer.vue')['default']
+    MaterialBatchSelect: typeof import('./src/components/master-data/MaterialBatchSelect.vue')['default']
     MaterialSelect: typeof import('./src/components/master-data/MaterialSelect.vue')['default']
     MetricCard: typeof import('./src/components/monitoring/MetricCard.vue')['default']
     NumberField: typeof import('./src/components/fields/NumberField.vue')['default']

--- a/client/src/api/document-management.ts
+++ b/client/src/api/document-management.ts
@@ -1,8 +1,26 @@
 import request from './request';
 
+export interface DocumentRevisionItem {
+  id: string;
+  number: string;
+  title: string;
+  versionNo: number;
+  versionLabel: string;
+  status: string;
+  revisionStatus?: string | null;
+  revisionOfId?: string | null;
+  superseded_by_id?: string | null;
+  isCurrentVersion?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
 export interface DocumentVersionItem {
   id: string;
-  version: number;
+  version: number | string;
+  documentVersionNo?: number;
+  documentVersionLabel?: string;
+  snapshotVersionLabel?: string;
   fileName: string;
   fileSize: string | number;
   createdAt: string;
@@ -19,7 +37,7 @@ export interface VersionCompareResult {
 
 export const documentManagementApi = {
   getVersions(id: string) {
-    return request.get<{ versions: DocumentVersionItem[] }>(`/documents/${id}/versions`);
+    return request.get<{ revisions: DocumentRevisionItem[]; versions: DocumentVersionItem[] }>(`/documents/${id}/versions`);
   },
   compareVersions(id: string, v1: number | string, v2: number | string) {
     return request.get<VersionCompareResult>(`/documents/${id}/versions/${v1}/compare/${v2}`);

--- a/client/src/views/documents/DocumentDetail.vue
+++ b/client/src/views/documents/DocumentDetail.vue
@@ -290,13 +290,37 @@
       </section>
     </el-card>
 
+    <el-card class="version-card" v-if="revisionHistory.length">
+      <template #header>
+        <span>修订链</span>
+      </template>
+      <el-table :data="revisionHistory" stripe>
+        <el-table-column prop="versionLabel" label="受控版本" width="100" />
+        <el-table-column prop="title" label="文件名称" min-width="160" />
+        <el-table-column label="状态" width="120">
+          <template #default="{ row }">
+            <el-tag :type="getStatusType(row.status)">
+              {{ getStatusText(row.status) }}
+            </el-tag>
+          </template>
+        </el-table-column>
+        <el-table-column label="修订状态" width="140">
+          <template #default="{ row }">
+            {{ revisionStatusText(row) }}
+          </template>
+        </el-table-column>
+      </el-table>
+    </el-card>
+
     <el-card class="version-card" v-if="versionHistory.length">
       <template #header>
         <span>版本历史</span>
       </template>
       <el-table :data="versionHistory" stripe>
-        <el-table-column prop="version" label="版本" width="80">
-          <template #default="{ row }">v{{ row.version }}</template>
+        <el-table-column prop="version" label="版本" width="180">
+          <template #default="{ row }">
+            {{ row.documentVersionLabel || displayVersion }} / {{ row.snapshotVersionLabel || `文件快照 ${row.version}` }}
+          </template>
         </el-table-column>
         <el-table-column prop="fileName" label="文件名" min-width="150" />
         <el-table-column prop="fileSize" label="大小" width="100">
@@ -419,17 +443,10 @@ import MarkdownEditor from '@/components/documents/MarkdownEditor.vue';
 import MarkdownViewer from '@/components/documents/MarkdownViewer.vue';
 import { useUserStore } from '@/stores/user';
 import filePreviewApi from '@/api/file-preview';
-import { documentManagementApi } from '@/api/document-management';
+import { documentManagementApi, type DocumentRevisionItem, type DocumentVersionItem } from '@/api/document-management';
 import { documentControlApi, type DocumentReferenceHealthIssue, type DocumentReferenceHealthResult, type ReferenceHealthStatus } from '@/api/document-control';
 
-interface VersionItem {
-  id: string;
-  version: number;
-  fileName: string;
-  fileSize: string | number;
-  createdAt: string;
-  creator: { name: string } | null;
-}
+type VersionItem = DocumentVersionItem;
 
 interface Approval {
   id: string;
@@ -499,6 +516,7 @@ const router = useRouter();
 const userStore = useUserStore();
 const loading = ref(false);
 const document = ref<Document | null>(null);
+const revisionHistory = ref<DocumentRevisionItem[]>([]);
 const versionHistory = ref<VersionItem[]>([]);
 const showPreview = ref(false);
 const previewLoading = ref(false);
@@ -700,6 +718,13 @@ const referenceHealthActionText = (status: ReferenceHealthStatus): string => {
   return map[status];
 };
 
+const revisionStatusText = (row: DocumentRevisionItem): string => {
+  if (row.isCurrentVersion || row.revisionStatus === 'current') return '当前有效';
+  if (row.revisionStatus === 'revision_draft') return '修订草稿';
+  if (row.revisionStatus === 'superseded' || row.superseded_by_id) return '已被替代';
+  return row.revisionStatus || '-';
+};
+
 const getStatusType = (status: string): string => {
   const map: Record<string, string> = {
     draft: 'info',
@@ -747,9 +772,11 @@ const fetchData = async () => {
 const fetchVersionHistory = async () => {
   try {
     const res = await documentManagementApi.getVersions(String(route.params.id));
+    revisionHistory.value = res.revisions || [];
     versionHistory.value = res.versions || [];
   } catch (error) {
-    // 版本历史获取失败不影响主流程
+    revisionHistory.value = [];
+    versionHistory.value = [];
   }
 };
 

--- a/client/src/views/documents/__tests__/DocumentDetail.spec.ts
+++ b/client/src/views/documents/__tests__/DocumentDetail.spec.ts
@@ -131,7 +131,7 @@ describe('DocumentDetail', () => {
       ],
     });
     mockGet.mockImplementation((url: string) => {
-      if (url.includes('/versions')) return Promise.resolve([]);
+      if (url.includes('/versions')) return Promise.resolve({ revisions: [], versions: [] });
       return Promise.resolve(mockDocument);
     });
   });
@@ -307,10 +307,35 @@ describe('DocumentDetail', () => {
     expect((c.vm as any).document.sourceReferences).toHaveLength(1);
   });
 
+  it('renders controlled revision chain and legacy file snapshot labels', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/versions')) {
+        return Promise.resolve({
+          revisions: [
+            { id: 'doc-v2', title: 'SOP', number: 'CX-01', versionNo: 2, versionLabel: 'V2', status: 'effective', revisionStatus: 'current', isCurrentVersion: true },
+            { id: 'doc-v1', title: 'SOP', number: 'CX-01', versionNo: 1, versionLabel: 'V1', status: 'superseded', revisionStatus: 'superseded', superseded_by_id: 'doc-v2' },
+          ],
+          versions: [
+            { id: 'snapshot-1', version: '2.0', documentVersionLabel: 'V2', snapshotVersionLabel: '文件快照 2.0', fileName: 'old.pdf', fileSize: 100, createdAt: '2026-05-02T00:00:00.000Z', creator: { name: '文控员' } },
+          ],
+        });
+      }
+      return Promise.resolve(mockDocument);
+    });
+    const c = w();
+    await flushPromises();
+
+    expect(c.text()).toContain('修订链');
+    expect(c.text()).toContain('V2');
+    expect(c.text()).toContain('V1');
+    expect(c.text()).toContain('文件快照 2.0');
+  });
+
   it('shows version action buttons for historical versions', async () => {
     mockGet.mockImplementation((url: string) => {
       if (url.endsWith('/versions')) {
         return Promise.resolve({
+          revisions: [],
           versions: [
             {
               id: 'v1',
@@ -341,6 +366,7 @@ describe('DocumentDetail', () => {
       }
       if (url.endsWith('/versions')) {
         return Promise.resolve({
+          revisions: [],
           versions: [
             {
               id: 'v1',

--- a/server/src/modules/document/document.service.spec.ts
+++ b/server/src/modules/document/document.service.spec.ts
@@ -241,6 +241,7 @@ describe('document status compatibility', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    prisma.$transaction.mockImplementation(async (callback: (tx: typeof prisma) => Promise<unknown>) => callback(prisma));
     const module = await Test.createTestingModule({
       providers: [
         DocumentService,
@@ -303,6 +304,40 @@ describe('document status compatibility', () => {
       where: { id: 'doc1' },
       data: expect.objectContaining({ status: 'effective' }),
     });
+  });
+
+  it('supersedes the previous effective document when approving a revision draft', async () => {
+    const pendingRevision = {
+      id: 'doc-v2',
+      number: 'CX-01',
+      title: '程序文件',
+      status: 'pending',
+      creatorId: 'creator-1',
+      revisionOfId: 'doc-v1',
+      lineage_key: 'CX-01',
+      deletedAt: null,
+    };
+    prisma.document.findUnique.mockResolvedValue(pendingRevision);
+    prisma.approval.findFirst.mockResolvedValue({ id: 'approval-1', documentId: 'doc-v2', approverId: 'admin-1', status: 'pending' });
+    prisma.user.findUnique
+      .mockResolvedValueOnce({ id: 'admin-1', role: 'admin' })
+      .mockResolvedValueOnce({ id: 'creator-1', role: 'user' });
+    prisma.document.findFirst.mockResolvedValue({ id: 'doc-v1', number: 'CX-01', status: 'effective', lineage_key: 'CX-01' });
+    prisma.approval.update.mockResolvedValue({ id: 'approval-1', status: 'approved' });
+    prisma.document.update
+      .mockResolvedValueOnce({ id: 'doc-v2', status: 'effective', revisionStatus: 'current' })
+      .mockResolvedValueOnce({ id: 'doc-v1', status: 'superseded', revisionStatus: 'superseded', superseded_by_id: 'doc-v2' });
+
+    await service.approve('doc-v2', 'approved', '通过', 'admin-1');
+
+    expect(prisma.document.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'doc-v1' },
+      data: expect.objectContaining({
+        status: 'superseded',
+        revisionStatus: 'superseded',
+        superseded_by_id: 'doc-v2',
+      }),
+    }));
   });
 
   it.each(['approved', 'effective'])('treats %s list filter as effective-compatible', async (status) => {
@@ -592,6 +627,7 @@ describe('document revision draft', () => {
     },
     approval: { findFirst: jest.fn(), update: jest.fn() },
     department: { findUnique: jest.fn() },
+    documentVersion: { findMany: jest.fn() },
     pendingNumber: { findFirst: jest.fn() },
     numberRule: { create: jest.fn(), update: jest.fn() },
     $transaction: jest.fn(),
@@ -664,6 +700,68 @@ describe('document revision draft', () => {
     }));
     expect(result.id).toBe('doc-v2');
     expect(result.versionLabel).toBe('V2');
+  });
+
+  it('returns controlled revision chain with Vn labels and legacy snapshot labels', async () => {
+    const currentDoc = {
+      id: 'doc-v2',
+      number: 'GRSS-PZ-ZD-08',
+      title: '原物料及产品放行制度',
+      level: 3,
+      versionNo: 2,
+      versionLabel: 'V2',
+      version: '2.0',
+      status: 'effective',
+      revisionStatus: 'current',
+      revisionOfId: 'doc-v1',
+      superseded_by_id: null,
+      lineage_key: 'GRSS-PZ-ZD-08',
+      creatorId: 'user-1',
+      deletedAt: null,
+    };
+    prisma.document.findUnique.mockResolvedValue(currentDoc);
+    prisma.document.findMany.mockResolvedValue([
+      { ...currentDoc },
+      {
+        ...currentDoc,
+        id: 'doc-v1',
+        versionNo: 1,
+        versionLabel: 'V1',
+        version: '1.0',
+        status: 'superseded',
+        revisionStatus: 'superseded',
+        revisionOfId: null,
+        superseded_by_id: 'doc-v2',
+      },
+    ]);
+    prisma.documentVersion.findMany.mockResolvedValue([
+      {
+        id: 'snapshot-1',
+        documentId: 'doc-v2',
+        version: { toString: () => '2.0' },
+        filePath: 'documents/v2-old.pdf',
+        fileName: '放行制度-v2-old.pdf',
+        fileSize: 1024,
+        creatorId: 'user-1',
+        creator: { id: 'user-1', name: '文控员' },
+        createdAt: new Date('2026-05-02T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await service.getVersionHistory('doc-v2', 'user-1', 'admin');
+
+    expect(result.revisions).toEqual([
+      expect.objectContaining({ id: 'doc-v2', versionNo: 2, versionLabel: 'V2', isCurrentVersion: true }),
+      expect.objectContaining({ id: 'doc-v1', versionNo: 1, versionLabel: 'V1', isCurrentVersion: false }),
+    ]);
+    expect(result.versions).toEqual([
+      expect.objectContaining({
+        id: 'snapshot-1',
+        version: '2.0',
+        documentVersionLabel: 'V2',
+        snapshotVersionLabel: '文件快照 2.0',
+      }),
+    ]);
   });
 });
 

--- a/server/src/modules/document/document.service.ts
+++ b/server/src/modules/document/document.service.ts
@@ -602,6 +602,38 @@ export class DocumentService {
     return { list: convertBigIntToNumber(enrichedList), total, page, limit };
   }
 
+  private async supersedePreviousEffectiveRevision(
+    tx: PrismaService | Prisma.TransactionClient,
+    document: { id: string; number: string; lineage_key?: string | null; revisionOfId?: string | null },
+  ) {
+    if (!document.revisionOfId) return;
+
+    const lineageKey = document.lineage_key ?? document.number;
+    const previous = await tx.document.findFirst({
+      where: {
+        id: { not: document.id },
+        deletedAt: null,
+        status: { in: [...EFFECTIVE_COMPAT_STATUSES] },
+        OR: [
+          { lineage_key: lineageKey } as any,
+          { id: document.revisionOfId },
+          { number: document.number },
+        ],
+      },
+    });
+
+    if (!previous) return;
+
+    await tx.document.update({
+      where: { id: previous.id },
+      data: {
+        status: 'superseded',
+        revisionStatus: 'superseded',
+        superseded_by_id: document.id,
+      } as any,
+    });
+  }
+
   async approve(id: string, status: string, comment: string | undefined, approverId: string) {
     const document = await this.findOne(id, approverId, 'leader');
 
@@ -651,24 +683,37 @@ export class DocumentService {
       );
     }
 
-    // 更新待处理的审批记录状态
-    await this.prisma.approval.update({
-      where: { id: pendingApproval.id },
-      data: {
-        status: status === 'approved' ? 'approved' : 'rejected',
-        comment: comment ?? null,
-      },
-    });
+    const result = await this.prisma.$transaction(async (tx) => {
+      await tx.approval.update({
+        where: { id: pendingApproval.id },
+        data: {
+          status: status === 'approved' ? 'approved' : 'rejected',
+          comment: comment ?? null,
+        },
+      });
 
-    const result = await this.prisma.document.update({
-      where: { id },
-      data: {
-        status: status === 'approved'
-          ? CANONICAL_DOCUMENT_STATUS.EFFECTIVE
-          : CANONICAL_DOCUMENT_STATUS.REJECTED,
-        approverId,
-        approvedAt: new Date(),
-      },
+      const updated = await tx.document.update({
+        where: { id },
+        data: {
+          status: status === 'approved'
+            ? CANONICAL_DOCUMENT_STATUS.EFFECTIVE
+            : CANONICAL_DOCUMENT_STATUS.REJECTED,
+          revisionStatus: status === 'approved' ? 'current' : (document as any).revisionStatus,
+          approverId,
+          approvedAt: new Date(),
+        } as any,
+      });
+
+      if (status === 'approved') {
+        await this.supersedePreviousEffectiveRevision(tx, {
+          id,
+          number: document.number,
+          lineage_key: (document as any).lineage_key,
+          revisionOfId: (document as any).revisionOfId,
+        });
+      }
+
+      return updated;
     });
 
     // 发送通知给文档创建人
@@ -706,20 +751,91 @@ export class DocumentService {
     return convertBigIntToNumber(result);
   }
 
+  private snapshotLabel(version: unknown): string {
+    const value =
+      typeof version === 'object' &&
+      version !== null &&
+      typeof (version as { toString?: unknown }).toString === 'function'
+        ? (version as { toString: () => string }).toString()
+        : String(version);
+    return `文件快照 ${value}`;
+  }
+
   async getVersionHistory(id: string, userId: string, role: string) {
-    const document = await this.findOne(id, userId, role);
+    const document = (await this.findOne(id, userId, role)) as any;
+    const lineageKey = document.lineage_key ?? document.number;
 
-    const versions = await this.prisma.documentVersion.findMany({
-      where: { documentId: id },
-      orderBy: { createdAt: 'desc' },
-      include: {
-        creator: {
-          select: { id: true, name: true },
+    const [revisionRows, versionRows] = await Promise.all([
+      this.prisma.document.findMany({
+        where: {
+          deletedAt: null,
+          OR: [
+            { id },
+            { revisionOfId: id },
+            { lineage_key: lineageKey },
+            { number: document.number },
+          ] as any,
         },
-      },
-    }) as unknown as any[];
+        orderBy: [{ versionNo: 'desc' }, { createdAt: 'desc' }],
+        select: {
+          id: true,
+          number: true,
+          title: true,
+          version: true,
+          versionNo: true,
+          status: true,
+          revisionStatus: true,
+          revisionOfId: true,
+          superseded_by_id: true,
+          lineage_key: true,
+          createdAt: true,
+          updatedAt: true,
+        } as any,
+      }) as unknown as any[],
+      this.prisma.documentVersion.findMany({
+        where: { documentId: id },
+        orderBy: { createdAt: 'desc' },
+        include: {
+          creator: {
+            select: { id: true, name: true },
+          },
+        },
+      }) as unknown as any[],
+    ]);
 
-    return { document, versions: convertBigIntToNumber(versions) };
+    const seenRevisionIds = new Set<string>();
+    const revisions = revisionRows
+      .filter((row) => {
+        if (seenRevisionIds.has(row.id)) return false;
+        seenRevisionIds.add(row.id);
+        return true;
+      })
+      .map((row) => {
+        const decorated = withDocumentVersionLabel(row);
+        return { ...decorated, isCurrentVersion: row.revisionStatus === 'current' };
+      });
+
+    const versions = versionRows.map((row) => {
+      const versionStr =
+        row.version != null &&
+        typeof row.version === 'object' &&
+        typeof (row.version as { toString?: unknown }).toString === 'function'
+          ? (row.version as { toString: () => string }).toString()
+          : String(row.version);
+      return {
+        ...row,
+        version: versionStr,
+        documentVersionNo: document.versionNo,
+        documentVersionLabel: document.versionLabel,
+        snapshotVersionLabel: this.snapshotLabel(row.version),
+      };
+    });
+
+    return {
+      document,
+      revisions: convertBigIntToNumber(revisions),
+      versions: convertBigIntToNumber(versions),
+    };
   }
 
   async deactivate(id: string, userId: string, role: string) {


### PR DESCRIPTION
## Summary

- Extends `getVersionHistory()` to return a controlled `revisions` chain (with `Vn` labels) alongside legacy `versions` file snapshots
- Adds `supersedePreviousEffectiveRevision()` and wraps `approve()` in a `$transaction` so approving a revision draft atomically supersedes the prior effective document in the same lineage
- Updates `DocumentVersionItem` and adds `DocumentRevisionItem` API types; updates `getVersions()` return shape
- Renders a new "修订链" card in `DocumentDetail.vue` with controlled version labels and revision status text; decorates snapshot rows with `documentVersionLabel / snapshotVersionLabel`

## Test plan

- [x] `document.service.spec.ts` — 51 tests pass (new: revision chain labels + supersede on approve)
- [x] `document-lifecycle.service.spec.ts` — 8 tests pass (publish already has supersede fields, no changes needed)
- [x] `DocumentDetail.spec.ts` — 43 tests pass (new: renders revision chain and snapshot labels)
- [x] `npm run build:client` — passes

## Notes

- No schema or migration changes
- `document-lifecycle.service.ts` was read-only verified (publish already sets `superseded_by_id`, `revisionStatus: 'superseded'`)
- Only plan-specified files modified