### PR TITLE
GAP-404: align record template fields update contract

### DIFF
--- a/client/src/api/record-template.ts
+++ b/client/src/api/record-template.ts
@@ -4,11 +4,43 @@ import request from './request';
 // Types
 // =========================================================================
 
+export type RecordTemplateFieldType =
+  | 'text' | 'textarea' | 'number'
+  | 'date' | 'time' | 'datetime' | 'daterange' | 'timerange'
+  | 'email' | 'phone' | 'url' | 'password'
+  | 'boolean' | 'switch'
+  | 'enum' | 'multi-enum' | 'select' | 'radio' | 'checkbox' | 'multiselect'
+  | 'cascader' | 'slider' | 'rate' | 'color'
+  | 'file' | 'image' | 'photo'
+  | 'inspection-table'
+  | 'table-input'
+  | 'checklist'
+  | 'signature'
+  | 'entity-link'
+  | 'richtext'
+  | 'range-select'
+  | 'constrained-number'
+  | 'checkbox-text'
+  | 'auto-username'
+  | 'auto-date'
+  | 'auto-display'
+  | 'section-header'
+  | 'static-content'
+  | 'template-content'
+  | 'approval-step'
+  | 'location'
+  | 'qrcode'
+  | 'barcode'
+  | 'tree';
+
 export interface RecordTemplateField {
   name: string;
   label: string;
-  type: string;
+  type: RecordTemplateFieldType;
   required?: boolean;
+  disabled?: boolean;
+  unit?: string;
+  defaultValue?: unknown;
   min?: number;
   max?: number;
   tolerance?: {
@@ -20,6 +52,10 @@ export interface RecordTemplateField {
   placeholder?: string;
   pattern?: string;
   patternMessage?: string;
+  entity?: string;
+  autoFill?: boolean;
+  inspectionRows?: Array<{ item: string; standard: string }>;
+  checklistItems?: string[];
 }
 
 export interface RecordTemplate {

--- a/server/src/modules/record-template/dto/update-fields-body.dto.ts
+++ b/server/src/modules/record-template/dto/update-fields-body.dto.ts
@@ -1,0 +1,133 @@
+import {
+  Allow,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { EntityType, FieldType } from '../types/fields-json.types';
+
+const VALID_FIELD_TYPES: FieldType[] = [
+  'text', 'textarea', 'number',
+  'date', 'time', 'datetime', 'daterange', 'timerange',
+  'email', 'phone', 'url', 'password',
+  'boolean', 'switch',
+  'enum', 'multi-enum', 'select', 'radio', 'checkbox', 'multiselect',
+  'cascader', 'slider', 'rate', 'color',
+  'file', 'image', 'photo',
+  'inspection-table',
+  'table-input',
+  'checklist',
+  'signature',
+  'entity-link',
+  'richtext',
+  'range-select',
+  'constrained-number',
+  'checkbox-text',
+  'auto-username',
+  'auto-date',
+  'auto-display',
+  'section-header',
+  'static-content',
+  'template-content',
+  'approval-step',
+  'location',
+  'qrcode',
+  'barcode',
+  'tree',
+];
+
+export class FieldOptionDto {
+  @IsString()
+  label: string;
+
+  @IsString()
+  value: string;
+}
+
+export class FieldDefDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  label: string;
+
+  @IsString()
+  @IsIn(VALID_FIELD_TYPES)
+  type: FieldType;
+
+  @IsOptional()
+  @IsBoolean()
+  required?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  disabled?: boolean;
+
+  @IsOptional()
+  @IsString()
+  unit?: string;
+
+  @IsOptional()
+  @Allow()
+  defaultValue?: unknown;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => FieldOptionDto)
+  options?: FieldOptionDto[];
+
+  @IsOptional()
+  @IsNumber()
+  min?: number;
+
+  @IsOptional()
+  @IsNumber()
+  max?: number;
+
+  @IsOptional()
+  @IsString()
+  placeholder?: string;
+
+  @IsOptional()
+  @IsString()
+  pattern?: string;
+
+  @IsOptional()
+  @IsString()
+  patternMessage?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  autoFill?: boolean;
+
+  @IsOptional()
+  @IsString()
+  entity?: EntityType;
+
+  @IsOptional()
+  @IsArray()
+  inspectionRows?: Array<{ item: string; standard: string }>;
+
+  @IsOptional()
+  @IsArray()
+  checklistItems?: string[];
+
+  /** tolerance is an object - validated loosely to avoid over-constraint on designer metadata */
+  @IsOptional()
+  @IsObject()
+  tolerance?: { type: 'range' | 'percentage'; min: number; max: number };
+}
+
+export class UpdateFieldsBodyDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => FieldDefDto)
+  fields: FieldDefDto[];
+}

--- a/server/src/modules/record-template/record-template.controller.ts
+++ b/server/src/modules/record-template/record-template.controller.ts
@@ -16,6 +16,7 @@ import { RecordTemplateService } from './record-template.service';
 import { CreateRecordTemplateDto } from './dto/create-record-template.dto';
 import { UpdateRecordTemplateDto } from './dto/update-record-template.dto';
 import { QueryRecordTemplateDto } from './dto/query-record-template.dto';
+import { UpdateFieldsBodyDto } from './dto/update-fields-body.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../../common/guards/roles.guard';
 
@@ -93,7 +94,7 @@ export class RecordTemplateController {
   @Put(':id/fields')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: '更新草稿模板字段' })
