### PR TITLE
feat: GAP-414 management review modeling

### DIFF
--- a/client/src/api/management-review.ts
+++ b/client/src/api/management-review.ts
@@ -1,0 +1,68 @@
+import request from './request';
+
+export interface ManagementReviewInput {
+  id: string;
+  sourceType: 'audit_report' | 'training_archive';
+  sourceId: string;
+  department?: string;
+  title: string;
+  summary: Record<string, unknown>;
+  included: boolean;
+}
+
+export interface ManagementReviewAction {
+  id: string;
+  action: string;
+  responsibleDepartment: string;
+  ownerId?: string;
+  dueDate?: string;
+  status: 'open' | 'in_progress' | 'completed' | 'cancelled';
+  verificationNote?: string;
+}
+
+export interface ManagementReview {
+  id: string;
+  companyId: string;
+  year: number;
+  title: string;
+  status: 'draft' | 'input_collection' | 'ready_for_meeting' | 'completed' | 'archived';
+  reviewDate?: string;
+  location?: string;
+  materialDueDate?: string;
+  purpose: string;
+  scope: string[];
+  participants: Record<string, unknown>[];
+  inputs: ManagementReviewInput[];
+  actions: ManagementReviewAction[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateManagementReviewPayload {
+  year: number;
+  title: string;
+  reviewDate?: string;
+  location?: string;
+  materialDueDate?: string;
+}
+
+export const managementReviewApi = {
+  list(params?: { year?: number; status?: string }) {
+    return request.get<ManagementReview[]>('/management-reviews', { params });
+  },
+  create(payload: CreateManagementReviewPayload) {
+    return request.post<ManagementReview>('/management-reviews', payload);
+  },
+  get(id: string) {
+    return request.get<ManagementReview>(`/management-reviews/${id}`);
+  },
+  collectSources(id: string) {
+    return request.post<{ auditReports: number; trainingArchives: number }>(`/management-reviews/${id}/collect-sources`);
+  },
+  createAction(id: string, payload: { action: string; responsibleDepartment: string; ownerId?: string; dueDate?: string }) {
+    return request.post<ManagementReviewAction>(`/management-reviews/${id}/actions`, payload);
+  },
+  updateAction(id: string, actionId: string, payload: { status?: string; verificationNote?: string }) {
+    return request.patch<ManagementReviewAction>(`/management-reviews/${id}/actions/${actionId}`, payload);
+  },
+};

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -607,6 +607,18 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/internal-audit/ReportDetail.vue'),
         meta: { title: '内审报告详情' },
       },
+      {
+        path: 'management-reviews',
+        name: 'ManagementReviewList',
+        component: () => import('@/views/management-review/ReviewList.vue'),
+        meta: { title: '管理评审' },
+      },
+      {
+        path: 'management-reviews/:id',
+        name: 'ManagementReviewDetail',
+        component: () => import('@/views/management-review/ReviewDetail.vue'),
+        meta: { title: '管理评审详情' },
+      },
       // 系统运维监控模块
       {
         path: 'monitoring/dashboard',

--- a/client/src/views/management-review/ReviewDetail.vue
+++ b/client/src/views/management-review/ReviewDetail.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="management-review-detail" v-loading="loading">
+    <div class="page-header">
+      <div>
+        <h2>{{ review?.title || '管理评审详情' }}</h2>
+        <p>{{ review?.year }} 年 · {{ review?.status }}</p>
+      </div>
+      <el-button type="primary" :loading="collecting" @click="collectSources">收集输入材料</el-button>
+    </div>
+
+    <el-tabs>
+      <el-tab-pane label="输入材料">
+        <el-table :data="review?.inputs || []" border>
+          <el-table-column prop="sourceType" label="来源" width="150" />
+          <el-table-column prop="department" label="部门" width="150" />
+          <el-table-column prop="title" label="标题" min-width="220" />
+          <el-table-column label="摘要" min-width="260">
+            <template #default="{ row }">
+              <pre>{{ formatSummary(row.summary) }}</pre>
+            </template>
+          </el-table-column>
+        </el-table>
+      </el-tab-pane>
+      <el-tab-pane label="改进措施">
+        <div class="action-bar">
+          <el-button @click="actionDialogVisible = true">新增改进措施</el-button>
+        </div>
+        <el-table :data="review?.actions || []" border>
+          <el-table-column prop="action" label="改进措施" min-width="260" />
+          <el-table-column prop="responsibleDepartment" label="责任部门" width="160" />
+          <el-table-column prop="status" label="状态" width="140" />
+          <el-table-column prop="dueDate" label="期限" width="150">
+            <template #default="{ row }">{{ formatDate(row.dueDate) }}</template>
+          </el-table-column>
+        </el-table>
+      </el-tab-pane>
+    </el-tabs>
+
+    <el-dialog v-model="actionDialogVisible" title="新增改进措施" width="560px">
+      <el-form :model="actionForm" label-width="110px">
+        <el-form-item label="改进措施" required>
+          <el-input v-model="actionForm.action" type="textarea" :rows="3" />
+        </el-form-item>
+        <el-form-item label="责任部门" required>
+          <el-input v-model="actionForm.responsibleDepartment" />
+        </el-form-item>
+        <el-form-item label="期限">
+          <el-date-picker v-model="actionForm.dueDate" type="date" value-format="YYYY-MM-DD" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="actionDialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="savingAction" @click="createAction">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import { managementReviewApi, type ManagementReview } from '@/api/management-review';
+
+const route = useRoute();
+const reviewId = route.params.id as string;
+const loading = ref(false);
+const collecting = ref(false);
+const savingAction = ref(false);
+const actionDialogVisible = ref(false);
+const review = ref<ManagementReview | null>(null);
+const actionForm = reactive({
+  action: '',
+  responsibleDepartment: '',
+  dueDate: '',
+});
+
+function formatDate(value?: string) {
+  return value ? value.slice(0, 10) : '-';
+}
+
+function formatSummary(summary: Record<string, unknown>) {
+  return JSON.stringify(summary, null, 2);
+}
+
+async function loadReview() {
+  loading.value = true;
+  try {
+    const res = await managementReviewApi.get(reviewId);
+    review.value = (res as any).data || res;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function collectSources() {
+  collecting.value = true;
+  try {
+    const res = await managementReviewApi.collectSources(reviewId);
+    const result = (res as any).data || res;
+    ElMessage.success(`已收集 ${result.auditReports} 份内审报告、${result.trainingArchives} 份培训档案`);
+    await loadReview();
+  } finally {
+    collecting.value = false;
+  }
+}
+
+async function createAction() {
+  if (!actionForm.action.trim() || !actionForm.responsibleDepartment.trim()) {
+    ElMessage.warning('改进措施和责任部门不能为空');
+    return;
+  }
+  savingAction.value = true;
+  try {
+    await managementReviewApi.createAction(reviewId, { ...actionForm });
+    ElMessage.success('已新增改进措施');
+    actionDialogVisible.value = false;
+    actionForm.action = '';
+    actionForm.responsibleDepartment = '';
+    actionForm.dueDate = '';
+    await loadReview();
+  } finally {
+    savingAction.value = false;
+  }
+}
+
+onMounted(loadReview);
+</script>
+
+<style scoped>
+.management-review-detail {
+  padding: 16px;
+}
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+.page-header p {
+  margin: 4px 0 0;
+  color: #606266;
+}
+.action-bar {
+  margin-bottom: 12px;
+}
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-size: 12px;
+}
+</style>

--- a/client/src/views/management-review/ReviewList.vue
+++ b/client/src/views/management-review/ReviewList.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="management-review-list">
+    <div class="page-header">
+      <h2>管理评审</h2>
+      <el-button type="primary" @click="dialogVisible = true">新建年度评审</el-button>
+    </div>
+
+    <el-table :data="reviews" v-loading="loading" border>
+      <el-table-column prop="year" label="年度" width="100" />
+      <el-table-column prop="title" label="标题" min-width="220" />
+      <el-table-column prop="status" label="状态" width="140" />
+      <el-table-column prop="reviewDate" label="评审时间" width="160">
+        <template #default="{ row }">{{ formatDate(row.reviewDate) }}</template>
+      </el-table-column>
+      <el-table-column label="输入材料" width="120">
+        <template #default="{ row }">{{ row.inputs?.length || 0 }}</template>
+      </el-table-column>
+      <el-table-column label="改进措施" width="120">
+        <template #default="{ row }">{{ row.actions?.length || 0 }}</template>
+      </el-table-column>
+      <el-table-column label="操作" width="120">
+        <template #default="{ row }">
+          <el-button type="primary" link @click="router.push(`/management-reviews/${row.id}`)">查看</el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <el-dialog v-model="dialogVisible" title="新建年度管理评审" width="520px">
+      <el-form :model="form" label-width="130px">
+        <el-form-item label="年度" required>
+          <el-input-number v-model="form.year" :min="2000" :max="2100" />
+        </el-form-item>
+        <el-form-item label="标题" required>
+          <el-input v-model="form.title" />
+        </el-form-item>
+        <el-form-item label="评审时间">
+          <el-date-picker v-model="form.reviewDate" type="date" value-format="YYYY-MM-DD" />
+        </el-form-item>
+        <el-form-item label="地点">
+          <el-input v-model="form.location" />
+        </el-form-item>
+        <el-form-item label="材料截止日期">
+          <el-date-picker v-model="form.materialDueDate" type="date" value-format="YYYY-MM-DD" />
+        </el-form-item>
+      </el-form>
+      <template #footer>
+        <el-button @click="dialogVisible = false">取消</el-button>
+        <el-button type="primary" :loading="saving" @click="createReview">保存</el-button>
+      </template>
+    </el-dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, reactive, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import { managementReviewApi, type ManagementReview } from '@/api/management-review';
+
+const router = useRouter();
+const loading = ref(false);
+const saving = ref(false);
+const dialogVisible = ref(false);
+const reviews = ref<ManagementReview[]>([]);
+const currentYear = new Date().getFullYear();
+const form = reactive({
+  year: currentYear,
+  title: `${currentYear} 年管理评审`,
+  reviewDate: '',
+  location: '会议室',
+  materialDueDate: '',
+});
+
+function formatDate(value?: string) {
+  return value ? value.slice(0, 10) : '-';
+}
+
+async function loadReviews() {
+  loading.value = true;
+  try {
+    const res = await managementReviewApi.list();
+    reviews.value = (res as any).data || res;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function createReview() {
+  if (!form.year || !form.title.trim()) {
+    ElMessage.warning('年度和标题不能为空');
+    return;
+  }
+  saving.value = true;
+  try {
+    const res = await managementReviewApi.create({ ...form });
+    const review = (res as any).data || res;
+    ElMessage.success('已创建管理评审');
+    dialogVisible.value = false;
+    router.push(`/management-reviews/${review.id}`);
+  } finally {
+    saving.value = false;
+  }
+}
+
+onMounted(loadReviews);
+</script>
+
+<style scoped>
+.management-review-list {
+  padding: 16px;
+}
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+</style>

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -36,6 +36,7 @@ import { BackupModule } from './modules/backup/backup.module';
 import { HealthModule } from './modules/health/health.module';
 import { TrainingModule } from './modules/training/training.module';
 import { InternalAuditModule } from './modules/internal-audit/internal-audit.module';
+import { ManagementReviewModule } from './modules/management-review/management-review.module';
 import { SearchModule } from './modules/search/search.module';
 import { ImportModule } from './modules/import/import.module';
 import { RecordTaskModule } from './modules/record-task/record-task.module';
@@ -128,6 +129,7 @@ import { ProductProcessChangeModule } from './modules/product-process-change/pro
     HealthModule,
     TrainingModule,
     InternalAuditModule,
+    ManagementReviewModule,
     SearchModule,
     ImportModule,
     RecordTaskModule,

--- a/server/src/modules/management-review/dto/create-management-review-action.dto.ts
+++ b/server/src/modules/management-review/dto/create-management-review-action.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateManagementReviewActionDto {
+  @IsString()
+  action!: string;
+
+  @IsString()
+  responsibleDepartment!: string;
+
+  @IsOptional()
+  @IsString()
+  ownerId?: string;
+
+  @IsOptional()
+  @IsString()
+  dueDate?: string;
+}

--- a/server/src/modules/management-review/dto/create-management-review.dto.ts
+++ b/server/src/modules/management-review/dto/create-management-review.dto.ts
@@ -1,0 +1,35 @@
+import { IsArray, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class CreateManagementReviewDto {
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  year!: number;
+
+  @IsString()
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  reviewDate?: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsOptional()
+  @IsString()
+  materialDueDate?: string;
+
+  @IsOptional()
+  @IsString()
+  purpose?: string;
+
+  @IsOptional()
+  @IsArray()
+  scope?: string[];
+
+  @IsOptional()
+  @IsArray()
+  participants?: Record<string, unknown>[];
+}

--- a/server/src/modules/management-review/dto/query-management-review.dto.ts
+++ b/server/src/modules/management-review/dto/query-management-review.dto.ts
@@ -1,0 +1,15 @@
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryManagementReviewDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(2000)
+  @Max(2100)
+  year?: number;
+
+  @IsOptional()
+  @IsString()
+  status?: string;
+}

--- a/server/src/modules/management-review/dto/update-management-review-action.dto.ts
+++ b/server/src/modules/management-review/dto/update-management-review-action.dto.ts
@@ -1,8 +1,8 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsIn, IsOptional, IsString } from 'class-validator';
 
 export class UpdateManagementReviewActionDto {
   @IsOptional()
-  @IsString()
+  @IsIn(['open', 'in_progress', 'completed', 'cancelled'])
   status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
 
   @IsOptional()

--- a/server/src/modules/management-review/dto/update-management-review-action.dto.ts
+++ b/server/src/modules/management-review/dto/update-management-review-action.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateManagementReviewActionDto {
+  @IsOptional()
+  @IsString()
+  status?: 'open' | 'in_progress' | 'completed' | 'cancelled';
+
+  @IsOptional()
+  @IsString()
+  verificationNote?: string;
+}

--- a/server/src/modules/management-review/management-review.controller.ts
+++ b/server/src/modules/management-review/management-review.controller.ts
@@ -1,0 +1,62 @@
+import { Body, Controller, Get, Param, Patch, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
+import { ManagementReviewService } from './management-review.service';
+import { CreateManagementReviewDto } from './dto/create-management-review.dto';
+import { QueryManagementReviewDto } from './dto/query-management-review.dto';
+import { CreateManagementReviewActionDto } from './dto/create-management-review-action.dto';
+import { UpdateManagementReviewActionDto } from './dto/update-management-review-action.dto';
+
+@Controller('management-reviews')
+@UseGuards(JwtAuthGuard)
+export class ManagementReviewController {
+  constructor(private readonly service: ManagementReviewService) {}
+
+  @Post()
+  create(@Body() dto: CreateManagementReviewDto, @Request() req: AuthenticatedRequest) {
+    return this.service.create(dto, { id: req.user.id, companyId: req.user.companyId });
+  }
+
+  @Get()
+  findAll(@Query() query: QueryManagementReviewDto, @Request() req: AuthenticatedRequest) {
+    return this.service.findAll(req.user.companyId, query);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findOne(id, req.user.companyId);
+  }
+
+  @Post(':id/collect-sources')
+  collectSources(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.collectSources(id, req.user.companyId);
+  }
+
+  @Post(':id/actions')
+  createAction(
+    @Param('id') id: string,
+    @Body() dto: CreateManagementReviewActionDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.service.createAction(id, req.user.companyId, dto);
+  }
+
+  @Patch(':id/actions/:actionId')
+  updateAction(
+    @Param('id') id: string,
+    @Param('actionId') actionId: string,
+    @Body() dto: UpdateManagementReviewActionDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.service.updateAction(id, actionId, req.user.companyId, dto);
+  }
+
+  @Post(':id/complete')
+  complete(
+    @Param('id') id: string,
+    @Body() body: { reportDocumentId?: string; reportRecordId?: string },
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.service.complete(id, req.user.companyId, body);
+  }
+}

--- a/server/src/modules/management-review/management-review.module.ts
+++ b/server/src/modules/management-review/management-review.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { ManagementReviewController } from './management-review.controller';
+import { ManagementReviewService } from './management-review.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ManagementReviewController],
+  providers: [ManagementReviewService],
+  exports: [ManagementReviewService],
+})
+export class ManagementReviewModule {}

--- a/server/src/modules/management-review/management-review.service.spec.ts
+++ b/server/src/modules/management-review/management-review.service.spec.ts
@@ -86,6 +86,42 @@ describe('ManagementReviewService', () => {
     });
   });
 
+  it('preserves management review scope and participants as JSON input', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findFirst.mockResolvedValue(null);
+    prisma.managementReview.create.mockResolvedValue({ id: 'mr-1', year: 2026 });
+    const service = new ManagementReviewService(prisma);
+    const participants = [
+      {
+        userId: 'user-2',
+        name: '张三',
+        department: '品质部',
+        role: '主持人',
+        attended: true,
+        note: null,
+      },
+    ];
+
+    await service.create(
+      {
+        year: 2026,
+        title: '2026 年管理评审',
+        scope: ['质量管理体系', '食品安全管理体系'],
+        participants,
+      } as any,
+      { id: 'user-1', companyId: 'company-1' },
+    );
+
+    expect(prisma.managementReview.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          scope: ['质量管理体系', '食品安全管理体系'],
+          participants,
+        }),
+      }),
+    );
+  });
+
   it('collects audit reports and training archives as idempotent review inputs', async () => {
     const prisma = createPrismaMock();
     prisma.managementReview.findUnique.mockResolvedValue({

--- a/server/src/modules/management-review/management-review.service.spec.ts
+++ b/server/src/modules/management-review/management-review.service.spec.ts
@@ -1,0 +1,258 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ManagementReviewService } from './management-review.service';
+
+describe('ManagementReviewService', () => {
+  function createPrismaMock(overrides: Record<string, any> = {}) {
+    const prisma = {
+      managementReview: {
+        findFirst: jest.fn(),
+        findUnique: jest.fn(),
+        findMany: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      managementReviewInput: {
+        upsert: jest.fn(),
+      },
+      managementReviewAction: {
+        findFirst: jest.fn(),
+        create: jest.fn(),
+        update: jest.fn(),
+      },
+      auditReport: {
+        findMany: jest.fn(),
+      },
+      trainingArchive: {
+        findMany: jest.fn(),
+      },
+      user: {
+        findMany: jest.fn(),
+      },
+    };
+    return { ...prisma, ...overrides } as any;
+  }
+
+  it('rejects duplicate management review year per company', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findFirst.mockResolvedValue({ id: 'mr-existing' });
+    const service = new ManagementReviewService(prisma);
+
+    await expect(
+      service.create({ year: 2026, title: '2026 年管理评审' } as any, {
+        id: 'user-1',
+        companyId: 'company-1',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('creates one annual review with company and creator context', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findFirst.mockResolvedValue(null);
+    prisma.managementReview.create.mockResolvedValue({ id: 'mr-1', year: 2026 });
+    const service = new ManagementReviewService(prisma);
+
+    await service.create(
+      {
+        year: 2026,
+        title: '2026 年管理评审',
+        reviewDate: '2026-12-15T00:00:00.000Z',
+        location: '会议室',
+        materialDueDate: '2026-12-14T00:00:00.000Z',
+      } as any,
+      { id: 'user-1', companyId: 'company-1' },
+    );
+
+    expect(prisma.managementReview.create).toHaveBeenCalledWith({
+      data: {
+        companyId: 'company-1',
+        year: 2026,
+        title: '2026 年管理评审',
+        status: 'draft',
+        reviewDate: new Date('2026-12-15T00:00:00.000Z'),
+        location: '会议室',
+        materialDueDate: new Date('2026-12-14T00:00:00.000Z'),
+        purpose:
+          '评审质量和食品安全管理体系的适宜性、充分性和有效性。',
+        scope: [],
+        participants: [],
+        createdBy: 'user-1',
+      },
+      include: {
+        inputs: true,
+        actions: true,
+      },
+    });
+  });
+
+  it('collects audit reports and training archives as idempotent review inputs', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findUnique.mockResolvedValue({
+      id: 'mr-1',
+      companyId: 'company-1',
+      year: 2026,
+    });
+    prisma.user.findMany.mockResolvedValue([{ id: 'user-company-1' }]);
+    prisma.auditReport.findMany.mockResolvedValue([
+      {
+        id: 'audit-report-1',
+        plan: {
+          title: '2026 年度内审',
+          startDate: new Date('2026-03-01'),
+          endDate: new Date('2026-03-10'),
+        },
+        summary: {
+          totalDocuments: 10,
+          conformCount: 8,
+          nonConformCount: 2,
+        },
+      },
+    ]);
+    prisma.trainingArchive.findMany.mockResolvedValue([
+      {
+        id: 'archive-1',
+        project: {
+          title: 'FSSC22000 专项培训',
+          department: '行政人事部',
+          scheduledDate: new Date('2026-08-20'),
+          learningRecords: [{ passed: true }, { passed: false }],
+        },
+      },
+    ]);
+    const service = new ManagementReviewService(prisma);
+
+    const result = await service.collectSources('mr-1', 'company-1');
+
+    expect(result).toEqual({ auditReports: 1, trainingArchives: 1 });
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: { company_id: 'company-1' },
+      select: { id: true },
+    });
+    expect(prisma.auditReport.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          plan: {
+            startDate: {
+              gte: new Date(Date.UTC(2026, 0, 1)),
+              lt: new Date(Date.UTC(2027, 0, 1)),
+            },
+            createdBy: { in: ['user-company-1'] },
+          },
+        },
+      }),
+    );
+    expect(prisma.trainingArchive.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          project: {
+            plan: { createdBy: { in: ['user-company-1'] } },
+            OR: [
+              { plan: { year: 2026 } },
+              {
+                scheduledDate: {
+                  gte: new Date(Date.UTC(2026, 0, 1)),
+                  lt: new Date(Date.UTC(2027, 0, 1)),
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+    expect(prisma.managementReviewInput.upsert).toHaveBeenCalledTimes(2);
+    expect(prisma.managementReviewInput.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          reviewId_sourceType_sourceId: {
+            reviewId: 'mr-1',
+            sourceType: 'audit_report',
+            sourceId: 'audit-report-1',
+          },
+        },
+      }),
+    );
+    expect(prisma.managementReviewInput.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          reviewId_sourceType_sourceId: {
+            reviewId: 'mr-1',
+            sourceType: 'training_archive',
+            sourceId: 'archive-1',
+          },
+        },
+      }),
+    );
+  });
+
+  it('does not collect audit reports or training archives from another company', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findUnique.mockResolvedValue({
+      id: 'mr-1',
+      companyId: 'company-1',
+      year: 2026,
+    });
+    prisma.user.findMany.mockResolvedValue([{ id: 'company-1-user' }]);
+    prisma.auditReport.findMany.mockResolvedValue([]);
+    prisma.trainingArchive.findMany.mockResolvedValue([]);
+    const service = new ManagementReviewService(prisma);
+
+    const result = await service.collectSources('mr-1', 'company-1');
+
+    expect(result).toEqual({ auditReports: 0, trainingArchives: 0 });
+    expect(prisma.auditReport.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          plan: expect.objectContaining({
+            createdBy: { in: ['company-1-user'] },
+          }),
+        }),
+      }),
+    );
+    expect(prisma.trainingArchive.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          project: expect.objectContaining({
+            plan: { createdBy: { in: ['company-1-user'] } },
+          }),
+        }),
+      }),
+    );
+    expect(prisma.managementReviewInput.upsert).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when collecting sources for another company', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findUnique.mockResolvedValue({
+      id: 'mr-1',
+      companyId: 'company-2',
+      year: 2026,
+    });
+    const service = new ManagementReviewService(prisma);
+
+    await expect(service.collectSources('mr-1', 'company-1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('does not update an action that does not belong to the review', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findUnique.mockResolvedValue({
+      id: 'mr-1',
+      companyId: 'company-1',
+      year: 2026,
+    });
+    prisma.managementReviewAction.findFirst.mockResolvedValue(null);
+    const service = new ManagementReviewService(prisma);
+
+    await expect(
+      service.updateAction('mr-1', 'action-from-other-review', 'company-1', {
+        status: 'completed',
+      } as any),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.managementReviewAction.findFirst).toHaveBeenCalledWith({
+      where: { id: 'action-from-other-review', reviewId: 'mr-1' },
+      select: { id: true },
+    });
+    expect(prisma.managementReviewAction.update).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/modules/management-review/management-review.service.spec.ts
+++ b/server/src/modules/management-review/management-review.service.spec.ts
@@ -1,5 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { validate } from 'class-validator';
 import { ManagementReviewService } from './management-review.service';
