### PR TITLE
feat: domain source-of-truth and semantic dedup cleanup (MYL-538)

### DIFF
--- a/docs/superpowers/plans/2026-05-03-gap-505-user-role-deprecation-migration-implementation.md
+++ b/docs/superpowers/plans/2026-05-03-gap-505-user-role-deprecation-migration-implementation.md
@@ -1,5 +1,9 @@
 # GAP-505 User.role 弃用 — 迁移字符串角色检查至 Role 模型 实现计划
 
+> **⚠️ SUPERSEDED（已作废）**
+> 本计划已被 `docs/superpowers/plans/2026-05-09-domain-source-of-truth-and-semantic-dedup-implementation.md` 全面覆盖并取代。
+> 所有 GAP-505 范围内的修复已作为该总计划的 Task 1 完成。请勿再执行本计划。
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to execute this plan task-by-task. Start every execution reply with: `I'm using the executing-plans skill to implement this plan.`
 > If you discover any conflict between this plan and the current code / AGENTS.md / docs/AGENT_GUIDE.md, stop immediately and report back to the main agent. Do NOT guess or expand scope.
 

--- a/server/src/modules/auth/auth.service.ts
+++ b/server/src/modules/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import { Injectable, UnauthorizedException, BadRequestException, InternalServerErrorException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../../prisma/prisma.service';
@@ -105,13 +105,16 @@ export class AuthService {
   }
 
   validateUser(payload: AuthTokenPayload) {
+    if (!payload.companyId) {
+      throw new InternalServerErrorException('JWT payload 缺少 companyId，认证上下文契约被破坏');
+    }
     return {
       id: payload.sub,
       username: payload.username,
       roleCode: payload.role,
       roleId: payload.roleId ?? '',
       name: payload.name,
-      companyId: payload.companyId ?? '1',
+      companyId: payload.companyId,
       departmentId: payload.departmentId,
     };
   }

--- a/server/src/modules/auth/auth.strategy.spec.ts
+++ b/server/src/modules/auth/auth.strategy.spec.ts
@@ -21,11 +21,11 @@ describe('JwtStrategy', () => {
     });
   });
 
-  it('defaults old JWT payloads to company 1', async () => {
+  it('throws InternalServerErrorException when companyId is missing from JWT payload', async () => {
     const strategy = new JwtStrategy();
 
     await expect(
       strategy.validate({ sub: 'u1', username: 'admin', role: 'admin', name: '管理员' }),
-    ).resolves.toEqual(expect.objectContaining({ companyId: '1' }));
+    ).rejects.toThrow('JWT payload 缺少 companyId，认证上下文契约被破坏');
   });
 });

--- a/server/src/modules/auth/auth.strategy.ts
+++ b/server/src/modules/auth/auth.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
@@ -23,13 +23,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload) {
+    if (!payload.companyId) {
+      throw new InternalServerErrorException('JWT payload 缺少 companyId，认证上下文契约被破坏');
+    }
     return {
       id: payload.sub,
       username: payload.username,
       roleCode: payload.role,
       roleId: payload.roleId ?? '',
       name: payload.name,
-      companyId: payload.companyId ?? '1',
+      companyId: payload.companyId,
       departmentId: payload.departmentId,
     };
   }

--- a/server/src/modules/import/import.controller.ts
+++ b/server/src/modules/import/import.controller.ts
@@ -14,6 +14,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiConsumes } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
 import { ImportService } from './import.service';