-  updateFields(@Param('id') id: string, @Body() body: { fields: Array<Record<string, unknown>> }) {
+  updateFields(@Param('id') id: string, @Body() body: UpdateFieldsBodyDto) {
     return this.templateService.updateFields(id, body.fields);
   }
 

--- a/server/src/modules/record-template/record-template.service.ts
+++ b/server/src/modules/record-template/record-template.service.ts
@@ -1,8 +1,10 @@
 import { Injectable, NotFoundException, ConflictException, BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateRecordTemplateDto } from './dto/create-record-template.dto';
 import { UpdateRecordTemplateDto } from './dto/update-record-template.dto';
 import { QueryRecordTemplateDto } from './dto/query-record-template.dto';
+import { FieldDef } from './types/fields-json.types';
 
 @Injectable()
 export class RecordTemplateService {
@@ -145,7 +147,7 @@ export class RecordTemplateService {
     const baseCode = (existing as any).baseCode || existing.code.replace(/-v\d+$/, '');
     const templateFamilyId = (existing as any).templateFamilyId || baseCode;
 
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       // Compute next version from the family's current max to avoid conflicts
       // with any draft created via createRevision() in the same family.
       const latest = await tx.recordTemplate.findFirst({
@@ -183,7 +185,7 @@ export class RecordTemplateService {
   /**
    * 更新草稿模板字段（已启用模板禁止原地修改）
    */
-  async updateFields(id: string, fields: Array<Record<string, unknown>>) {
+  async updateFields(id: string, fields: FieldDef[]) {
     const template = await this.findOne(id);
     if (template.status === 'active' || (template as any).versionStatus === 'active') {
       throw new BadRequestException('已启用模板不能原地修改字段，请发起模板改版');
@@ -240,7 +242,7 @@ export class RecordTemplateService {
     if ((template as any).versionStatus !== 'draft') {
       throw new BadRequestException('只有草稿模板版本可以启用');
     }
-    return this.prisma.$transaction(async (tx) => {
+    return this.prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.recordTemplate.updateMany({
         where: {
           templateFamilyId: (template as any).templateFamilyId || (template as any).baseCode || template.code,

--- a/server/src/modules/record-template/types/fields-json.types.ts
+++ b/server/src/modules/record-template/types/fields-json.types.ts
@@ -1,11 +1,31 @@
 export type FieldType =
-  | 'text' | 'number' | 'date' | 'datetime' | 'boolean'
-  | 'enum' | 'multi-enum'
+  | 'text' | 'textarea' | 'number'
+  | 'date' | 'time' | 'datetime' | 'daterange' | 'timerange'
+  | 'email' | 'phone' | 'url' | 'password'
+  | 'boolean' | 'switch'
+  | 'enum' | 'multi-enum' | 'select' | 'radio' | 'checkbox' | 'multiselect'
+  | 'cascader' | 'slider' | 'rate' | 'color'
+  | 'file' | 'image' | 'photo'
   | 'inspection-table'
+  | 'table-input'
   | 'checklist'
-  | 'photo'
   | 'signature'
-  | 'entity-link';
+  | 'entity-link'
+  | 'richtext'
+  | 'range-select'
+  | 'constrained-number'
+  | 'checkbox-text'
+  | 'auto-username'
+  | 'auto-date'
+  | 'auto-display'
+  | 'section-header'
+  | 'static-content'
+  | 'template-content'
+  | 'approval-step'
+  | 'location'
+  | 'qrcode'
+  | 'barcode'
+  | 'tree';
 
 // Historical compatibility only. New batch-linked templates should use production_batch.
 export type EntityType =
@@ -17,10 +37,20 @@ export interface FieldDef {
   label: string;
   type: FieldType;
   required?: boolean;
+  disabled?: boolean;
   unit?: string;
   defaultValue?: unknown;
-  options?: string[];
-  validRange?: { min?: number; max?: number };
+  /** Enum / multi-enum options. Stored as label+value objects to support display labels distinct from values. */
+  options?: Array<{ label: string; value: string }>;
+  /** Numeric range validation. Stored flat on the field (not nested as validRange). */
+  min?: number;
+  max?: number;
+  /** Tolerance band for numeric deviation checks. */
+  tolerance?: { type: 'range' | 'percentage'; min: number; max: number };
+  /** Form UI rendering hints - no business logic. */
+  placeholder?: string;
+  pattern?: string;
+  patternMessage?: string;
   entity?: EntityType;
   autoFill?: boolean;
   inspectionRows?: Array<{ item: string; standard: string }>;
@@ -37,6 +67,11 @@ export interface ConditionalRule {
   show: string[];
 }
 
+/**
+ * Full-template fieldsJson shape used by the create/update template DTO paths.
+ * The `updateFields` (designer patch) path stores `{ fields: FieldDef[] }` directly -
+ * a flat structure without sections - and does NOT use this interface.
+ */
 export interface FieldsJson {
   sections: SectionDef[];
   conditionalRules?: ConditionalRule[];


### PR DESCRIPTION
## Summary
- Added `UpdateFieldsBodyDto` with nested field option validation for `PUT /record-templates/:id/fields`.
- Aligned server/client record-template field types with stored label/value options, flat min/max, tolerance, UI metadata, and existing designer field types.
- Typed the `updateFields` service path and documented the flat `{ fields }` patch shape versus full-template `FieldsJson.sections`.

## Test Plan
- PASS: `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run build:client`
- FAIL: `PATH=/opt/homebrew/opt/node@20/bin:$PATH npm run build:server` is blocked by existing project-wide TypeScript/Prisma errors outside GAP-404; filtered build log shows no GAP-scoped record-template errors after fixes.
- FAIL: `cd server && PATH=/opt/homebrew/opt/node@20/bin:$PATH npm test -- record-template --runInBand 2>&1 | tail -20` exits with `RangeError: Maximum call stack size exceeded` in Jest runtime.