### PR TITLE
GAP-505 migrate User.role permission checks to Role.code

### DIFF
--- a/server/src/modules/approval/approval.service.ts
+++ b/server/src/modules/approval/approval.service.ts
@@ -66,9 +66,11 @@ export class ApprovalService {
       // Admin 角色可以覆盖审批权限
       const user = await this.prisma.user.findUnique({
         where: { id: approverId },
+        include: { roleObj: true },
       });
 
-      if (!user || user.role !== 'admin') {
+      const userRoleCode = user?.roleObj?.code ?? user?.role;
+      if (!user || userRoleCode !== 'admin') {
         throw new BusinessException(ErrorCode.FORBIDDEN, '无权审批此记录');
       }
     }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -24,6 +24,7 @@ export class AuthService {
     const lockoutDisabled = process.env.AUTH_LOCKOUT_DISABLED === 'true';
     const user = await this.prisma.user.findUnique({
       where: { username: dto.username },
+      include: { roleObj: true },
     });
 
     if (!user) {
@@ -52,10 +53,12 @@ export class AuthService {
       data:  { loginAttempts: 0, firstFailedAt: null, lockedUntil: null },
     });
 
+    const roleCode = user.roleObj?.code ?? user.role;
+
     const payload = {
       sub: user.id,
       username: user.username,
-      role: user.role,
+      role: roleCode,
       name: user.name,
       companyId: user.company_id,
     };
@@ -67,7 +70,7 @@ export class AuthService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: user.role,
+        role: roleCode,
         companyId: user.company_id,
       },
     };

--- a/server/src/modules/auth/sso.service.ts
+++ b/server/src/modules/auth/sso.service.ts
@@ -53,7 +53,7 @@ export class SsoService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: user.role,
+        role: user.roleObj?.code ?? user.role,
         companyId: user.company_id,
       },
     };
@@ -82,7 +82,7 @@ export class SsoService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: user.role,
+        role: user.roleObj?.code ?? user.role,
         companyId: user.company_id,
       },
     };