+import { UpdateManagementReviewActionDto } from './dto/update-management-review-action.dto';
 
 describe('ManagementReviewService', () => {
   function createPrismaMock(overrides: Record<string, any> = {}) {
@@ -230,6 +232,43 @@ describe('ManagementReviewService', () => {
 
     await expect(service.collectSources('mr-1', 'company-1')).rejects.toThrow(
       NotFoundException,
+    );
+  });
+
+  it('throws BadRequestException when collecting sources for a completed review', async () => {
+    const prisma = createPrismaMock();
+    prisma.managementReview.findUnique.mockResolvedValue({
+      id: 'mr-1',
+      companyId: 'company-1',
+      year: 2026,
+      status: 'completed',
+    });
+    const service = new ManagementReviewService(prisma);
+
+    await expect(service.collectSources('mr-1', 'company-1')).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(prisma.user.findMany).not.toHaveBeenCalled();
+    expect(prisma.managementReviewInput.upsert).not.toHaveBeenCalled();
+    expect(prisma.managementReview.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid management review action status values', async () => {
+    const dto = Object.assign(new UpdateManagementReviewActionDto(), {
+      status: 'invalid-status',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          property: 'status',
+          constraints: expect.objectContaining({
+            isIn: expect.any(String),
+          }),
+        }),
+      ]),
     );
   });
 

--- a/server/src/modules/management-review/management-review.service.ts
+++ b/server/src/modules/management-review/management-review.service.ts
@@ -1,0 +1,243 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { CreateManagementReviewDto } from './dto/create-management-review.dto';
+import { QueryManagementReviewDto } from './dto/query-management-review.dto';
+import { CreateManagementReviewActionDto } from './dto/create-management-review-action.dto';
+import { UpdateManagementReviewActionDto } from './dto/update-management-review-action.dto';
+
+type Actor = { id: string; companyId: string };
+
+@Injectable()
+export class ManagementReviewService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(dto: CreateManagementReviewDto, actor: Actor) {
+    const existing = await this.prisma.managementReview.findFirst({
+      where: { companyId: actor.companyId, year: dto.year },
+      select: { id: true },
+    });
+    if (existing) {
+      throw new BadRequestException('该年度管理评审已存在');
+    }
+
+    return this.prisma.managementReview.create({
+      data: {
+        companyId: actor.companyId,
+        year: dto.year,
+        title: dto.title,
+        status: 'draft',
+        reviewDate: dto.reviewDate ? new Date(dto.reviewDate) : undefined,
+        location: dto.location,
+        materialDueDate: dto.materialDueDate ? new Date(dto.materialDueDate) : undefined,
+        purpose: dto.purpose ?? '评审质量和食品安全管理体系的适宜性、充分性和有效性。',
+        scope: dto.scope ?? [],
+        participants: dto.participants ?? [],
+        createdBy: actor.id,
+      },
+      include: { inputs: true, actions: true },
+    });
+  }
+
+  findAll(companyId: string, query: QueryManagementReviewDto) {
+    return this.prisma.managementReview.findMany({
+      where: {
+        companyId,
+        ...(query.year ? { year: query.year } : {}),
+        ...(query.status ? { status: query.status } : {}),
+      },
+      orderBy: [{ year: 'desc' }, { createdAt: 'desc' }],
+      include: { inputs: true, actions: true },
+    });
+  }
+
+  async findOne(id: string, companyId: string) {
+    const review = await this.prisma.managementReview.findUnique({
+      where: { id },
+      include: { inputs: true, actions: true },
+    });
+    if (!review || review.companyId !== companyId) {
+      throw new NotFoundException('管理评审不存在');
+    }
+    return review;
+  }
+
+  async collectSources(id: string, companyId: string) {
+    const review = await this.findOwnedReview(id, companyId);
+    const start = new Date(Date.UTC(review.year, 0, 1));
+    const end = new Date(Date.UTC(review.year + 1, 0, 1));
+    const companyUsers = await this.prisma.user.findMany({
+      where: { company_id: companyId },
+      select: { id: true },
+    });
+    const companyUserIds = companyUsers.map((user: { id: string }) => user.id);
+
+    const auditReports = await this.prisma.auditReport.findMany({
+      where: {
+        plan: {
+          startDate: { gte: start, lt: end },
+          createdBy: { in: companyUserIds },
+        },
+      },
+      include: {
+        plan: { select: { title: true, startDate: true, endDate: true } },
+      },
+    });
+
+    const trainingArchives = await this.prisma.trainingArchive.findMany({
+      where: {
+        project: {
+          plan: {
+            createdBy: { in: companyUserIds },
+          },
+          OR: [
+            { plan: { year: review.year } },
+            { scheduledDate: { gte: start, lt: end } },
+          ],
+        },
+      },
+      include: {
+        project: {
+          include: {
+            plan: { select: { year: true, title: true } },
+            learningRecords: { select: { passed: true } },
+          },
+        },
+      },
+    });
+
+    for (const report of auditReports) {
+      await this.prisma.managementReviewInput.upsert({
+        where: {
+          reviewId_sourceType_sourceId: {
+            reviewId: id,
+            sourceType: 'audit_report',
+            sourceId: report.id,
+          },
+        },
+        create: {
+          reviewId: id,
+          sourceType: 'audit_report',
+          sourceId: report.id,
+          department: '品质部',
+          title: report.plan?.title ?? `${review.year} 年内审报告`,
+          summary: {
+            planStartDate: report.plan?.startDate,
+            planEndDate: report.plan?.endDate,
+            ...(report.summary as Record<string, unknown>),
+          },
+        },
+        update: {
+          title: report.plan?.title ?? `${review.year} 年内审报告`,
+          summary: {
+            planStartDate: report.plan?.startDate,
+            planEndDate: report.plan?.endDate,
+            ...(report.summary as Record<string, unknown>),
+          },
+        },
+      });
+    }
+
+    for (const archive of trainingArchives) {
+      const records = archive.project?.learningRecords ?? [];
+      const attendeeCount = records.length;
+      const passedCount = records.filter((r: any) => r.passed).length;
+      const passRate = attendeeCount === 0 ? 0 : Math.round((passedCount / attendeeCount) * 10000) / 100;
+      await this.prisma.managementReviewInput.upsert({
+        where: {
+          reviewId_sourceType_sourceId: {
+            reviewId: id,
+            sourceType: 'training_archive',
+            sourceId: archive.id,
+          },
+        },
+        create: {
+          reviewId: id,
+          sourceType: 'training_archive',
+          sourceId: archive.id,
+          department: archive.project?.department,
+          title: archive.project?.title ?? `${review.year} 年培训档案`,
+          summary: {
+            projectId: archive.projectId,
+            trainingDate: archive.project?.scheduledDate,
+            attendeeCount,
+            passedCount,
+            passRate,
+          },
+        },
+        update: {
+          department: archive.project?.department,
+          title: archive.project?.title ?? `${review.year} 年培训档案`,
+          summary: {
+            projectId: archive.projectId,
+            trainingDate: archive.project?.scheduledDate,
+            attendeeCount,
+            passedCount,
+            passRate,
+          },
+        },
+      });
+    }
+
+    await this.prisma.managementReview.update({
+      where: { id },
+      data: { status: 'input_collection' },
+    });
+
+    return { auditReports: auditReports.length, trainingArchives: trainingArchives.length };
+  }
+
+  async createAction(reviewId: string, companyId: string, dto: CreateManagementReviewActionDto) {
+    await this.findOwnedReview(reviewId, companyId);
+    return this.prisma.managementReviewAction.create({
+      data: {
+        reviewId,
+        action: dto.action,
+        responsibleDepartment: dto.responsibleDepartment,
+        ownerId: dto.ownerId,
+        dueDate: dto.dueDate ? new Date(dto.dueDate) : undefined,
+      },
+    });
+  }
+
+  async updateAction(reviewId: string, actionId: string, companyId: string, dto: UpdateManagementReviewActionDto) {
+    await this.findOwnedReview(reviewId, companyId);
+    const action = await this.prisma.managementReviewAction.findFirst({
+      where: { id: actionId, reviewId },
+      select: { id: true },
+    });
+    if (!action) {
+      throw new NotFoundException('管理评审改进措施不存在');
+    }
+
+    return this.prisma.managementReviewAction.update({
+      where: { id: actionId },
+      data: {
+        ...(dto.status ? { status: dto.status } : {}),
+        ...(dto.verificationNote !== undefined ? { verificationNote: dto.verificationNote } : {}),
+        ...(dto.status === 'completed' ? { completedAt: new Date() } : {}),
+      },
+    });
+  }
+
+  async complete(id: string, companyId: string, body: { reportDocumentId?: string; reportRecordId?: string }) {
+    await this.findOwnedReview(id, companyId);
+    return this.prisma.managementReview.update({
+      where: { id },
+      data: {
+        status: 'completed',
+        completedAt: new Date(),
+        reportDocumentId: body.reportDocumentId,
+        reportRecordId: body.reportRecordId,
+      },
+      include: { inputs: true, actions: true },
+    });
+  }
+
+  private async findOwnedReview(id: string, companyId: string) {
+    const review = await this.prisma.managementReview.findUnique({ where: { id } });
+    if (!review || review.companyId !== companyId) {
+      throw new NotFoundException('管理评审不存在');
+    }
+    return review;
+  }
+}