@@ -42,9 +43,9 @@ export class ImportController {
   @UseGuards(RolesGuard)
   @Roles('admin')
   @UseInterceptors(FileInterceptor('file'))
-  async importDocuments(@UploadedFile() file: Express.Multer.File, @Request() req: { user: { sub: string } }) {
+  async importDocuments(@UploadedFile() file: Express.Multer.File, @Request() req: AuthenticatedRequest) {
     this.validateFile(file);
-    return this.service.importDocuments(file.buffer, req.user.sub);
+    return this.service.importDocuments(file.buffer, req.user.id);
   }
 
   @Get('templates/users')

--- a/server/src/modules/process-step/process-step.controller.ts
+++ b/server/src/modules/process-step/process-step.controller.ts
@@ -7,11 +7,13 @@ import {
   Patch,
   Delete,
   UseGuards,
+  Request,
 } from '@nestjs/common';
 import { ProcessStepService } from './process-step.service';
 import { CreateProcessStepDto } from './dto/create-process-step.dto';
 import { UpdateProcessStepDto } from './dto/update-process-step.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 
 @Controller('process-steps')
 @UseGuards(JwtAuthGuard)
@@ -19,32 +21,32 @@ export class ProcessStepController {
   constructor(private service: ProcessStepService) {}
 
   @Get()
-  findAll() {
-    return this.service.findAll();
+  findAll(@Request() req: AuthenticatedRequest) {
+    return this.service.findAll(req.user.companyId);
   }
 
   @Get('product/:productId')
-  findByProduct(@Param('productId') productId: string) {
-    return this.service.findByProduct(productId);
+  findByProduct(@Param('productId') productId: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findByProduct(productId, req.user.companyId);
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.service.findOne(id);
+  findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.findOne(id, req.user.companyId);
   }
 
   @Post()
-  create(@Body() dto: CreateProcessStepDto) {
-    return this.service.create(dto);
+  create(@Body() dto: CreateProcessStepDto, @Request() req: AuthenticatedRequest) {
+    return this.service.create(dto, req.user.companyId);
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() dto: UpdateProcessStepDto) {
-    return this.service.update(id, dto);
+  update(@Param('id') id: string, @Body() dto: UpdateProcessStepDto, @Request() req: AuthenticatedRequest) {
+    return this.service.update(id, dto, req.user.companyId);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.service.remove(id);
+  remove(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.service.remove(id, req.user.companyId);
   }
 }

--- a/server/src/modules/process-step/process-step.service.spec.ts
+++ b/server/src/modules/process-step/process-step.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ProcessStepService } from './process-step.service';
 
 describe('ProcessStepService', () => {
@@ -8,6 +8,7 @@ describe('ProcessStepService', () => {
       findMany: jest.fn(),
       findFirst: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
     },
   };
 
@@ -24,24 +25,27 @@ describe('ProcessStepService', () => {
     is_ccp: false,
   };
 
+  const COMPANY_A = 'company-a';
+  const COMPANY_B = 'company-b';
+
   it('rejects orphan process steps without product_id or recipe_id', async () => {
-    await expect(service.create(baseDto as any)).rejects.toThrow(BadRequestException);
+    await expect(service.create(baseDto as any, COMPANY_A)).rejects.toThrow(BadRequestException);
     expect(prisma.processStep.create).not.toHaveBeenCalled();
   });
 
   it('rejects blank product_id and recipe_id', async () => {
-    await expect(service.create({ ...baseDto, product_id: ' ', recipe_id: '' } as any)).rejects.toThrow(BadRequestException);
+    await expect(service.create({ ...baseDto, product_id: ' ', recipe_id: '' } as any, COMPANY_A)).rejects.toThrow(BadRequestException);
     expect(prisma.processStep.create).not.toHaveBeenCalled();
   });
 
   it('allows product-level process steps', async () => {
     prisma.processStep.create.mockResolvedValue({ id: 'step-1' });
 
-    await service.create({ ...baseDto, product_id: 'prod-1' } as any);
+    await service.create({ ...baseDto, product_id: 'prod-1' } as any, COMPANY_A);
 
     expect(prisma.processStep.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ product_id: 'prod-1', recipe_id: undefined }),
+        data: expect.objectContaining({ product_id: 'prod-1', company_id: COMPANY_A }),
       }),
     );
   });
@@ -49,12 +53,78 @@ describe('ProcessStepService', () => {
   it('allows recipe-level process steps', async () => {
     prisma.processStep.create.mockResolvedValue({ id: 'step-2' });
 
-    await service.create({ ...baseDto, recipe_id: 'recipe-1' } as any);
+    await service.create({ ...baseDto, recipe_id: 'recipe-1' } as any, COMPANY_A);
 
     expect(prisma.processStep.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ product_id: undefined, recipe_id: 'recipe-1' }),
+        data: expect.objectContaining({ recipe_id: 'recipe-1', company_id: COMPANY_A }),
       }),
     );
+  });
+
+  describe('tenant isolation', () => {
+    it('findAll passes companyId to query', async () => {
+      prisma.processStep.findMany.mockResolvedValue([]);
+      await service.findAll(COMPANY_A);
+      expect(prisma.processStep.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ company_id: COMPANY_A }) }),
+      );
+    });
+
+    it('findByProduct passes companyId to query', async () => {
+      prisma.processStep.findMany.mockResolvedValue([]);
+      await service.findByProduct('prod-1', COMPANY_A);
+      expect(prisma.processStep.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ company_id: COMPANY_A, product_id: 'prod-1' }) }),
+      );
+    });
+
+    it('findOne passes companyId to query', async () => {
+      prisma.processStep.findFirst.mockResolvedValue({ id: 'step-1' });
+      await service.findOne('step-1', COMPANY_A);
+      expect(prisma.processStep.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: expect.objectContaining({ id: 'step-1', company_id: COMPANY_A }) }),
+      );
+    });
+
+    it('findOne returns NotFoundException when record belongs to different company', async () => {
+      prisma.processStep.findFirst.mockResolvedValue(null);
+      await expect(service.findOne('step-x', COMPANY_B)).rejects.toThrow(NotFoundException);
+    });
+
+    it('update uses scoped updateMany with companyId', async () => {
+      prisma.processStep.updateMany.mockResolvedValue({ count: 1 });
+      prisma.processStep.findFirst.mockResolvedValue({ id: 'step-1' });
+
+      await service.update('step-1', { step_name: '新名称' }, COMPANY_A);
+
+      expect(prisma.processStep.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'step-1', company_id: COMPANY_A }),
+        }),
+      );
+    });
+
+    it('update throws NotFoundException when step not found in company scope', async () => {
+      prisma.processStep.updateMany.mockResolvedValue({ count: 0 });
+      await expect(service.update('step-x', { step_name: '新名称' }, COMPANY_B)).rejects.toThrow(NotFoundException);
+    });
+
+    it('remove uses scoped updateMany with companyId', async () => {
+      prisma.processStep.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.remove('step-1', COMPANY_A);
+
+      expect(prisma.processStep.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ id: 'step-1', company_id: COMPANY_A }),
+        }),
+      );
+    });
+
+    it('remove throws NotFoundException when step not found in company scope', async () => {
+      prisma.processStep.updateMany.mockResolvedValue({ count: 0 });
+      await expect(service.remove('step-x', COMPANY_B)).rejects.toThrow(NotFoundException);
+    });
   });
 });

