### PR TITLE
PR2: Record.status signed 与 TaskStatus 共享类型收口

### DIFF
--- a/client/src/api/record.ts
+++ b/client/src/api/record.ts
@@ -10,7 +10,7 @@ export interface Record {
   templateId: string;
   dataJson: globalThis.Record<string, unknown>;
   submitterId: string;
-  status: 'draft' | 'submitted' | 'approved' | 'rejected';
+  status: 'draft' | 'submitted' | 'signed' | 'approved' | 'rejected';
   submittedAt?: string;
   approvedAt?: string;
   createdAt: string;

--- a/client/src/api/task.ts
+++ b/client/src/api/task.ts
@@ -1,16 +1,10 @@
 import request from './request';
+import type { TaskStatus } from '@noidear/types';
+export type { TaskStatus };
 
 // =========================================================================
 // Types
 // =========================================================================
-
-export type TaskStatus =
-  | 'pending'
-  | 'submitted'
-  | 'approved'
-  | 'rejected'
-  | 'cancelled'
-  | 'overdue';
 
 export interface TaskTemplate {
   id: string;

--- a/client/src/views/record/RecordDetail.vue
+++ b/client/src/views/record/RecordDetail.vue
@@ -95,8 +95,8 @@ const loading = ref(false);
 const record = ref<any>(null);
 const changeLogs = ref<RecordChangeLog[]>([]);
 
-const statusTextMap: Record<string, string> = { draft: '草稿', submitted: '已提交', approved: '已通过', rejected: '已驳回' };
-const statusTypeMap: Record<string, string> = { draft: 'info', submitted: 'warning', approved: 'success', rejected: 'danger' };
+const statusTextMap: Record<string, string> = { draft: '草稿', submitted: '已提交', signed: '已签署', approved: '已通过', rejected: '已驳回' };
+const statusTypeMap: Record<string, string> = { draft: 'info', submitted: 'warning', signed: 'success', approved: 'success', rejected: 'danger' };
 
 const formatValue = (value: unknown): string => {
   if (value === null || value === undefined) return '-';

--- a/client/src/views/record/RecordList.vue
+++ b/client/src/views/record/RecordList.vue
@@ -94,8 +94,8 @@ const router = useRouter();
 const loading = ref(false);
 const tableData = ref<any[]>([]);
 
-const statusTextMap: Record<string, string> = { draft: '草稿', submitted: '已提交', approved: '已通过', rejected: '已驳回' };
-const statusTypeMap: Record<string, string> = { draft: 'info', submitted: 'warning', approved: 'success', rejected: 'danger' };
+const statusTextMap: Record<string, string> = { draft: '草稿', submitted: '已提交', signed: '已签署', approved: '已通过', rejected: '已驳回' };
+const statusTypeMap: Record<string, string> = { draft: 'info', submitted: 'warning', signed: 'success', approved: 'success', rejected: 'danger' };
 
 const filterForm = reactive({ status: '' });
 const pagination = reactive({ page: 1, limit: 20, total: 0 });

--- a/packages/types/task.ts
+++ b/packages/types/task.ts
@@ -1,6 +1,12 @@
 // 任务相关类型
 
-export type TaskStatus = 'pending' | 'completed' | 'cancelled';
+export type TaskStatus =
+  | 'pending'
+  | 'submitted'
+  | 'approved'
+  | 'rejected'
+  | 'cancelled'
+  | 'overdue';
 export type TaskRecordStatus = 'pending' | 'submitted' | 'approved' | 'rejected';
 
 export interface Task {


### PR DESCRIPTION
## Summary

- `client/src/api/record.ts`: `Record.status` 类型补充 `'signed'`，对齐后端 `signRecord` 写入值
- `client/src/views/record/RecordDetail.vue` + `RecordList.vue`: `statusTextMap` / `statusTypeMap` 补全 `signed: '已签署'`
- `packages/types/task.ts`: `TaskStatus` 从 3 种扩展到 6 种 (`pending | submitted | approved | rejected | cancelled | overdue`)，删除旧 `'completed'`
- `client/src/api/task.ts`: 删除本地 `TaskStatus` 重定义，改为从 `@noidear/types` 导入

## Plan

`docs/superpowers/plans/2026-05-09-semantic-dedup-hotfix-pack.md`

## Execution Issue

MYL-517

## Root Issue

MYL-510 (facbb7cc-f03b-47d3-9a5a-ac1b291fd62c)

## Verification

- `npm run build:client`: ✅ 0 errors (3595 modules transformed)
- `npm run build:server`: 188 pre-existing errors (existed before this PR, not introduced by these changes)
- No duplicate `TaskStatus` definition in `client/src/`: confirmed via `rg -n "type TaskStatus"`