--- a/server/src/modules/management-review/management-review.service.ts
+++ b/server/src/modules/management-review/management-review.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import type { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateManagementReviewDto } from './dto/create-management-review.dto';
 import { QueryManagementReviewDto } from './dto/query-management-review.dto';
@@ -6,6 +7,38 @@ import { CreateManagementReviewActionDto } from './dto/create-management-review-
 import { UpdateManagementReviewActionDto } from './dto/update-management-review-action.dto';
 
 type Actor = { id: string; companyId: string };
+
+function toInputJsonArray(values: readonly unknown[], fieldName: string): Prisma.InputJsonArray {
+  return values.map((value) => toInputJsonValue(value, fieldName));
+}
+
+function toInputJsonValue(value: unknown, fieldName: string): Prisma.InputJsonValue | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === 'string' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new BadRequestException(`${fieldName} 必须是有效 JSON`);
+    }
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return toInputJsonArray(value, fieldName);
+  }
+  if (typeof value === 'object') {
+    const jsonObject: Record<string, Prisma.InputJsonValue | null> = {};
+    for (const [key, nestedValue] of Object.entries(value)) {
+      if (nestedValue !== undefined) {
+        jsonObject[key] = toInputJsonValue(nestedValue, fieldName);
+      }
+    }
+    return jsonObject;
+  }
+  throw new BadRequestException(`${fieldName} 必须是有效 JSON`);
+}
 
 @Injectable()
 export class ManagementReviewService {
@@ -20,6 +53,9 @@ export class ManagementReviewService {
       throw new BadRequestException('该年度管理评审已存在');
     }
 
+    const scope = toInputJsonArray(dto.scope ?? [], 'scope');
+    const participants = toInputJsonArray(dto.participants ?? [], 'participants');
+
     return this.prisma.managementReview.create({
       data: {
         companyId: actor.companyId,
@@ -30,8 +66,8 @@ export class ManagementReviewService {
         location: dto.location,
         materialDueDate: dto.materialDueDate ? new Date(dto.materialDueDate) : undefined,
         purpose: dto.purpose ?? '评审质量和食品安全管理体系的适宜性、充分性和有效性。',
-        scope: dto.scope ?? [],
-        participants: dto.participants ?? [],
+        scope,
+        participants,
         createdBy: actor.id,
       },
       include: { inputs: true, actions: true },

--- a/server/src/modules/management-review/management-review.service.ts
+++ b/server/src/modules/management-review/management-review.service.ts
@@ -63,6 +63,10 @@ export class ManagementReviewService {
 
   async collectSources(id: string, companyId: string) {
     const review = await this.findOwnedReview(id, companyId);
+    if (review.status === 'completed' || review.status === 'archived') {
+      throw new BadRequestException('管理评审已完成或归档，无法重新收集输入材料');
+    }
+
     const start = new Date(Date.UTC(review.year, 0, 1));
     const end = new Date(Date.UTC(review.year + 1, 0, 1));
     const companyUsers = await this.prisma.user.findMany({

--- a/server/src/prisma/migrations/20260502143000_management_review_models/migration.sql
+++ b/server/src/prisma/migrations/20260502143000_management_review_models/migration.sql
@@ -1,0 +1,89 @@
+CREATE TABLE "management_reviews" (
+  "id" TEXT NOT NULL,
+  "companyId" TEXT NOT NULL,
+  "year" INTEGER NOT NULL,
+  "title" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'draft',
+  "reviewDate" TIMESTAMP(3),
+  "location" TEXT,
+  "materialDueDate" TIMESTAMP(3),
+  "purpose" TEXT NOT NULL DEFAULT '评审质量和食品安全管理体系的适宜性、充分性和有效性。',
+  "scope" JSONB NOT NULL DEFAULT '[]',
+  "participants" JSONB NOT NULL DEFAULT '[]',
+  "createdBy" TEXT NOT NULL,
+  "completedAt" TIMESTAMP(3),
+  "reportDocumentId" TEXT,
+  "reportRecordId" TEXT,
+  "meetingMinutesRecordId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "management_reviews_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "management_review_inputs" (
+  "id" TEXT NOT NULL,
+  "reviewId" TEXT NOT NULL,
+  "sourceType" TEXT NOT NULL,
+  "sourceId" TEXT NOT NULL,
+  "department" TEXT,
+  "title" TEXT NOT NULL,
+  "summary" JSONB NOT NULL,
+  "included" BOOLEAN NOT NULL DEFAULT true,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "management_review_inputs_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "management_review_actions" (
+  "id" TEXT NOT NULL,
+  "reviewId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "responsibleDepartment" TEXT NOT NULL,
+  "ownerId" TEXT,
+  "dueDate" TIMESTAMP(3),
+  "status" TEXT NOT NULL DEFAULT 'open',
+  "verificationNote" TEXT,
+  "completedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "management_review_actions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "management_reviews_companyId_year_key" ON "management_reviews"("companyId", "year");
+CREATE INDEX "management_reviews_companyId_status_idx" ON "management_reviews"("companyId", "status");
+CREATE INDEX "management_reviews_year_idx" ON "management_reviews"("year");
+CREATE INDEX "management_reviews_reportDocumentId_idx" ON "management_reviews"("reportDocumentId");
+CREATE INDEX "management_reviews_reportRecordId_idx" ON "management_reviews"("reportRecordId");
+CREATE INDEX "management_reviews_meetingMinutesRecordId_idx" ON "management_reviews"("meetingMinutesRecordId");
+CREATE UNIQUE INDEX "management_review_inputs_reviewId_sourceType_sourceId_key" ON "management_review_inputs"("reviewId", "sourceType", "sourceId");
+CREATE INDEX "management_review_inputs_reviewId_sourceType_idx" ON "management_review_inputs"("reviewId", "sourceType");
+CREATE INDEX "management_review_actions_reviewId_status_idx" ON "management_review_actions"("reviewId", "status");
+CREATE INDEX "management_review_actions_ownerId_idx" ON "management_review_actions"("ownerId");
+
+ALTER TABLE "management_reviews"
+  ADD CONSTRAINT "management_reviews_createdBy_fkey"
+  FOREIGN KEY ("createdBy") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "management_reviews"
+  ADD CONSTRAINT "management_reviews_reportDocumentId_fkey"
+  FOREIGN KEY ("reportDocumentId") REFERENCES "documents"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "management_reviews"
+  ADD CONSTRAINT "management_reviews_reportRecordId_fkey"
+  FOREIGN KEY ("reportRecordId") REFERENCES "records"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "management_reviews"
+  ADD CONSTRAINT "management_reviews_meetingMinutesRecordId_fkey"
+  FOREIGN KEY ("meetingMinutesRecordId") REFERENCES "records"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "management_review_inputs"
+  ADD CONSTRAINT "management_review_inputs_reviewId_fkey"
+  FOREIGN KEY ("reviewId") REFERENCES "management_reviews"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "management_review_actions"
+  ADD CONSTRAINT "management_review_actions_reviewId_fkey"
+  FOREIGN KEY ("reviewId") REFERENCES "management_reviews"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "management_review_actions"
+  ADD CONSTRAINT "management_review_actions_ownerId_fkey"
+  FOREIGN KEY ("ownerId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -200,6 +200,9 @@ model User {
 
   ownedDocuments Document[] @relation("DocumentOwnerUser")
 
+  managementReviewsCreated ManagementReview[]       @relation("ManagementReviewCreator")
+  managementReviewActions  ManagementReviewAction[] @relation("ManagementReviewActionOwner")
+
   @@map("users")
 }
 
@@ -375,6 +378,8 @@ model Document {
   revisionOf     Document?  @relation("DocumentRevisions", fields: [revisionOfId], references: [id], onDelete: SetNull)
   revisions      Document[] @relation("DocumentRevisions")
   revisionStatus String     @default("current")
+
+  managementReviewReports ManagementReview[] @relation("ManagementReviewReportDocument")
 
   @@index([number])
   @@index([lineage_key])
@@ -881,6 +886,8 @@ model Record {
   changeEvent    ChangeEvent? @relation("ChangeEventRecords", fields: [changeEventId], references: [id], onDelete: SetNull)
   changeFormTasks ChangeEventFormTask[]
   product_recall_evidence ProductRecallEvidence[]
+  managementReviewMeetingMinutes ManagementReview[] @relation("ManagementReviewMeetingMinutes")
+  managementReviewReports        ManagementReview[] @relation("ManagementReviewReportRecord")
 
   @@index([templateId])
   @@index([number])
@@ -2277,6 +2284,82 @@ model AuditReport {
 
   @@index([documentId])
   @@map("audit_reports")
+}
+
+model ManagementReview {
+  id                 String   @id @default(cuid())
+  companyId          String
+  year               Int
+  title              String
+  status             String   @default("draft")
+  reviewDate         DateTime?
+  location           String?
+  materialDueDate    DateTime?
+  purpose            String   @default("评审质量和食品安全管理体系的适宜性、充分性和有效性。")
+  scope              Json     @default("[]")
+  participants       Json     @default("[]")
+  createdBy          String
+  completedAt        DateTime?
+  reportDocumentId   String?
+  reportRecordId     String?
+  meetingMinutesRecordId String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  creator              User      @relation("ManagementReviewCreator", fields: [createdBy], references: [id], onDelete: Restrict)
+  reportDocument       Document? @relation("ManagementReviewReportDocument", fields: [reportDocumentId], references: [id], onDelete: SetNull)
+  reportRecord         Record?   @relation("ManagementReviewReportRecord", fields: [reportRecordId], references: [id], onDelete: SetNull)
+  meetingMinutesRecord Record?   @relation("ManagementReviewMeetingMinutes", fields: [meetingMinutesRecordId], references: [id], onDelete: SetNull)
+  inputs               ManagementReviewInput[]
+  actions              ManagementReviewAction[]
+
+  @@unique([companyId, year])
+  @@index([companyId, status])
+  @@index([year])
+  @@index([reportDocumentId])
+  @@index([reportRecordId])
+  @@index([meetingMinutesRecordId])
+  @@map("management_reviews")
+}
+
+model ManagementReviewInput {
+  id         String   @id @default(cuid())
+  reviewId   String
+  sourceType String
+  sourceId   String
+  department String?
+  title      String
+  summary    Json
+  included   Boolean  @default(true)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  review ManagementReview @relation(fields: [reviewId], references: [id], onDelete: Cascade)
+
+  @@unique([reviewId, sourceType, sourceId])
+  @@index([reviewId, sourceType])
+  @@map("management_review_inputs")
+}
+
+model ManagementReviewAction {
+  id                    String   @id @default(cuid())
+  reviewId              String
+  action                String
+  responsibleDepartment String
+  ownerId               String?
+  dueDate               DateTime?
+  status                String   @default("open")
+  verificationNote      String?
+  completedAt           DateTime?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  review ManagementReview @relation(fields: [reviewId], references: [id], onDelete: Cascade)
+  owner  User?            @relation("ManagementReviewActionOwner", fields: [ownerId], references: [id], onDelete: SetNull)
+
+  @@index([reviewId, status])
+  @@index([ownerId])
+  @@map("management_review_actions")
 }
 
 // TASK-379: 用户文档访问日志表（智能推荐基础数据）


### PR DESCRIPTION
## Summary

- Add three Prisma models: `ManagementReview`, `ManagementReviewInput`, `ManagementReviewAction` with migration SQL
- Add NestJS module with create/list/detail/collect-sources/action endpoints; tenant-safe source collection filters by `User.company_id`
- Add Vue list + detail pages and routes for annual review management, input collection, and action tracking

## Test plan

- [x] `management-review.service.spec.ts` — 6 tests pass (duplicate year rejection, creation, source collection idempotency, cross-company isolation, cross-company NotFoundException, action ownership guard)
- [x] Prisma schema validates cleanly
- [x] Server build: no new TS errors introduced (pre-existing 183 errors unchanged)
- [x] Client build: passes successfully