@@ -190,7 +190,10 @@ export class SsoService {
   }
 
   private async findOrCreateUser(username: string, name: string, provider: string) {
-    const existing = await this.prisma.user.findUnique({ where: { username } });
+    const existing = await this.prisma.user.findUnique({
+      where: { username },
+      include: { roleObj: true },
+    });
     if (existing) return existing;
 
     // 首次登录自动创建账号（BR-SSO-1）
@@ -201,6 +204,7 @@ export class SsoService {
 
     return this.prisma.user.create({
       data: { id, username, name, password: defaultPassword, role: 'user', status: 'active', company_id: '1' },
+      include: { roleObj: true },
     });
   }
 
@@ -208,7 +212,7 @@ export class SsoService {
     return this.jwtService.sign({
       sub: user.id,
       username: user.username,
-      role: user.role,
+      role: user.roleObj?.code ?? user.role,
       name: user.name,
       companyId: user.company_id,
     });

--- a/server/src/modules/document/document.service.ts
+++ b/server/src/modules/document/document.service.ts
@@ -661,6 +661,7 @@ export class DocumentService {
     // 获取审批人信息用于权限检查
     const approver = await this.prisma.user.findUnique({
       where: { id: approverId },
+      include: { roleObj: true },
     });
 
     if (!approver) {
@@ -674,7 +675,8 @@ export class DocumentService {
 
     // 权限控制：验证是否为指定的审批人
     const isDesignatedApprover = pendingApproval.approverId === approverId;
-    const isAdmin = approver?.role === 'admin';
+    const approverRoleCode = approver?.roleObj?.code ?? approver?.role;
+    const isAdmin = approverRoleCode === 'admin';
 
     if (!isDesignatedApprover && !isAdmin) {
       throw new BusinessException(
@@ -1089,9 +1091,11 @@ export class DocumentService {
     // 权限检查：只有管理员可以物理删除
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
+      include: { roleObj: true },
     });
 
-    if (!user || user.role !== 'admin') {
+    const userRoleCode = user?.roleObj?.code ?? user?.role;
+    if (!user || userRoleCode !== 'admin') {
       throw new BusinessException(
         ErrorCode.FORBIDDEN,
         '只有管理员可以物理删除文档',

--- a/server/src/modules/task/task.service.ts
+++ b/server/src/modules/task/task.service.ts
@@ -29,6 +29,7 @@ interface TemplateField {
 interface UserContext {
   id: string;
   role: string;
+  roleObj?: { code: string } | null;
   departmentId: string | null;
 }
 
@@ -51,7 +52,7 @@ export class TaskService {
   private async getUserContext(userId: string): Promise<UserContext> {
     const user = await this.prisma.user.findUnique({
       where: { id: userId },
-      select: { id: true, role: true, departmentId: true },
+      select: { id: true, role: true, departmentId: true, roleObj: { select: { code: true } } },
     });
     if (!user) throw new NotFoundException('User not found');
     return user;
@@ -59,7 +60,8 @@ export class TaskService {
 
   async create(dto: CreateTaskDto, userId: string) {
     const user = await this.getUserContext(userId);
-    if (!this.isAdminOrLeader(user.role)) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (!this.isAdminOrLeader(roleCode)) {
       throw new ForbiddenException('Only admin or leader can create tasks');
     }
 
@@ -115,8 +117,9 @@ export class TaskService {
     const skip = (page - 1) * limit;
 
     const where: Record<string, unknown> = {};
+    const roleCode = user.roleObj?.code ?? user.role;
 
-    if (!this.isAdminOrLeader(user.role)) {
+    if (!this.isAdminOrLeader(roleCode)) {
       // Regular members only see their own department
       where['departmentId'] = user.departmentId;
     } else if (query.departmentId) {
@@ -165,7 +168,8 @@ export class TaskService {
     if (!task) {
       throw new NotFoundException('Task not found');
     }
-    if (!this.isAdminOrLeader(user.role)) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (!this.isAdminOrLeader(roleCode)) {
       if (task.departmentId !== user.departmentId) {
         throw new ForbiddenException('Access denied: different department');
       }
@@ -180,7 +184,8 @@ export class TaskService {
     if (!task) {
       throw new NotFoundException('Task not found');
     }
-    if (user.role !== 'admin' && task.creatorId !== userId) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (roleCode !== 'admin' && task.creatorId !== userId) {
       throw new ForbiddenException('Only admin or task creator can update');
     }
     if (task.status !== 'pending') {
@@ -223,7 +228,8 @@ export class TaskService {
     }
 
     // Department check for non-admin/leader
-    if (!this.isAdminOrLeader(user.role)) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (!this.isAdminOrLeader(roleCode)) {
       if (task.departmentId !== user.departmentId) {
         throw new ForbiddenException('Access denied: different department');
       }
@@ -293,7 +299,8 @@ export class TaskService {
       throw new NotFoundException('Task not found');
     }
 
-    if (!this.isAdminOrLeader(user.role)) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (!this.isAdminOrLeader(roleCode)) {
       if (task.departmentId !== user.departmentId) {
         throw new ForbiddenException('Access denied: different department');
       }
@@ -340,7 +347,8 @@ export class TaskService {
     if (!task) {
       throw new NotFoundException('Task not found');
     }
-    if (user.role !== 'admin' && task.creatorId !== userId) {
+    const roleCode = user.roleObj?.code ?? user.role;
+    if (roleCode !== 'admin' && task.creatorId !== userId) {
       throw new ForbiddenException('Only admin or task creator can cancel');
     }
     if (task.status !== 'pending') {

--- a/server/src/modules/user-permission/user-permission.service.ts
+++ b/server/src/modules/user-permission/user-permission.service.ts
@@ -122,9 +122,11 @@ export class UserPermissionService {
       if (revokedBy) {
         const revoker = await this.prisma.user.findUnique({
           where: { id: revokedBy },
+          include: { roleObj: true },
         });
 
-        if (revoker && revoker.role !== 'admin' && userPermission.grantedBy !== revokedBy) {
+        const revokerRoleCode = revoker?.roleObj?.code ?? revoker?.role;
+        if (revoker && revokerRoleCode !== 'admin' && userPermission.grantedBy !== revokedBy) {
           throw new ForbiddenException('仅原授权人或管理员可撤销此权限');
         }
       }


### PR DESCRIPTION
## Summary
- Use `roleObj?.code ?? role` when login/SSO builds JWT role values.
- Add `roleObj` reads for DB-fetched users in task, document, approval, and user-permission admin checks.
- Keep the JWT/API `role` field name and `User.role` fallback for backward compatibility.

## Verification
- `git diff --check` passed.
- Locked grep for direct Type-B `User.role` permission checks passed with no output.
- Broad `.role` audit leaves only allowed categories: process approval row roles, import/export DTO/request-sourced roles, Role model operations, and `req.user.role`.
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH cd server && npx tsc --noEmit` failed on existing unrelated repo-wide TypeScript errors, including implicit-any errors across many modules and Prisma generated type mismatches.
- Exact plan command `cd server && npm test -- --testPathPattern="auth|sso|document|user-permission|task|approval" --passWithNoTests` failed before tests because current Jest requires `--testPathPatterns`.
- Equivalent focused check `cd server && npm test -- --testPathPatterns="auth|sso|user-permission|approval" --passWithNoTests --runInBand` passed: 13 suites, 120 tests.
- Equivalent broader check with `document|task` still fails due existing test harness issues: missing `NumberRuleService` / `DocumentControlMetadataService` providers in DocumentService tests, plus task/document stack overflow under the local runtime.

## Notes
- No Prisma schema or migration changes.