--- a/server/src/modules/process-step/process-step.service.ts
+++ b/server/src/modules/process-step/process-step.service.ts
@@ -16,23 +16,23 @@ export class ProcessStepService {
     }
   }
 
-  async findAll() {
+  async findAll(companyId: string) {
     return this.prisma.processStep.findMany({
-      where: { company_id: '1', deleted_at: null },
+      where: { company_id: companyId, deleted_at: null },
       orderBy: [{ step_no: 'asc' }, { created_at: 'desc' }],
     });
   }
 
-  async findByProduct(productId: string) {
+  async findByProduct(productId: string, companyId: string) {
     return this.prisma.processStep.findMany({
-      where: { company_id: '1', product_id: productId, deleted_at: null },
+      where: { company_id: companyId, product_id: productId, deleted_at: null },
       orderBy: { step_no: 'asc' },
     });
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, companyId: string) {
     const step = await this.prisma.processStep.findFirst({
-      where: { id, company_id: '1', deleted_at: null },
+      where: { id, company_id: companyId, deleted_at: null },
     });
     if (!step) {
       throw new NotFoundException(`ProcessStep ${id} not found`);
@@ -40,12 +40,12 @@ export class ProcessStepService {
     return step;
   }
 
-  async create(dto: CreateProcessStepDto) {
+  async create(dto: CreateProcessStepDto, companyId: string) {
     this.assertHasProductOrRecipe(dto.product_id, dto.recipe_id);
 
     return this.prisma.processStep.create({
       data: {
-        company_id: '1',
+        company_id: companyId,
         product_id: dto.product_id,
         recipe_id: dto.recipe_id,
         step_no: dto.step_no,
@@ -64,10 +64,9 @@ export class ProcessStepService {
     });
   }
 
-  async update(id: string, dto: UpdateProcessStepDto) {
-    await this.findOne(id);
-    return this.prisma.processStep.update({
-      where: { id },
+  async update(id: string, dto: UpdateProcessStepDto, companyId: string) {
+    const result = await this.prisma.processStep.updateMany({
+      where: { id, company_id: companyId, deleted_at: null },
       data: {
         ...(dto.product_id !== undefined && { product_id: dto.product_id }),
         ...(dto.recipe_id !== undefined && { recipe_id: dto.recipe_id }),
@@ -83,13 +82,20 @@ export class ProcessStepService {
         ...(dto.responsible_person !== undefined && { responsible_person: dto.responsible_person }),
       },
     });
+    if (result.count === 0) {
+      throw new NotFoundException(`ProcessStep ${id} not found`);
+    }
+    return this.findOne(id, companyId);
   }
 
-  async remove(id: string) {
-    await this.findOne(id);
-    return this.prisma.processStep.update({
-      where: { id },
+  async remove(id: string, companyId: string) {
+    const result = await this.prisma.processStep.updateMany({
+      where: { id, company_id: companyId, deleted_at: null },
       data: { deleted_at: new Date() },
     });
+    if (result.count === 0) {
+      throw new NotFoundException(`ProcessStep ${id} not found`);
+    }
+    return { success: true };
   }
 }

--- a/server/src/modules/process/process-instance.controller.ts
+++ b/server/src/modules/process/process-instance.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { PrismaService } from '../../prisma/prisma.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { ProcessStepApprovalService } from './process-step-approval.service';
 import { ApprovalEngineService } from '../unified-approval/approval-engine.service';
 
@@ -38,8 +39,8 @@ export class ProcessInstanceController {
 
   @Get('approvals/pending')
   @ApiOperation({ summary: '查我的待签任务' })
-  async getPendingApprovals(@Request() req: any) {
-    const userId = req.user?.sub || req.user?.id;
+  async getPendingApprovals(@Request() req: AuthenticatedRequest) {
+    const userId = req.user.id;
     const list = await this.approvalService.listPendingForUser(userId);
     return { code: 0, data: list, message: 'success' };
   }
@@ -59,8 +60,8 @@ export class ProcessInstanceController {
 
   @Post()
   @ApiOperation({ summary: '创建流程实例' })
-  async create(@Body() data: any, @Request() req: any) {
-    const userId = req.user?.sub || req.user?.id;
+  async create(@Body() data: any, @Request() req: AuthenticatedRequest) {
+    const userId = req.user.id;
 
     const productId = typeof data.productId === 'string' && data.productId.trim()
       ? data.productId.trim()
@@ -93,9 +94,9 @@ export class ProcessInstanceController {
   async submitStep(
     @Param('id') id: string,
     @Body() body: any,
-    @Request() req: any,
+    @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user?.sub || req.user?.id;
+    const userId = req.user.id;
 
     const instance = await this.prisma.processInstance.findUnique({
       where: { id },
@@ -194,9 +195,9 @@ export class ProcessInstanceController {
     @Param('id') id: string,
     @Param('stepNumber') stepNumber: string,
     @Body() body: any,
-    @Request() req: any,
+    @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user?.sub || req.user?.id;
+    const userId = req.user.id;
     const { action, comment = '' } = body;
     // Never trust role from client — omit requestedRole entirely
     const result = await this.approvalService.submitApproval(

--- a/server/src/modules/unified-approval/approval-instance.controller.ts
+++ b/server/src/modules/unified-approval/approval-instance.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, NotFoundException, Param, Post, Request, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from './approval-engine.service';
 import { StartApprovalDto } from './dto';
@@ -13,8 +14,8 @@ export class ApprovalInstanceController {
   ) {}
 
   @Post()
-  start(@Body() dto: StartApprovalDto, @Request() req: any) {
-    return this.engine.startApproval({ ...dto, createdById: req.user?.id ?? req.user?.userId ?? req.user?.sub });
+  start(@Body() dto: StartApprovalDto, @Request() req: AuthenticatedRequest) {
+    return this.engine.startApproval({ ...dto, createdById: req.user.id });
   }
 
   @Get()

--- a/server/src/modules/unified-approval/approval-task.controller.ts
+++ b/server/src/modules/unified-approval/approval-task.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, ForbiddenException, Get, NotFoundException, Param, Post, Request, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { PrismaService } from '../../prisma/prisma.service';
 import { ApprovalEngineService } from './approval-engine.service';
 import { ApprovalAssignmentResolver } from './approval-assignment.resolver';
@@ -15,8 +16,8 @@ export class ApprovalTaskController {
   ) {}
 
   @Get('my-pending')
-  async findMyPending(@Request() req: any) {
-    const userId = req.user?.id ?? req.user?.userId ?? req.user?.sub;
+  async findMyPending(@Request() req: AuthenticatedRequest) {
+    const userId = req.user.id;
     const rows = await this.prisma.approvalTask.findMany({
       where: { status: 'PENDING' },
       include: { instance: true },
@@ -35,8 +36,8 @@ export class ApprovalTaskController {
   }
 
   @Get('history')
-  history(@Request() req: any) {
-    const userId = req.user?.id ?? req.user?.userId ?? req.user?.sub;
+  history(@Request() req: AuthenticatedRequest) {
+    const userId = req.user.id;
     return this.prisma.approvalAction.findMany({
       where: { actorId: userId },
       include: { instance: true, task: true },
@@ -45,8 +46,8 @@ export class ApprovalTaskController {
   }
 
   @Get(':id')
-  async findOne(@Param('id') id: string, @Request() req: any) {
-    const userId = req.user?.id ?? req.user?.userId ?? req.user?.sub;
+  async findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    const userId = req.user.id;
     const record = await this.prisma.approvalTask.findUnique({
       where: { id },
       include: { instance: { include: { tasks: true, actions: true } } },
@@ -64,12 +65,12 @@ export class ApprovalTaskController {
   }
 
   @Post(':id/approve')
-  approve(@Param('id') id: string, @Body() dto: ApprovalTaskActionDto, @Request() req: any) {
-    return this.engine.approveTask(id, req.user?.id ?? req.user?.userId ?? req.user?.sub, dto.comment ?? '');
+  approve(@Param('id') id: string, @Body() dto: ApprovalTaskActionDto, @Request() req: AuthenticatedRequest) {
+    return this.engine.approveTask(id, req.user.id, dto.comment ?? '');
   }
 
   @Post(':id/reject')
-  reject(@Param('id') id: string, @Body() dto: RejectApprovalTaskDto, @Request() req: any) {
-    return this.engine.rejectTask(id, req.user?.id ?? req.user?.userId ?? req.user?.sub, dto.comment);
+  reject(@Param('id') id: string, @Body() dto: RejectApprovalTaskDto, @Request() req: AuthenticatedRequest) {
+    return this.engine.rejectTask(id, req.user.id, dto.comment);
   }
 }

--- a/server/src/modules/warehouse/inbound.controller.ts
+++ b/server/src/modules/warehouse/inbound.controller.ts
@@ -8,19 +8,22 @@ import {
   HttpCode,
   HttpStatus,
   Request,
+  UseGuards,
 } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { InboundService } from './inbound.service';
 import { CreateInboundDto, QueryInboundDto } from './dto/inbound.dto';
 
 @Controller('warehouse/inbound')
+@UseGuards(JwtAuthGuard)
 export class InboundController {
   constructor(private readonly inboundService: InboundService) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  create(@Body() createInboundDto: CreateInboundDto, @Request() req: any) {
-    const userId = req?.user?.id ?? req?.user?.userId ?? req?.user?.sub;
-    return this.inboundService.create(createInboundDto, userId);
+  create(@Body() createInboundDto: CreateInboundDto, @Request() req: AuthenticatedRequest) {
+    return this.inboundService.create(createInboundDto, req.user.id);
   }
 
   @Get()
@@ -34,14 +37,12 @@ export class InboundController {
   }
 
   @Post(':id/approve')
-  approve(@Param('id') id: string, @Request() req: any) {
-    const approverId = req.user?.id || 'system';
-    return this.inboundService.approve(id, approverId);
+  approve(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.inboundService.approve(id, req.user.id);
   }
 
   @Post(':id/complete')
-  complete(@Param('id') id: string, @Request() req: any) {
-    const operatorId = req.user?.id || 'system';
-    return this.inboundService.complete(id, operatorId);
+  complete(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.inboundService.complete(id, req.user.id);
   }
 }

--- a/server/src/modules/workflow/workflow-advanced.controller.ts
+++ b/server/src/modules/workflow/workflow-advanced.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuthenticatedRequest } from '../auth/authenticated-user';
 import { WorkflowAdvancedService } from './workflow-advanced.service';
 import { DelegateTaskDto } from './dto/delegate-task.dto';
 import { RollbackTaskDto } from './dto/rollback-task.dto';
@@ -27,9 +28,9 @@ export class WorkflowAdvancedController {
   async delegate(
     @Param('id') id: string,
     @Body() dto: DelegateTaskDto,
-    @Request() req: { user: { sub: string } },
+    @Request() req: AuthenticatedRequest,
   ) {
-    return this.service.delegateTask(id, dto, req.user.sub);
+    return this.service.delegateTask(id, dto, req.user.id);
   }
 
   @Post('tasks/:id/rollback')
@@ -37,9 +38,9 @@ export class WorkflowAdvancedController {
   async rollback(
     @Param('id') id: string,
     @Body() dto: RollbackTaskDto,
-    @Request() req: { user: { sub: string } },
+    @Request() req: AuthenticatedRequest,
   ) {
-    return this.service.rollbackTask(id, dto, req.user.sub);
+    return this.service.rollbackTask(id, dto, req.user.id);
   }
 
   @Post('tasks/:id/transfer')
@@ -47,9 +48,9 @@ export class WorkflowAdvancedController {
   async transfer(
     @Param('id') id: string,
     @Body() dto: TransferTaskDto,
-    @Request() req: { user: { sub: string } },
+    @Request() req: AuthenticatedRequest,
   ) {
-    return this.service.transferTask(id, dto, req.user.sub);
+    return this.service.transferTask(id, dto, req.user.id);
   }
 
   @Get('delegation-logs')


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/plans/2026-05-09-domain-source-of-truth-and-semantic-dedup-implementation.md` (MYL-538).

Most of Tasks 1-4 were already implemented in prior PRs. This PR delivers the remaining work:

**Auth context cleanup (Task 1 / MYL-536 patch):**
- `auth.strategy.ts`, `auth.service.ts`: remove `companyId ?? '1'` silent fallback → throw `InternalServerErrorException` when JWT payload missing `companyId`
- `workflow-advanced.controller.ts`: `req.user.sub` → `req.user.id`, typed as `AuthenticatedRequest`
- `import.controller.ts`: `req.user.sub` → `req.user.id`, typed as `AuthenticatedRequest`
- `process-instance.controller.ts`: `req.user?.sub || req.user?.id` compat chain → `req.user.id`
- `approval-task.controller.ts`: `req.user?.id ?? userId ?? sub` compat chain → `req.user.id`
- `approval-instance.controller.ts`: same compat chain → `req.user.id`
- `warehouse/inbound.controller.ts`: add `JwtAuthGuard` at class level, fix `|| 'system'` silent fallbacks to `req.user.id`

**Process-step tenant isolation (MYL-536 patch):**
- `process-step.service.ts`: all public methods accept `companyId` param; `update`/`remove` use scoped `updateMany({ where: { id, company_id: companyId } })` and throw `NotFoundException` when `count === 0`
- `process-step.controller.ts`: pass `req.user.companyId` to all service calls

**Docs:**
- Marked old GAP-505 plan as `SUPERSEDED` by the current total plan

**Tests:**
- `auth.strategy.spec.ts`: updated to expect `InternalServerErrorException` instead of defaulting to `companyId: '1'`
- `process-step.service.spec.ts`: added 8 tenant isolation tests covering `findAll`, `findByProduct`, `findOne`, `update`, `remove` scoped writes and `NotFoundException` on cross-tenant access

## Tasks already completed in prior PRs (verified clean by scan)

- `CurrentUser.role` / `req.user.role` / `req.user.userId`: 0 matches
- `Department.parentId` in schema: removed (migration `20260509090000_remove_department_parent_id` exists)
- `subdepartment` in active code: 0 matches (only in test asserting its absence)
- `AuthenticatedUser.userId`: 0 matches
- `DepartmentPermission.vue` tree logic: already flat list
- `assertManagerCandidate` in `department.service.ts`: already implemented and tested
- `org-bootstrap.service.ts`: already checks persistent `org_permission_bootstrap_completed` flag first
- Router guard and `OrganizationBootstrap.vue`: already redirect completed users to dashboard

## Test plan

- [ ] `npm run test -- src/modules/auth/auth.strategy.spec.ts` → 2 pass
- [ ] `npm run test -- src/modules/process-step/process-step.service.spec.ts` → 12 pass (4 existing + 8 new)
- [ ] `npm run test -- src/modules/department/department.service.spec.ts` → all pass
- [ ] Verify `rg "req\.user\.sub|req\.user\.userId" server/src` → 0 results
- [ ] Verify `rg "company_id: '1'" server/src/modules/process-step` → 0 results
- [ ] Verify `rg "|| 'system'" server/src/modules/warehouse/inbound.controller.ts` → 0 results