### PR TITLE
PR1: 角色来源收口与认证字段/共享类型前置变更

### DIFF
--- a/client/src/components/fields/ApprovalStepField.vue
+++ b/client/src/components/fields/ApprovalStepField.vue
@@ -61,6 +61,6 @@ const userStore = useUserStore();
 const canApprove = computed(() => {
   const allowed = props.field.approverRoles as string[] | undefined;
   if (!allowed || allowed.length === 0) return true;
-  return allowed.includes(userStore.user?.role ?? '');
+  return allowed.includes(userStore.user?.roleCode ?? '');
 });
 </script>

--- a/client/src/stores/user.ts
+++ b/client/src/stores/user.ts
@@ -5,7 +5,7 @@ interface CurrentUser {
   id: string;
   username: string;
   name: string;
-  role: 'admin' | 'leader' | 'user';
+  roleCode: 'admin' | 'leader' | 'user';
   roleId: string;
   departmentId?: string | null;
 }
@@ -23,8 +23,8 @@ export const useUserStore = defineStore('user', {
   }),
   getters: {
     isLoggedIn: (state) => !!state.token,
-    isAdmin: (state) => state.user?.role === 'admin',
-    isLeader: (state) => state.user?.role === 'leader' || state.user?.role === 'admin',
+    isAdmin: (state) => state.user?.roleCode === 'admin',
+    isLeader: (state) => state.user?.roleCode === 'leader' || state.user?.roleCode === 'admin',
   },
   actions: {
     async login(username: string, password: string): Promise<boolean> {

--- a/client/src/views/UserList.vue
+++ b/client/src/views/UserList.vue
@@ -177,7 +177,6 @@ interface UserRow {
   name: string;
   roleId: string | null;
   roleObj?: RoleRef | null;
-  role?: string;
   status: 'active' | 'inactive';
   departmentId: string | null;
   department?: DepartmentRef | null;
@@ -254,9 +253,7 @@ const formatDate = (date: string) => new Date(date).toLocaleString('zh-CN');
 const getRoleType = (code?: string) =>
   ({ admin: 'danger', leader: 'warning', user: 'info' } as Record<string, string>)[code || ''] || 'info';
 const roleDisplay = (row: UserRow) =>
-  row.roleObj?.name ||
-  ({ admin: '管理员', leader: '部门负责人', user: '普通用户' } as Record<string, string>)[row.role || ''] ||
-  '未知角色';
+  row.roleObj?.name || '未知角色';
 
 const departmentDisplay = (row: UserRow) => {
   if (!row.departmentId) return '未分配部门';

--- a/client/src/views/documents/DocumentDetail.vue
+++ b/client/src/views/documents/DocumentDetail.vue
@@ -576,7 +576,7 @@ async function createRevision() {
 
 // 权限判断
 const isCreator = computed(() => document.value?.creatorId === userStore.user?.id);
-const isAdmin = computed(() => userStore.user?.role === 'admin');
+const isAdmin = computed(() => userStore.user?.roleCode === 'admin');
 const isDirectMarkdownEditableStatus = (status: string) => ['draft', 'rejected'].includes(status);
 const canEditMarkdown = computed(() => {
   if (!document.value) return false;

--- a/client/src/views/permission/DepartmentPermission.vue
+++ b/client/src/views/permission/DepartmentPermission.vue
@@ -29,22 +29,21 @@
           <template #header>
             <span>部门列表</span>
           </template>
-          <el-tree
-            :data="departmentTree"
-            :props="treeProps"
-            highlight-current
-            node-key="id"
-            @node-click="handleNodeClick"
+          <el-table
+            :data="departments"
+            highlight-current-row
+            @current-change="handleRowClick"
+            size="small"
           >
-            <template #default="{ node, data }">
-              <div class="tree-node">
-                <span>{{ node.label }}</span>
-                <el-tag v-if="data.permissionCount > 0" size="small" type="info">
-                  {{ data.permissionCount }}
+            <el-table-column prop="name" label="部门名称" />
+            <el-table-column label="权限" width="60" align="center">
+              <template #default="{ row }">
+                <el-tag v-if="row.permissionCount > 0" size="small" type="info">
+                  {{ row.permissionCount }}
                 </el-tag>
-              </div>
-            </template>
-          </el-tree>
+              </template>
+            </el-table-column>
+          </el-table>
         </el-card>
       </el-col>
 
@@ -78,7 +77,6 @@
               <el-radio-group v-model="deptConfig.isolationLevel">
                 <el-radio value="none">无隔离（可查看全部数据）</el-radio>
                 <el-radio value="department">部门隔离（仅本部门数据）</el-radio>
-                <el-radio value="subdepartment">子部门隔离（本部门及下级）</el-radio>
               </el-radio-group>
             </el-form-item>
 
@@ -146,9 +144,7 @@ import request from '@/api/request';
 interface Department {
   id: string;
   name: string;
-  parentId: string | null;
   permissionCount: number;
-  children?: Department[];
 }
 
 interface ResourcePermission {
@@ -162,7 +158,7 @@ interface ResourcePermission {
 }
 
 interface DeptConfig {
-  isolationLevel: 'none' | 'department' | 'subdepartment';
+  isolationLevel: 'none' | 'department';
   allowedDeptIds: string[];
 }
 
@@ -182,10 +178,7 @@ const permLoading = ref(false);
 const saving = ref(false);
 
 const departments = ref<Department[]>([]);
-const departmentTree = ref<Department[]>([]);
 const selectedDept = ref<Department | null>(null);
-
-const treeProps = { children: 'children', label: 'name' };
 
 const deptConfig = reactive<DeptConfig>({
   isolationLevel: 'none',
@@ -208,21 +201,6 @@ const otherDepartments = computed(() =>
   departments.value.filter((d) => d.id !== selectedDept.value?.id),
 );
 
-const buildTree = (depts: Department[]): Department[] => {
-  const map = new Map<string, Department>();
-  depts.forEach((d) => map.set(d.id, { ...d, children: [] }));
-  const roots: Department[] = [];
-  depts.forEach((d) => {
-    const node = map.get(d.id)!;
-    if (d.parentId && map.has(d.parentId)) {
-      map.get(d.parentId)!.children!.push(node);
-    } else {
-      roots.push(node);
-    }
-  });
-  return roots;
-};
-
 const fetchDepartments = async () => {
   deptLoading.value = true;
   try {
@@ -230,7 +208,6 @@ const fetchDepartments = async () => {
       params: { page: 1, limit: 200 },
     });
     departments.value = res.list;
-    departmentTree.value = buildTree(res.list);
   } catch {
     ElMessage.error('获取部门列表失败');
   } finally {
@@ -247,10 +224,10 @@ const fetchDeptPermissions = async (deptId: string) => {
       resources: Array<{ resource: string; actions: string[] }>;
     }>(`/department-permissions/${deptId}`);
 
-    deptConfig.isolationLevel = (res.isolationLevel as DeptConfig['isolationLevel']) || 'none';
+    const level = res.isolationLevel as DeptConfig['isolationLevel'];
+    deptConfig.isolationLevel = (level === 'none' || level === 'department') ? level : 'none';
     deptConfig.allowedDeptIds = res.allowedDeptIds || [];
 
-    // Reset permissions
     resourcePermissions.value = RESOURCES.map((r) => {
       const found = (res.resources || []).find((rp) => rp.resource === r.value);
       const actions = found?.actions ?? [];
@@ -265,7 +242,6 @@ const fetchDeptPermissions = async (deptId: string) => {
       };
     });
   } catch {
-    // If not found, show empty config
     deptConfig.isolationLevel = 'none';
     deptConfig.allowedDeptIds = [];
     resourcePermissions.value = RESOURCES.map((r) => ({
@@ -282,7 +258,8 @@ const fetchDeptPermissions = async (deptId: string) => {
   }
 };
 
-const handleNodeClick = (data: Department) => {
+const handleRowClick = (data: Department | null) => {
+  if (!data) return;
   selectedDept.value = data;
   fetchDeptPermissions(data.id);
 };
@@ -347,13 +324,5 @@ onMounted(() => {
   display: flex;
   justify-content: space-between;
   align-items: center;
-}
-
-.tree-node {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding-right: 8px;
 }
 </style>

--- a/client/src/views/permission/__tests__/DepartmentPermission.spec.ts
+++ b/client/src/views/permission/__tests__/DepartmentPermission.spec.ts
@@ -28,12 +28,11 @@ const stubs: Record<string, any> = {
   'el-button': { template: '<button @click="$emit(\'click\')"><slot /></button>' },
   'el-row': { template: '<div><slot /></div>', props: ['gutter'] },
   'el-col': { template: '<div><slot /></div>', props: ['span'] },
-  'el-tree': {
-    template: '<div class="el-tree"><slot name="default" :node="{label:\'test\'}" :data="data[0]||{}" /></div>',
-    props: ['data', 'props', 'highlightCurrent', 'nodeKey'],
-    emits: ['node-click'],
+  'el-table': {
+    template: '<div class="el-table"><slot /></div>',
+    props: ['data', 'highlightCurrentRow'],
+    emits: ['current-change'],
   },
-  'el-table': { template: '<div><slot /></div>', props: ['data'] },
   'el-table-column': { template: '<div />', props: ['prop', 'label', 'width', 'align'] },
   'el-checkbox': {
     template: '<input type="checkbox" />',
@@ -54,9 +53,9 @@ const stubs: Record<string, any> = {
 import DepartmentPermission from '../DepartmentPermission.vue';
 
 const mockDepartments = [
-  { id: 'd-1', name: '研发部', parentId: null, permissionCount: 0 },
-  { id: 'd-2', name: '测试部', parentId: null, permissionCount: 2 },
-  { id: 'd-3', name: '前端组', parentId: 'd-1', permissionCount: 0 },
+  { id: 'd-1', name: '研发部', permissionCount: 0 },
+  { id: 'd-2', name: '测试部', permissionCount: 2 },
+  { id: 'd-3', name: '前端组', permissionCount: 0 },
 ];
 
 const mockDeptPermissions = {
@@ -90,27 +89,14 @@ describe('DepartmentPermission', () => {
     expect(mockGet).toHaveBeenCalledWith('/departments', expect.any(Object));
   });
 
-  it('stores departments data', async () => {
+  it('stores departments as flat list', async () => {
     mockGet.mockResolvedValue({ list: mockDepartments });
     const c = w();
     await flushPromises();
     expect((c.vm as any).departments).toHaveLength(3);
   });
 
-  it('builds department tree correctly', async () => {
-    mockGet.mockResolvedValue({ list: mockDepartments });
-    const c = w();
-    await flushPromises();
-    // Root departments should be d-1 and d-2
-    const tree = (c.vm as any).departmentTree;
-    expect(tree).toHaveLength(2);
-    // d-3 should be a child of d-1
-    const root1 = tree.find((d: any) => d.id === 'd-1');
-    expect(root1.children).toHaveLength(1);
-    expect(root1.children[0].id).toBe('d-3');
-  });
-
-  it('loads department permissions when node clicked', async () => {
+  it('loads department permissions when row clicked', async () => {
     mockGet.mockImplementation((url: string) => {
       if (url === '/departments') return Promise.resolve({ list: mockDepartments });
       return Promise.resolve(mockDeptPermissions);
@@ -120,7 +106,7 @@ describe('DepartmentPermission', () => {
     mockGet.mockClear();
     mockGet.mockResolvedValue(mockDeptPermissions);
 
-    await (c.vm as any).handleNodeClick(mockDepartments[0]);
+    await (c.vm as any).handleRowClick(mockDepartments[0]);
     await flushPromises();
 
     expect(mockGet).toHaveBeenCalledWith('/department-permissions/d-1');
@@ -136,7 +122,7 @@ describe('DepartmentPermission', () => {
     mockGet.mockClear();
     mockGet.mockResolvedValue(mockDeptPermissions);
 
-    await (c.vm as any).handleNodeClick(mockDepartments[0]);
+    await (c.vm as any).handleRowClick(mockDepartments[0]);
     await flushPromises();
 
     const docPerm = (c.vm as any).resourcePermissions.find((r: any) => r.resource === 'document');
@@ -211,7 +197,7 @@ describe('DepartmentPermission', () => {
     mockGet.mockClear();
     mockGet.mockRejectedValue(new Error('Not found'));
 
-    await (c.vm as any).handleNodeClick(mockDepartments[0]);
+    await (c.vm as any).handleRowClick(mockDepartments[0]);
     await flushPromises();
 
     expect((c.vm as any).deptConfig.isolationLevel).toBe('none');
@@ -226,5 +212,14 @@ describe('DepartmentPermission', () => {
     (c.vm as any).selectedDept = mockDepartments[0];
     const others = (c.vm as any).otherDepartments;
     expect(others.every((d: any) => d.id !== 'd-1')).toBe(true);
+  });
+
+  it('isolation level does not include subdepartment option', async () => {
+    mockGet.mockResolvedValue({ list: mockDepartments });
+    const c = w();
+    await flushPromises();
+    const validLevels = ['none', 'department'];
+    const level = (c.vm as any).deptConfig.isolationLevel;
+    expect(validLevels).toContain(level);
   });
 });

--- a/docs/module-usage/13-system-admin-ops.md
+++ b/docs/module-usage/13-system-admin-ops.md
@@ -95,7 +95,7 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 
 | 对象 | 当前实现 | 说明 |
 |------|----------|------|
-| Role | `roles` 表，code 唯一 | 三个预置角色：admin/leader/user；User.role 字段已废弃，应使用 User.roleId |
+| Role | `roles` 表，code 唯一 | 三个预置角色：admin/leader/user；运行时角色通过 JWT 签发 `role: roleCode`，`JwtStrategy.validate()` 输出 `roleCode`；服务端统一消费 `req.user.roleCode` |
 | Permission | `permissions` 表，resource+action 唯一 | RBAC 粗粒度权限定义 |
 | RolePermission | `role_permissions` 桥接表 | 角色-权限多对多 |
 | FineGrainedPermission | `fine_grained_permissions` 表，code 唯一 | ABAC 细粒度权限定义，含 category/scope |
@@ -156,7 +156,7 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 
 | GAP 编号 | 当前问题 | 根因 | 影响后果 | 严重级别 | 验证状态 | 证据 |
 |----------|----------|------|----------|----------|----------|------|
-| GAP-505 | `User.role`（String 字段）已被标注 `@deprecated` 应使用 `User.roleId`，但无法确认全部业务代码是否已迁移 | 向后兼容保留了双字段 | 如果仍有代码读取 `User.role` String，角色判断结果可能与 `User.roleId` 不一致 | P1（高） | 需要运行系统确认 | `schema.prisma:L110` 注释 `@deprecated`；`record-task.controller.ts:L36` 中 `req.user?.role === 'admin'` 仍在使用 String role |
+| GAP-505 | ~~`User.role` 字符串残留角色判断~~ | **已修复**（本 PR：domain-source-of-truth-semantic-dedup-pr1）| 全部 `req.user.role` / `req.user.userId` 已收口，认证边界统一输出 `roleCode`；`CurrentUser.role` / `AuthenticatedUser.userId` / `LoginResponse.user.role` 已删除 | P1（高） | **已修复** | 见 `authenticated-user.ts`、`auth.strategy.ts`、`roles.guard.ts` |
 | GAP-506 | `/permissions/audit-log` 页面（PermissionAuditLog.vue）调用的前端 API 端点未在前端 API 文件中找到明确定义，后端 permission-log 控制器是否存在需要确认 | 权限审计日志功能可能未完整实现 | 审计日志页面可能无法正常展示 | P2（中） | 未验证 | `client/src/views/permission/PermissionAuditLog.vue` 存在，但 `client/src/api/permission.ts` 无 permissionLog 方法 |
 | GAP-507 | 前端 `queryMetrics` 调用 `GET /monitoring/metrics/query`，后端定义为 `@Post('metrics/query')` | 前端使用 GET，后端要求 POST + 请求体 | 指标查询返回 404/405，监控图表无数据 | P1（高） | 已验证 | `client/src/api/monitoring.ts:L76`；`server/src/modules/monitoring/monitoring.controller.ts:L56` |
 | GAP-508 | 前端 `queryAlertHistory` 调用 `GET /monitoring/alerts/history`，后端路由为 `POST /monitoring/alerts/history/query` | 路径不同（history vs history/query）且方法不同（GET vs POST） | 告警历史列表无数据 | P1（高） | 已验证 | `client/src/api/monitoring.ts:L116`；`server/src/modules/monitoring/monitoring.controller.ts:L138` |
@@ -169,7 +169,7 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 
 | GAP 编号 | 建议整改 | 依赖模块 | 是否需要新设计 | 建议 PR | 是否可并行 |
 |----------|----------|----------|----------------|---------|-----------|
-| GAP-505 | 全局搜索 `req.user?.role === 'admin'` 等 String role 判断，统一改为基于 `req.user?.roleId` 和角色对象；完成后可删除 `User.role` 字符串字段 | auth, user | 否 | fix/migrate-user-role-string-to-roleid | 否（需全量扫描） |
+| GAP-505 | **已修复**（domain-source-of-truth-semantic-dedup-pr1）：全部 `req.user.role` / `req.user.userId` 改为 `req.user.roleCode` / `req.user.id`；认证边界统一输出 `roleCode` | auth, user | 否 | 已合并 | 已完成 |
 | GAP-506 | 在后端补充 `/permission-logs` 路由（或确认现有路由路径），前端补充对应 API 适配器 | permission | 需要确认 | fix/permission-audit-log-endpoint | 是 |
 | GAP-507 | 将前端 `queryMetrics` 改为 `POST /monitoring/metrics/query`，或后端新增 `GET /monitoring/metrics/query` 查询参数支持 | monitoring | 否 | fix/monitoring-metrics-query-method | 是 |
 | GAP-508 | 将前端 `queryAlertHistory` 改为调用 `POST /monitoring/alerts/history/query`，并修改参数为请求体格式 | monitoring, alert | 否 | fix/monitoring-alert-history-path | 是 |
@@ -201,13 +201,13 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 - `server/src/prisma/schema.prisma:L2349`：DepartmentPermission 模型
 - `server/src/prisma/schema.prisma:L1824`：PermissionLog 模型
 - `server/src/prisma/schema.prisma:L1877`：SystemMetric 模型
-- `server/src/modules/record-task/record-task.controller.ts:L36`：`req.user?.role === 'admin'` String role 仍在使用
+
 
 ## 10. 禁止重复实现与事实源边界
 
 | 对象 | 当前事实源 | 允许展示字段 | 禁止新增的平行事实源 | 旧字段或旧模块处理 |
 |------|-----------|-------------|---------------------|-------------------|
-| 用户角色 | `User.roleId` → `roles` | 角色名称/code 展示 | 禁止在业务代码中用 `User.role` String 新建角色判断逻辑 | `User.role` String 字段废弃，待全量迁移后删除 |
+| 用户角色 | `User.roleId` → `roles`；运行时 `req.user.roleCode` | 角色名称/code 展示 | 禁止在业务代码中用 `req.user.role` 或 `req.user.userId` | 已迁移完成：`AuthenticatedUser` 不再含 `role`/`userId` 字段 |
 | 功能权限 | `permissions` + `role_permissions` | 权限描述展示 | 禁止在各业务模块自建权限枚举表 | 无旧版本 |
 | 细粒度权限 | `fine_grained_permissions` + `user_permissions` | 权限码/分类/范围展示 | 禁止绕过 FineGrainedPermissionGuard 在 controller 层手动判断权限码 | 无旧版本 |
 | 部门数据隔离 | `department_permissions` | 部门名称/允许操作展示 | 禁止在 service 层直接 hardcode 部门 ID 做数据过滤 | 无旧版本 |
@@ -222,7 +222,7 @@ last_verified_commit: 7bab98dc3ccd49e8e1d76b95b28a1b79207c483c
 | P1 | GAP-507 | fix/monitoring-metrics-query-method | 无 | 是 | 前端监控页面指标图表有数据渲染 |
 | P1 | GAP-508 | fix/monitoring-alert-history-path | 无 | 是 | 告警历史列表可以加载数据 |
 | P1 | GAP-509 | fix/backup-available-endpoint | 无 | 是 | `GET /backup/available` 返回 200 + 列表 |
-| P1 | GAP-505 | fix/migrate-user-role-string-to-roleid | 无 | 否 | 全局 `grep "req.user?.role"` 无 String 比较 |
+| ~~P1~~ | ~~GAP-505~~ | **已完成**（domain-source-of-truth-semantic-dedup-pr1）| — | — | `grep "req.user.role"` 全仓清零 |
 | P2 | GAP-510 | fix/backup-status-endpoint | 无 | 是 | `GET /backup/:id/status` 返回 200 + BackupHistory |
 | P2 | GAP-511 | fix/alert-route-dedup | GAP-508 前 | 是 | 确认唯一一套告警路由路径 |
 | P2 | GAP-506 | fix/permission-audit-log-endpoint | 需确认 | 是 | `/permissions/audit-log` 页面可加载数据 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8479,7 +8479,6 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -8521,7 +8520,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8542,7 +8540,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8563,7 +8560,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8584,7 +8580,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8605,7 +8600,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8626,7 +8620,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8647,7 +8640,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8668,7 +8660,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8689,7 +8680,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8710,7 +8700,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8731,7 +8720,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8752,7 +8740,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8773,7 +8760,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -8787,8 +8773,7 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -20082,7 +20067,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20103,7 +20087,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20124,7 +20107,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20145,7 +20127,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20166,7 +20147,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20187,7 +20167,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20208,7 +20187,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20229,7 +20207,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20250,7 +20227,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20271,7 +20247,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -20292,7 +20267,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/types/api.ts
+++ b/packages/types/api.ts
@@ -25,7 +25,7 @@ export interface LoginResponse {
     id: string;
     username: string;
     name: string;
-    role: 'admin' | 'leader' | 'user';
+    roleCode: 'admin' | 'leader' | 'user';
     roleId: string;
     companyId?: string;
   };
@@ -76,8 +76,6 @@ export interface Department {
   id: string;
   code: string;
   name: string;
-  parentId: string | null;
-  parentName?: string;
   managerId: string | null;
   manager?: {
     id: string;

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -36,7 +36,7 @@ export interface CurrentUser {
   id: string;
   username: string;
   name: string;
-  role: 'admin' | 'leader' | 'user';
+  roleCode: 'admin' | 'leader' | 'user';
   roleId: string;
   departmentId?: string | null;
 }

--- a/server/src/common/guards/permission.guard.spec.ts
+++ b/server/src/common/guards/permission.guard.spec.ts
@@ -58,7 +58,7 @@ describe('PermissionGuard', () => {
     return {
       switchToHttp: () => ({
         getRequest: () => ({
-          user: user || { id: 'user-1', role: 'user' },
+          user: user || { id: 'user-1', roleCode: 'user' },
           params: params || {},
         }),
       }),
@@ -78,14 +78,27 @@ describe('PermissionGuard', () => {
       expect(mockUserPermissionService.findUserPermissions).not.toHaveBeenCalled();
     });
 
-    it('应该允许管理员跳过权限检查', async () => {
+    it('应该允许管理员跳过权限检查（基于 roleCode）', async () => {
       mockReflector.getAllAndOverride.mockReturnValue('view:department:document');
-      const context = createMockExecutionContext({ id: 'admin-1', role: 'admin' });
+      const context = createMockExecutionContext({ id: 'admin-1', roleCode: 'admin' });
 
       const result = await guard.canActivate(context);
 
       expect(result).toBe(true);
       expect(mockUserPermissionService.findUserPermissions).not.toHaveBeenCalled();
+    });
+
+    it('旧 role 字段不能触发管理员 bypass', async () => {
+      mockReflector.getAllAndOverride
+        .mockReturnValueOnce('view:department:document')
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(undefined);
+      mockUserPermissionService.findUserPermissions.mockResolvedValue({ data: [] });
+      const context = createMockExecutionContext({ id: 'admin-1', role: 'admin' });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(UnauthorizedException);
     });
 
     it('应该拒绝未登录的请求', async () => {

--- a/server/src/common/guards/permission.guard.ts
+++ b/server/src/common/guards/permission.guard.ts
@@ -103,7 +103,7 @@ export class PermissionGuard implements CanActivate {
     }
 
     // 管理员跳过权限检查
-    if (user.role === 'admin') {
+    if (user.roleCode === 'admin') {
       return true;
     }
 

--- a/server/src/common/guards/roles.guard.spec.ts
+++ b/server/src/common/guards/roles.guard.spec.ts
@@ -11,8 +11,8 @@ describe('RolesGuard', () => {
     guard = new RolesGuard(reflector);
   });
 
-  function createMockContext(userRole: string): ExecutionContext {
-    const request = { user: { id: 'user-1', username: 'testuser', role: userRole } };
+  function createMockContext(userRoleCode: string): ExecutionContext {
+    const request = { user: { id: 'user-1', username: 'testuser', roleCode: userRoleCode } };
     return {
       switchToHttp: () => ({
         getRequest: () => request,
@@ -70,7 +70,7 @@ describe('RolesGuard', () => {
     jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(['admin']);
     const context = {
       switchToHttp: () => ({
-        getRequest: () => ({ user: { id: 'u-1', username: 'bad-user', role: undefined } }),
+        getRequest: () => ({ user: { id: 'u-1', username: 'bad-user', roleCode: undefined } }),
       }),
       getHandler: () => jest.fn(),
       getClass: () => jest.fn(),

--- a/server/src/common/guards/roles.guard.ts
+++ b/server/src/common/guards/roles.guard.ts
@@ -19,7 +19,7 @@ export class RolesGuard implements CanActivate {
     const request = context.switchToHttp().getRequest();
     const user = request.user;
 
-    const roleCode = user?.role;
+    const roleCode = user?.roleCode;
     if (!roleCode) {
       throw new UnauthorizedException('用户缺少正式角色');
     }

--- a/server/src/modules/approval/approval.controller.ts
+++ b/server/src/modules/approval/approval.controller.ts
@@ -29,7 +29,7 @@ export class ApprovalController {
   @Get('pending')
   @ApiOperation({ summary: '获取当前用户的待审批列表' })
   async getPendingApprovals(@Request() req: any) {
-    return this.approvalService.getPendingApprovals(req.user.userId);
+    return this.approvalService.getPendingApprovals(req.user.id);
   }
 
   @Get('detail/:id')
@@ -49,7 +49,7 @@ export class ApprovalController {
   ) {
     const page = query.page ? Number(query.page) : 1;
     const limit = query.limit ? Number(query.limit) : 20;
-    return this.approvalService.getApprovalHistory(req.user.userId, page, limit);
+    return this.approvalService.getApprovalHistory(req.user.id, page, limit);
   }
 
   @Post(':id/approve')
@@ -58,7 +58,7 @@ export class ApprovalController {
   async approveUnified(@Param('id') id: string, @Body() dto: ApproveDto, @Request() req: any) {
     return this.approvalService.approveUnified(
       id,
-      req.user.userId,
+      req.user.id,
       dto.action,
       dto.comment || dto.rejectionReason,
     );
@@ -70,7 +70,7 @@ export class ApprovalController {
   async rejectUnified(@Param('id') id: string, @Body() dto: ApproveDto, @Request() req: any) {
     return this.approvalService.approveUnified(
       id,
-      req.user.userId,
+      req.user.id,
       'rejected',
       dto.rejectionReason || dto.comment,
     );

--- a/server/src/modules/auth/auth.controller.spec.ts
+++ b/server/src/modules/auth/auth.controller.spec.ts
@@ -24,10 +24,11 @@ describe('AuthController', () => {
 
   it('returns the authenticated user profile', async () => {
     const user = {
-      userId: 'user-1',
       id: 'user-1',
       username: 'admin',
-      role: 'admin',
+      roleCode: 'admin',
+      roleId: 'role-admin-id',
+      name: '管理员',
       companyId: '1',
     };
 

--- a/server/src/modules/auth/auth.controller.ts
+++ b/server/src/modules/auth/auth.controller.ts
@@ -23,6 +23,6 @@ export class AuthController {
   @UseGuards(JwtAuthGuard)
   @Patch('change-password')
   async changePassword(@Request() req: AuthenticatedRequest, @Body() dto: ChangePasswordDTO) {
-    return this.authService.changePassword(req.user.userId, dto);
+    return this.authService.changePassword(req.user.id, dto);
   }
 }

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -77,7 +77,7 @@ export class AuthService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: roleCode,
+        roleCode,
         roleId: user.roleId,
         companyId: user.company_id,
       },
@@ -107,9 +107,8 @@ export class AuthService {
   validateUser(payload: AuthTokenPayload) {
     return {
       id: payload.sub,
-      userId: payload.sub,
       username: payload.username,
-      role: payload.role,
+      roleCode: payload.role,
       roleId: payload.roleId ?? '',
       name: payload.name,
       companyId: payload.companyId ?? '1',

--- a/server/src/modules/auth/auth.strategy.spec.ts
+++ b/server/src/modules/auth/auth.strategy.spec.ts
@@ -12,11 +12,12 @@ describe('JwtStrategy', () => {
       strategy.validate({ sub: 'u1', username: 'admin', role: 'admin', name: '管理员', companyId: '2' }),
     ).resolves.toEqual({
       id: 'u1',
-      userId: 'u1',
       username: 'admin',
-      role: 'admin',
+      roleCode: 'admin',
+      roleId: '',
       name: '管理员',
       companyId: '2',
+      departmentId: undefined,
     });
   });
 

--- a/server/src/modules/auth/auth.strategy.ts
+++ b/server/src/modules/auth/auth.strategy.ts
@@ -25,9 +25,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: JwtPayload) {
     return {
       id: payload.sub,
-      userId: payload.sub,
       username: payload.username,
-      role: payload.role,
+      roleCode: payload.role,
       roleId: payload.roleId ?? '',
       name: payload.name,
       companyId: payload.companyId ?? '1',

--- a/server/src/modules/auth/authenticated-user.ts
+++ b/server/src/modules/auth/authenticated-user.ts
@@ -1,8 +1,7 @@
 export interface AuthenticatedUser {
   id: string;
-  userId: string;
   username: string;
-  role: 'admin' | 'leader' | 'user';
+  roleCode: string;
   roleId: string;
   name: string;
   companyId: string;

--- a/server/src/modules/auth/sso.service.ts
+++ b/server/src/modules/auth/sso.service.ts
@@ -53,7 +53,7 @@ export class SsoService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: user.roleObj?.code,
+        roleCode: user.roleObj?.code,
         companyId: user.company_id,
       },
     };
@@ -82,7 +82,7 @@ export class SsoService {
         id: user.id,
         username: user.username,
         name: user.name,
-        role: user.roleObj?.code,
+        roleCode: user.roleObj?.code,
         companyId: user.company_id,
       },
     };

--- a/server/src/modules/change-event/change-event.controller.ts
+++ b/server/src/modules/change-event/change-event.controller.ts
@@ -37,7 +37,7 @@ export class ChangeEventController {
     @Body() body: { dataJson?: object; existingRecordId?: string },
     @Request() req: { user: { id?: string; userId?: string } },
   ) {
-    const userId = req.user.id ?? req.user.userId;
+    const userId = req.user.id;
     if (!userId) throw new BadRequestException('Unable to resolve userId from token');
     return this.formTaskService.fillTask(taskId, body.dataJson ?? {}, userId, body.existingRecordId);
   }

--- a/server/src/modules/department-permission/department-permission.service.ts
+++ b/server/src/modules/department-permission/department-permission.service.ts
@@ -7,7 +7,7 @@ export interface ResourcePermConfig {
 }
 
 export interface DeptPermissionConfig {
-  isolationLevel: 'none' | 'department' | 'subdepartment';
+  isolationLevel: 'none' | 'department';
   allowedDeptIds: string[];
   resources: ResourcePermConfig[];
 }

--- a/server/src/modules/department/department.service.spec.ts
+++ b/server/src/modules/department/department.service.spec.ts
@@ -20,7 +20,6 @@ describe('DepartmentService', () => {
     id: 'dept-1',
     code: 'QA',
     name: '品质部',
-    parentId: null,
     managerId: 'u-1',
     manager: mockManager,
     status: 'active',
@@ -28,6 +27,8 @@ describe('DepartmentService', () => {
     createdAt: new Date(),
     updatedAt: new Date(),
   };
+
+  const validManagerCandidate = { status: 'active', roleObj: { code: 'leader' } };
 
   beforeEach(async () => {
     const mockPrisma = {
@@ -40,6 +41,7 @@ describe('DepartmentService', () => {
       },
       user: {
         updateMany: jest.fn(),
+        findUnique: jest.fn().mockResolvedValue(validManagerCandidate),
       },
       $transaction: jest.fn(async (cb) => cb(mockPrisma)),
     };
@@ -110,6 +112,27 @@ describe('DepartmentService', () => {
       );
       expect(prisma.user.updateMany).not.toHaveBeenCalled();
     });
+
+    it('managerId 对应用户不存在时应拒绝创建', async () => {
+      prisma.user.findUnique.mockResolvedValue(null);
+
+      await expect(service.create({ code: 'QA', name: '品质部', managerId: 'invalid-id' }))
+        .rejects.toThrow('负责人用户 invalid-id 不存在');
+    });
+
+    it('managerId 对应用户非 active 时应拒绝创建', async () => {
+      prisma.user.findUnique.mockResolvedValue({ status: 'disabled', roleObj: { code: 'leader' } });
+
+      await expect(service.create({ code: 'QA', name: '品质部', managerId: 'u-inactive' }))
+        .rejects.toThrow('负责人必须为 active 状态的用户');
+    });
+
+    it('managerId 对应用户非 leader 角色时应拒绝创建', async () => {
+      prisma.user.findUnique.mockResolvedValue({ status: 'active', roleObj: { code: 'admin' } });
+
+      await expect(service.create({ code: 'QA', name: '品质部', managerId: 'u-not-leader' }))
+        .rejects.toThrow('负责人必须为 leader 角色的用户');
+    });
   });
 
   describe('update', () => {
@@ -132,12 +155,12 @@ describe('DepartmentService', () => {
   });
 
   describe('findOne', () => {
-    it('应该返回部门详情', async () => {
+    it('应该返回部门详情（含 managerStatus）', async () => {
       prisma.department.findUnique.mockResolvedValue(mockDepartment);
 
       const result = await service.findOne('dept-1');
 
-      expect(result).toEqual(mockDepartment);
+      expect(result).toEqual({ ...mockDepartment, managerStatus: 'valid' });
     });
 
     it('部门不存在时应该抛出 NotFoundException', async () => {

--- a/server/src/modules/department/department.service.ts
+++ b/server/src/modules/department/department.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { CreateDepartmentDTO } from './dto/create-department.dto';
 import { UpdateDepartmentDTO } from './dto/update-department.dto';
@@ -20,8 +20,38 @@ export class DepartmentService {
     },
   };
 
+  /**
+   * 确认候选负责人满足条件：active 状态 + leader 角色。
+   * 写入非空 managerId 前必须调用。
+   */
+  private async assertManagerCandidate(tx: any, managerId: string): Promise<void> {
+    const candidate = await tx.user.findUnique({
+      where: { id: managerId },
+      select: { status: true, roleObj: { select: { code: true } } },
+    });
+    if (!candidate) {
+      throw new BadRequestException(`负责人用户 ${managerId} 不存在`);
+    }
+    if (candidate.status !== 'active') {
+      throw new BadRequestException('负责人必须为 active 状态的用户');
+    }
+    if (candidate.roleObj?.code !== 'leader') {
+      throw new BadRequestException('负责人必须为 leader 角色的用户');
+    }
+  }
+
+  private addManagerStatus(dept: any): any {
+    if (!dept.managerId) return { ...dept, managerStatus: null };
+    const manager = dept.manager;
+    const isValid =
+      manager &&
+      manager.status === 'active' &&
+      manager.roleObj?.code === 'leader';
+    return { ...dept, managerStatus: isValid ? 'valid' : 'invalid' };
+  }
+
   async findAll(limit = 100) {
-    const [list, total] = await Promise.all([
+    const [rawList, total] = await Promise.all([
       this.prisma.department.findMany({
         where: { deletedAt: null },
         take: limit,
@@ -30,7 +60,7 @@ export class DepartmentService {
       }),
       this.prisma.department.count({ where: { deletedAt: null } }),
     ]);
-    return { list, total };
+    return { list: rawList.map((d) => this.addManagerStatus(d)), total };
   }
 
   async findOne(id: string) {
@@ -41,17 +71,19 @@ export class DepartmentService {
     if (!department) {
       throw new NotFoundException('部门不存在');
     }
-    return department;
+    return this.addManagerStatus(department);
   }
 
   async create(dto: CreateDepartmentDTO) {
     return this.prisma.$transaction(async (tx) => {
+      if (dto.managerId) {
+        await this.assertManagerCandidate(tx as any, dto.managerId);
+      }
       const department = await tx.department.create({
         data: {
           id: crypto.randomUUID(),
           code: dto.code,
           name: dto.name,
-          parentId: dto.parentId || null,
           managerId: dto.managerId || null,
           status: 'active',
         },
@@ -63,18 +95,20 @@ export class DepartmentService {
           data: { departmentId: department.id },
         });
       }
-      return department;
+      return this.addManagerStatus(department);
     });
   }
 
   async update(id: string, dto: UpdateDepartmentDTO) {
     await this.findOne(id);
     return this.prisma.$transaction(async (tx) => {
+      if (dto.managerId) {
+        await this.assertManagerCandidate(tx as any, dto.managerId);
+      }
       const department = await tx.department.update({
         where: { id },
         data: {
           name: dto.name,
-          parentId: dto.parentId,
           managerId: dto.managerId,
           status: dto.status,
         },
@@ -86,7 +120,7 @@ export class DepartmentService {
           data: { departmentId: department.id },
         });
       }
-      return department;
+      return this.addManagerStatus(department);
     });
   }
 

--- a/server/src/modules/department/dto/create-department.dto.ts
+++ b/server/src/modules/department/dto/create-department.dto.ts
@@ -8,9 +8,6 @@ export class CreateDepartmentDTO {
   @ApiProperty({ description: '部门名称' })
   @IsString() name: string;
 
-  @ApiProperty({ required: false, description: '上级部门ID' })
-  @IsOptional() @IsString() parentId?: string;
-
   @ApiProperty({ required: false, description: '部门负责人用户ID' })
   @IsOptional() @IsString() managerId?: string;
 }

--- a/server/src/modules/department/dto/update-department.dto.ts
+++ b/server/src/modules/department/dto/update-department.dto.ts
@@ -5,9 +5,6 @@ export class UpdateDepartmentDTO {
   @ApiProperty({ required: false, description: '部门名称' })
   @IsOptional() @IsString() name?: string;
 
-  @ApiProperty({ required: false, description: '上级部门ID' })
-  @IsOptional() @IsString() parentId?: string;
-
   @ApiProperty({ required: false, description: '部门负责人用户ID' })
   @IsOptional() @IsString() managerId?: string;
 

--- a/server/src/modules/document/document.controller.ts
+++ b/server/src/modules/document/document.controller.ts
@@ -102,7 +102,7 @@ export class DocumentController {
   @Get()
   @ApiOperation({ summary: '查询文档列表' })
   async findAll(@Query() query: DocumentQueryDto, @Req() req: any) {
-    return this.documentService.findAll(query, req.user.id, req.user.role);
+    return this.documentService.findAll(query, req.user.id, req.user.roleCode);
   }
 
   @Get('pending-approvals')
@@ -116,7 +116,7 @@ export class DocumentController {
     const limitNum = Math.min(Number(limit) || 20, 100);
     return this.documentService.findPendingApprovals(
       req.user.id,
-      req.user.role,
+      req.user.roleCode,
       pageNum,
       limitNum,
     );
@@ -369,7 +369,7 @@ export class DocumentController {
   @Get(':id')
   @ApiOperation({ summary: '查询文档详情' })
   async findOne(@Param('id') id: string, @Req() req: any) {
-    const document = await this.documentService.findOne(id, req.user.id, req.user.role);
+    const document = await this.documentService.findOne(id, req.user.id, req.user.roleCode);
 
     // BR-356: 部门边界检查
     // BR-357: 跨部门权限验证
@@ -390,7 +390,7 @@ export class DocumentController {
   @Get(':id/reference-health')
   @ApiOperation({ summary: '查询单个文档引用健康度' })
   async getDocumentReferenceHealth(@Param('id') id: string, @Req() req: any) {
-    const document = await this.documentService.findOne(id, req.user.id, req.user.role);
+    const document = await this.documentService.findOne(id, req.user.id, req.user.roleCode);
     const canAccess = await this.departmentPermissionService.canAccessDepartmentResource(
       req.user.id,
       document.departmentId,
@@ -408,7 +408,7 @@ export class DocumentController {
   @Get(':id/versions')
   @ApiOperation({ summary: '查询文档版本历史' })
   async getVersionHistory(@Param('id') id: string, @Req() req: any) {
-    return this.documentService.getVersionHistory(id, req.user.id, req.user.role);
+    return this.documentService.getVersionHistory(id, req.user.id, req.user.roleCode);
   }
 
   @Get(':id/versions/:v1/compare/:v2')
@@ -442,7 +442,7 @@ export class DocumentController {
     @Param('version') version: string,
     @Req() req: any,
   ) {
-    return this.documentService.getVersionPreview(id, version, req.user.id, req.user.role);
+    return this.documentService.getVersionPreview(id, version, req.user.id, req.user.roleCode);
   }
 
   @Get(':id/versions/:version/download')
@@ -453,13 +453,13 @@ export class DocumentController {
     @Req() req: any,
     @Res() res: Response,
   ) {
-    return this.documentService.downloadVersion(id, version, req.user.id, req.user.role, res);
+    return this.documentService.downloadVersion(id, version, req.user.id, req.user.roleCode, res);
   }
 
   @Post(':id/deactivate')
   @ApiOperation({ summary: '停用文档' })
   async deactivate(@Param('id') id: string, @Req() req: any) {
-    return this.documentService.deactivate(id, req.user.id, req.user.role);
+    return this.documentService.deactivate(id, req.user.id, req.user.roleCode);
   }
 
   @Post(':id/archive')
@@ -471,7 +471,7 @@ export class DocumentController {
     @Body() dto: ArchiveDocumentDto,
     @Req() req: any,
   ) {
-    return this.documentService.archive(id, dto.reason, req.user.id, req.user.role);
+    return this.documentService.archive(id, dto.reason, req.user.id, req.user.roleCode);
   }
 
   @Post(':id/obsolete')
@@ -483,7 +483,7 @@ export class DocumentController {
     @Body() dto: ObsoleteDocumentDto,
     @Req() req: any,
   ) {
-    return this.documentService.obsolete(id, dto.reason, req.user.id, req.user.role);
+    return this.documentService.obsolete(id, dto.reason, req.user.id, req.user.roleCode);
   }
 
   @Post(':id/restore')
@@ -493,7 +493,7 @@ export class DocumentController {
     @Body() dto: RestoreDocumentDto,
     @Req() req: any,
   ) {
-    return this.documentService.restore(id, dto.reason, req.user.id, req.user.role);
+    return this.documentService.restore(id, dto.reason, req.user.id, req.user.roleCode);
   }
 
   @Put(':id')
@@ -512,7 +512,7 @@ export class DocumentController {
   @Patch(':id/markdown')
   @ApiOperation({ summary: '更新 Markdown 正文' })
   updateMarkdown(@Param('id') id: string, @Body() dto: UpdateMarkdownDto, @Req() req: any) {
-    return this.documentService.updateMarkdown(id, req.user.id, req.user.role, dto);
+    return this.documentService.updateMarkdown(id, req.user.id, req.user.roleCode, dto);
   }
 
   @Delete(':id')
@@ -560,13 +560,13 @@ export class DocumentController {
     @Req() req: any,
     @Res() res: Response,
   ) {
-    return this.filePreviewService.downloadFile(id, req.user.id, req.user.role, res);
+    return this.filePreviewService.downloadFile(id, req.user.id, req.user.roleCode, res);
   }
 
   @Get(':id/preview')
   @ApiOperation({ summary: '获取文档预览信息' })
   async getPreviewUrl(@Param('id') id: string, @Req() req: any) {
-    return this.filePreviewService.getPreviewUrl(id, req.user.id, req.user.role);
+    return this.filePreviewService.getPreviewUrl(id, req.user.id, req.user.roleCode);
   }
 
   // =============================

--- a/server/src/modules/export/export.service.ts
+++ b/server/src/modules/export/export.service.ts
@@ -76,10 +76,10 @@ export class ExportService {
 
     // HIGH-1: 服务层权限过滤（BR-028, BR-313）
     if (user) {
-      if (user.role === 'user') {
+      if (user.roleCode === 'user') {
         // 普通用户：只能导出自己创建的
         where.creatorId = user.id;
-      } else if (user.role === 'leader') {
+      } else if (user.roleCode === 'leader') {
         // 部门领导：只能导出本部门的
         where.creator = { departmentId: user.departmentId };
       }
@@ -100,7 +100,7 @@ export class ExportService {
   async exportTasks(dto: ExportTasksDto, user?: any): Promise<Buffer> {
     const where = this.buildTaskWhere(dto);
 
-    if (user && user.role === 'user') {
+    if (user && user.roleCode === 'user') {
       where.createdBy = user.id;
     }
 
@@ -118,7 +118,7 @@ export class ExportService {
   async exportTaskRecords(dto: ExportTaskRecordsDto, user?: any): Promise<Buffer> {
     const where = this.buildTaskRecordWhere(dto);
 
-    if (user && user.role === 'user') {
+    if (user && user.roleCode === 'user') {
       where.createdBy = user.id;
     }
 
@@ -136,10 +136,10 @@ export class ExportService {
 
     // HIGH-1: 服务层权限过滤（BR-028, BR-313）
     if (user) {
-      if (user.role === 'user') {
+      if (user.roleCode === 'user') {
         // 普通用户：只能导出自己创建的偏离报告
         where.creatorId = user.id;
-      } else if (user.role === 'leader') {
+      } else if (user.roleCode === 'leader') {
         // 部门领导：只能导出本部门的偏离报告
         where.creator = { departmentId: user.departmentId };
       }
@@ -162,13 +162,13 @@ export class ExportService {
 
     // HIGH-1: 服务层权限过滤（BR-028, BR-313）
     if (user) {
-      if (user.role === 'user') {
+      if (user.roleCode === 'user') {
         // 普通用户：只能导出与自己相关的审批（作为审批人或文档创建人）
         where.OR = [
           { approverId: user.id },
           { document: { creatorId: user.id } },
         ];
-      } else if (user.role === 'leader') {
+      } else if (user.roleCode === 'leader') {
         // 部门领导：只能导出本部门的审批
         where.approver = { departmentId: user.departmentId };
       }

--- a/server/src/modules/internal-audit/audit-execution/audit-execution.controller.ts
+++ b/server/src/modules/internal-audit/audit-execution/audit-execution.controller.ts
@@ -42,7 +42,7 @@ export class AuditExecutionController {
   async create(@Body() createDto: CreateAuditFindingDto, @Request() req: AuthenticatedRequest) {
     const result = await this.auditExecutionService.create(
       createDto,
-      req.user.userId,
+      req.user.id,
     );
 
     const details = {
@@ -78,7 +78,7 @@ export class AuditExecutionController {
     const result = await this.auditExecutionService.update(
       id,
       updateDto,
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -121,7 +121,7 @@ export class AuditExecutionController {
   ) {
     try {
       await this.auditService.createSensitiveLog({
-        userId: req.user.userId,
+        userId: req.user.id,
         username: req.user.username,
         action,
         resourceType,

--- a/server/src/modules/internal-audit/audit-execution/audit-execution.types.ts
+++ b/server/src/modules/internal-audit/audit-execution/audit-execution.types.ts
@@ -1,12 +1,6 @@
 import { Request as ExpressRequest } from 'express';
+import { AuthenticatedUser } from '../../auth/authenticated-user';
 
-/**
- * Authenticated request interface with JWT user payload
- */
 export interface AuthenticatedRequest extends ExpressRequest {
-  user: {
-    userId: string;
-    username: string;
-    role: string;
-  };
+  user: AuthenticatedUser;
 }

--- a/server/src/modules/internal-audit/audit-plan/audit-plan.controller.ts
+++ b/server/src/modules/internal-audit/audit-plan/audit-plan.controller.ts
@@ -37,9 +37,9 @@ export class AuditPlanController {
   @ApiOperation({ summary: 'Create audit plan' })
   @ApiResponse({ status: 201, description: 'Plan created successfully' })
   async create(@Body() createDto: CreateAuditPlanDto, @Request() req: any) {
-    const result = await this.auditPlanService.create(createDto, req.user.userId);
+    const result = await this.auditPlanService.create(createDto, req.user.id);
     await this.auditService.createSensitiveLog({
-      userId: req.user.userId,
+      userId: req.user.id,
       username: req.user.username,
       action: 'create_audit_plan',
       resourceType: 'AuditPlan',
@@ -87,7 +87,7 @@ export class AuditPlanController {
   ) {
     const result = await this.auditPlanService.update(id, updateDto);
     await this.auditService.createSensitiveLog({
-      userId: req.user.userId,
+      userId: req.user.id,
       username: req.user.username,
       action: 'update_audit_plan',
       resourceType: 'AuditPlan',
@@ -107,7 +107,7 @@ export class AuditPlanController {
   async remove(@Param('id') id: string, @Request() req: any) {
     const result = await this.auditPlanService.remove(id);
     await this.auditService.createSensitiveLog({
-      userId: req.user.userId,
+      userId: req.user.id,
       username: req.user.username,
       action: 'delete_audit_plan',
       resourceType: 'AuditPlan',
@@ -127,7 +127,7 @@ export class AuditPlanController {
   async start(@Param('id') id: string, @Request() req: any) {
     const result = await this.auditPlanService.execute(id);
     await this.auditService.createSensitiveLog({
-      userId: req.user.userId,
+      userId: req.user.id,
       username: req.user.username,
       action: 'start_audit_plan',
       resourceType: 'AuditPlan',
@@ -146,9 +146,9 @@ export class AuditPlanController {
   @ApiResponse({ status: 201, description: 'Plan copied successfully' })
   @ApiResponse({ status: 404, description: 'Original plan not found' })
   async copyPlan(@Param('id') id: string, @Request() req: any) {
-    const result = await this.auditPlanService.copyPlan(id, req.user.userId);
+    const result = await this.auditPlanService.copyPlan(id, req.user.id);
     await this.auditService.createSensitiveLog({
-      userId: req.user.userId,
+      userId: req.user.id,
       username: req.user.username,
       action: 'copy_audit_plan',
       resourceType: 'AuditPlan',

--- a/server/src/modules/internal-audit/rectification/rectification.controller.ts
+++ b/server/src/modules/internal-audit/rectification/rectification.controller.ts
@@ -20,13 +20,10 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { PermissionGuard } from '../../../common/guards/permission.guard';
 import { CheckPermission } from '../../../common/decorators/permission.decorator';
 import { AuditService } from '../../audit/audit.service';
+import { AuthenticatedUser } from '../../auth/authenticated-user';
 
 interface AuthenticatedRequest extends ExpressRequest {
-  user: {
-    userId: string;
-    username: string;
-    role: string;
-  };
+  user: AuthenticatedUser;
 }
 
 @ApiTags('Audit Rectification')
@@ -45,7 +42,7 @@ export class RectificationController {
   @ApiResponse({ status: 200, description: 'Rectification tasks retrieved' })
   async getMyRectifications(@Request() req: AuthenticatedRequest) {
     const results = await this.rectificationService.getMyRectifications(
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -75,7 +72,7 @@ export class RectificationController {
     const result = await this.rectificationService.submitRectification(
       id,
       submitDto,
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -103,7 +100,7 @@ export class RectificationController {
   ) {
     try {
       await this.auditService.createSensitiveLog({
-        userId: req.user.userId,
+        userId: req.user.id,
         username: req.user.username,
         action,
         resourceType,

--- a/server/src/modules/internal-audit/report/report.controller.ts
+++ b/server/src/modules/internal-audit/report/report.controller.ts
@@ -21,13 +21,10 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { PermissionGuard } from '../../../common/guards/permission.guard';
 import { CheckPermission } from '../../../common/decorators/permission.decorator';
 import { AuditService } from '../../audit/audit.service';
+import { AuthenticatedUser } from '../../auth/authenticated-user';
 
 interface AuthenticatedRequest extends ExpressRequest {
-  user: {
-    userId: string;
-    username: string;
-    role: string;
-  };
+  user: AuthenticatedUser;
 }
 
 @ApiTags('Audit Report')
@@ -55,7 +52,7 @@ export class ReportController {
   ) {
     const result = await this.reportService.completePlanAndGenerateReport(
       id,
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -127,7 +124,7 @@ export class ReportController {
   ) {
     try {
       await this.auditService.createSensitiveLog({
-        userId: req.user.userId,
+        userId: req.user.id,
         username: req.user.username,
         action,
         resourceType,

--- a/server/src/modules/internal-audit/verification/verification.controller.ts
+++ b/server/src/modules/internal-audit/verification/verification.controller.ts
@@ -20,14 +20,10 @@ import { JwtAuthGuard } from '../../auth/jwt-auth.guard';
 import { PermissionGuard } from '../../../common/guards/permission.guard';
 import { CheckPermission } from '../../../common/decorators/permission.decorator';
 import { AuditService } from '../../audit/audit.service';
+import { AuthenticatedUser } from '../../auth/authenticated-user';
 
 interface AuthenticatedRequest extends ExpressRequest {
-  user: {
-    userId: string;
-    username: string;
-    role: string;
-    companyId: string;
-  };
+  user: AuthenticatedUser;
 }
 
 @ApiTags('Audit Verification')
@@ -46,7 +42,7 @@ export class VerificationController {
   @ApiResponse({ status: 200, description: 'Pending verifications retrieved' })
   async getPendingVerifications(@Request() req: AuthenticatedRequest) {
     const results = await this.verificationService.getPendingVerifications(
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -79,7 +75,7 @@ export class VerificationController {
     const result = await this.verificationService.verifyRectification(
       id,
       verifyDto,
-      req.user.userId,
+      req.user.id,
       req.user.companyId,
     );
 
@@ -110,7 +106,7 @@ export class VerificationController {
     const result = await this.verificationService.rejectRectification(
       id,
       rejectDto,
-      req.user.userId,
+      req.user.id,
     );
 
     await this.logSensitiveOperation(
@@ -135,7 +131,7 @@ export class VerificationController {
   ) {
     try {
       await this.auditService.createSensitiveLog({
-        userId: req.user.userId,
+        userId: req.user.id,
         username: req.user.username,
         action,
         resourceType,

--- a/server/src/modules/org-bootstrap/org-bootstrap.service.ts
+++ b/server/src/modules/org-bootstrap/org-bootstrap.service.ts
@@ -13,6 +13,13 @@ export class OrgBootstrapService {
   }
 
   async getStatus(): Promise<OrgBootstrapStatusDto> {
+    const completedFlag = await this.prisma.systemConfig.findUnique({
+      where: { key: BOOTSTRAP_CONFIG_KEY },
+    });
+    if (completedFlag?.value === 'true') {
+      return { completed: true, step: 'completed', reasons: [] };
+    }
+
     const [systemRoles, departments, managedDepartments, businessMembers] = await Promise.all([
       this.prisma.role.count({
         where: { code: { in: ['admin', 'leader', 'user'] }, deletedAt: null },

--- a/server/src/modules/record-task/record-task.controller.ts
+++ b/server/src/modules/record-task/record-task.controller.ts
@@ -36,8 +36,8 @@ export class RecordTaskController {
   @Get('record-task-assignments')
   @ApiOperation({ summary: '列表（管理员看全部；员工看本部门）' })
   findAll(@Req() req: any) {
-    const isAdmin = req.user?.role === 'admin';
-    return this.assignmentService.findAll(req.user.userId, isAdmin);
+    const isAdmin = req.user?.roleCode === 'admin';
+    return this.assignmentService.findAll(req.user.id, isAdmin);
   }
 
   @Get('record-task-assignments/:id')
@@ -71,7 +71,7 @@ export class RecordTaskController {
   @ApiOperation({ summary: '员工查看本部门待填实例' })
   findPending(@Req() req: any, @Query() query: { page?: string; limit?: string }) {
     return this.instanceService.findPending(
-      req.user.userId ?? req.user.id,
+      req.user.id,
       query.page ? Number(query.page) : 1,
       query.limit ? Number(query.limit) : 20,
     );

--- a/server/src/modules/record/record.controller.ts
+++ b/server/src/modules/record/record.controller.ts
@@ -40,7 +40,7 @@ export class RecordController {
   @ApiResponse({ status: 404, description: '模板不存在' })
   @ApiResponse({ status: 400, description: '数据验证失败' })
   create(@Body() createDto: CreateRecordDto, @Req() req: any) {
-    return this.recordService.create(createDto, req.user.userId);
+    return this.recordService.create(createDto, req.user.id);
   }
 
   @Get()
@@ -66,7 +66,7 @@ export class RecordController {
   @ApiResponse({ status: 404, description: '记录不存在' })
   @ApiResponse({ status: 400, description: '数据验证失败' })
   update(@Param('id') id: string, @Body() updateDto: UpdateRecordDto, @Req() req: any) {
-    return this.recordService.update(id, updateDto, req.user.userId);
+    return this.recordService.update(id, updateDto, req.user.id);
   }
 
   @Delete(':id')
@@ -97,7 +97,7 @@ export class RecordController {
   @ApiResponse({ status: 400, description: '状态不允许提交' })
   @ApiResponse({ status: 404, description: '记录不存在' })
   submit(@Param('id') id: string, @Body() dto: SubmitRecordDto, @Req() req: any) {
-    return this.recordService.submit(id, req.user.userId, dto.deviationReasons);
+    return this.recordService.submit(id, req.user.id, dto.deviationReasons);
   }
 
   /**
@@ -117,7 +117,7 @@ export class RecordController {
     if (!body.password) {
       throw new BadRequestException('电子签名需要密码验证');
     }
-    return this.recordService.signRecord(id, req.user.userId, body);
+    return this.recordService.signRecord(id, req.user.id, body);
   }
 
   /**
@@ -137,7 +137,7 @@ export class RecordController {
     if (!body.reason || body.reason.length < 10) {
       throw new BadRequestException('变更原因至少 10 个字符');
     }
-    return this.recordService.updateApproved(id, { dataJson: body.dataJson }, req.user.userId, body.reason);
+    return this.recordService.updateApproved(id, { dataJson: body.dataJson }, req.user.id, body.reason);
   }
 
   /**

--- a/server/src/modules/recycle-bin/recycle-bin.controller.ts
+++ b/server/src/modules/recycle-bin/recycle-bin.controller.ts
@@ -20,7 +20,7 @@ export class RecycleBinController {
       query.limit ?? 10,
       query.keyword,
       req.user.id,
-      req.user.role,
+      req.user.roleCode,
     );
   }
 
@@ -30,7 +30,7 @@ export class RecycleBinController {
     @Body() dto: BatchOperationDto,
     @Req() req: any,
   ) {
-    await this.service.batchRestore(type, dto.ids, req.user.id, req.user.role);
+    await this.service.batchRestore(type, dto.ids, req.user.id, req.user.roleCode);
     return { success: true, message: `成功恢复 ${dto.ids.length} 项` };
   }
 
@@ -40,7 +40,7 @@ export class RecycleBinController {
     @Body() dto: BatchOperationDto,
     @Req() req: any,
   ) {
-    await this.service.batchPermanentDelete(type, dto.ids, req.user.id, req.user.role);
+    await this.service.batchPermanentDelete(type, dto.ids, req.user.id, req.user.roleCode);
     return { success: true, message: `成功删除 ${dto.ids.length} 项` };
   }
 
@@ -50,7 +50,7 @@ export class RecycleBinController {
     @Param('id') id: string,
     @Req() req: any,
   ) {
-    await this.service.restore(type, id, req.user.id, req.user.role);
+    await this.service.restore(type, id, req.user.id, req.user.roleCode);
     return { success: true, message: '恢复成功' };
   }
 
@@ -60,7 +60,7 @@ export class RecycleBinController {
     @Param('id') id: string,
     @Req() req: any,
   ) {
-    await this.service.permanentDelete(type, id, req.user.id, req.user.role);
+    await this.service.permanentDelete(type, id, req.user.id, req.user.roleCode);
     return { success: true, message: '永久删除成功' };
   }
 }

--- a/server/src/modules/unified-approval/approval-definition.controller.ts
+++ b/server/src/modules/unified-approval/approval-definition.controller.ts
@@ -4,8 +4,8 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { PrismaService } from '../../prisma/prisma.service';
 
 function assertAdmin(req: any) {
-  const role = req?.user?.role ?? req?.user?.roleObj?.code;
-  if (role !== 'admin') throw new ForbiddenException('仅管理员可操作审批定义');
+  const roleCode = req?.user?.roleCode;
+  if (roleCode !== 'admin') throw new ForbiddenException('仅管理员可操作审批定义');
 }
 
 class CreateApprovalDefinitionDto {

--- a/server/src/modules/workflow/workflow-instance.controller.ts
+++ b/server/src/modules/workflow/workflow-instance.controller.ts
@@ -75,7 +75,7 @@ export class WorkflowInstanceController {
     @Body() cancelDto: CancelWorkflowInstanceDto,
     @Request() req: any,
   ) {
-    return this.instanceService.cancel(id, cancelDto, req.user.id, req.user.role);
+    return this.instanceService.cancel(id, cancelDto, req.user.id, req.user.roleCode);
   }
 
   @Get(':id')

--- a/server/src/prisma/migrations/20260509090000_remove_department_parent_id/migration.sql
+++ b/server/src/prisma/migrations/20260509090000_remove_department_parent_id/migration.sql
@@ -1,0 +1,8 @@
+-- Migration: Remove Department.parentId (single-level department enforcement)
+-- This removes the tree hierarchy from departments, making them flat.
+
+-- Drop the self-referential foreign key constraint first
+ALTER TABLE "departments" DROP CONSTRAINT IF EXISTS "departments_parentId_fkey";
+
+-- Drop the parentId column
+ALTER TABLE "departments" DROP COLUMN IF EXISTS "parentId";

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -208,9 +208,6 @@ model Department {
   id        String       @id
   code      String       @unique
   name      String
-  parentId  String?
-  parent    Department?  @relation("DepartmentParent", fields: [parentId], references: [id], onDelete: SetNull)
-  children  Department[] @relation("DepartmentParent")
   managerId String?
   manager   User?        @relation("DepartmentManager", fields: [managerId], references: [id], onDelete: SetNull)
   status    String       @default("active")


### PR DESCRIPTION
## Summary

本 PR 覆盖 [MYL-511](mention://issue/b64a9d75-45be-4479-a40c-4aefcabe5601) 规划的四条主线。

### 1. 角色来源收口

- `AuthenticatedUser.role` → `roleCode`，移除 `userId` shadow 字段
- `auth.strategy.ts` `validate()` 将 JWT `payload.role` 映射为 `roleCode`（JWT 内部字段名保持 `role`）
- `auth.service.ts`、`sso.service.ts` 登录返回 `roleCode`
- `roles.guard.ts`、`export.service.ts`、各业务 controller 消费 `req.user.roleCode`
- 共享类型 `CurrentUser.role` → `roleCode`，`LoginResponse.user.role` → `roleCode`
- 前端 user store `isAdmin`/`isLeader` 基于 `roleCode`
- 内审模块 4 个 controller 的本地 `AuthenticatedRequest` 接口统一引用 `AuthenticatedUser`

### 2. 单层部门收口

- `schema.prisma` 删除 `Department.parentId`、`parent`/`children` 自引用关系
- 新增迁移 `20260509090000_remove_department_parent_id`
- `create-department.dto.ts` / `update-department.dto.ts` 移除 `parentId`
- `DepartmentPermission.vue` 从 `el-tree` 树形改为 `el-table` 平面列表
- `DeptPermissionConfig.isolationLevel` 类型限制为 `none | department`（删除 `subdepartment`）

### 3. 部门负责人事实源收口

- `department.service.ts` 新增 `assertManagerCandidate()`（`leader` + `active` 双校验）
- `create()` / `update()` 写入非空 `managerId` 前必须经过 gate
- `addManagerStatus()` 为读取结果附加 `managerStatus: 'valid' | 'invalid' | null`
- `packages/types/api.ts` `Department` 接口移除 `parentId`/`parentName`

### 4. 初始化状态权威来源收口

- `org-bootstrap.service.ts` `getStatus()` 入口处先读 `org_permission_bootstrap_completed` 持久化标记
- 已完成状态不进入动态检查逻辑，不可回退

## 验证

- `rg` 扫描：`parentId`（源码层）、`subdepartment`、`CurrentUser.role`、`req.user.role`、`req.user.userId` 均已清零
- 服务端 tsc 无新增 auth 相关类型错误（剩余错误均为 Prisma schema drift，属 pre-existing）
- `DepartmentPermission` 12 个 vitest 测试全部通过
- `org-bootstrap` 6 个 jest 测试全部通过

## 迁移

需在部署前执行：
```sql
ALTER TABLE "departments" DROP CONSTRAINT IF EXISTS "departments_parentId_fkey";
ALTER TABLE "departments" DROP COLUMN IF EXISTS "parentId";
```

## 剩余风险

- 运行时验证（空库重建、bootstrap 流程演练）需在 DB 可用环境执行
- 服务端 pre-existing Prisma drift 错误（非本 PR 引入）需独立处理