### PR TITLE
refactor(org-bootstrap): PR2 Backend deprecated diagnostic contraction

### DIFF
--- a/server/src/modules/org-bootstrap/dto/org-bootstrap-status.dto.ts
+++ b/server/src/modules/org-bootstrap/dto/org-bootstrap-status.dto.ts
@@ -1,3 +1,5 @@
+// Deprecated diagnostic types. This DTO is NOT a product initialization contract.
+// Frontend routing must NOT consume these fields to gate access.
 export type BootstrapStep =
   | 'system_role_baseline'
   | 'departments'
@@ -12,6 +14,8 @@ export type BootstrapReason =
   | 'missing_business_member';
 
 export interface OrgBootstrapStatusDto {
+  /** Always true — this endpoint is a deprecated authenticated diagnostic only. */
+  deprecated: true;
   completed: boolean;
   step: BootstrapStep;
   reasons: BootstrapReason[];

--- a/server/src/modules/org-bootstrap/org-bootstrap.service.spec.ts
+++ b/server/src/modules/org-bootstrap/org-bootstrap.service.spec.ts
@@ -1,102 +1,78 @@
 import { OrgBootstrapService } from './org-bootstrap.service';
 
-describe('OrgBootstrapService', () => {
+// Deprecated diagnostic endpoint tests.
+// This endpoint is NOT a product initialization gate.
+// It must never write org_permission_bootstrap_completed.
+describe('OrgBootstrapService (deprecated diagnostic)', () => {
   let prisma: any;
   let service: OrgBootstrapService;
 
   beforeEach(() => {
     prisma = {
       role: { count: jest.fn() },
-      department: { count: jest.fn() },
-      user: { count: jest.fn() },
-      systemConfig: { upsert: jest.fn(), findUnique: jest.fn() },
+      systemConfig: { upsert: jest.fn(), update: jest.fn(), create: jest.fn(), findUnique: jest.fn() },
     };
     service = new OrgBootstrapService(prisma);
   });
 
-  it('缺部门时返回 departments 步骤', async () => {
+  it('returns deprecated: true on every call', async () => {
     prisma.role.count.mockResolvedValue(3);
-    prisma.department.count.mockResolvedValue(0);
 
     const status = await service.getStatus();
 
-    expect(status.completed).toBe(false);
-    expect(status.step).toBe('departments');
-    expect(status.reasons).toContain('missing_department');
+    expect(status.deprecated).toBe(true);
   });
 
-  it('缺系统角色时返回 system_role_baseline 步骤', async () => {
-    prisma.role.count.mockResolvedValue(2);
-    prisma.department.count.mockResolvedValue(0);
+  it('does not write org_permission_bootstrap_completed when organization data is complete', async () => {
+    prisma.role.count.mockResolvedValue(3);
+
+    await service.getStatus();
+
+    expect(prisma.systemConfig.upsert).not.toHaveBeenCalled();
+    expect(prisma.systemConfig.update).not.toHaveBeenCalled();
+    expect(prisma.systemConfig.create).not.toHaveBeenCalled();
+  });
+
+  it('does not write org_permission_bootstrap_completed even when system roles are missing', async () => {
+    prisma.role.count.mockResolvedValue(0);
+
+    await service.getStatus();
+
+    expect(prisma.systemConfig.upsert).not.toHaveBeenCalled();
+    expect(prisma.systemConfig.update).not.toHaveBeenCalled();
+    expect(prisma.systemConfig.create).not.toHaveBeenCalled();
+  });
+
+  it('does not use missing departments as a product initialization gate', async () => {
+    // Even if department data is absent, the endpoint must not gate product access.
+    // The service does not query department data at all.
+    prisma.role.count.mockResolvedValue(3);
 
     const status = await service.getStatus();
 
-    expect(status.completed).toBe(false);
+    expect(status).toMatchObject({ deprecated: true });
+    expect(status.reasons ?? []).not.toContain('missing_department');
+    expect(status.reasons ?? []).not.toContain('missing_department_manager');
+    expect(status.reasons ?? []).not.toContain('missing_business_member');
+  });
+
+  it('returns system_role_baseline diagnostic when system roles are missing', async () => {
+    prisma.role.count.mockResolvedValue(2);
+
+    const status = await service.getStatus();
+
+    expect(status.deprecated).toBe(true);
     expect(status.step).toBe('system_role_baseline');
     expect(status.reasons).toContain('missing_system_roles');
   });
 
-  it('只有部门 + leader 负责人时仍返回 department_members 步骤', async () => {
+  it('returns completed step when system roles are present', async () => {
     prisma.role.count.mockResolvedValue(3);
-    // department.count is called twice: total departments, then managed departments
-    prisma.department.count
-      .mockResolvedValueOnce(1) // departments >= 1
-      .mockResolvedValueOnce(1); // managedDepartments >= 1 (has leader manager)
-    prisma.user.count.mockResolvedValue(0); // no 'user' role members with departmentId
 
     const status = await service.getStatus();
 
-    expect(status.completed).toBe(false);
-    expect(status.step).toBe('department_members');
-    expect(status.reasons).toContain('missing_business_member');
-  });
-
-  it('leader 角色用户不能满足 businessMembers 条件，查询必须过滤 roleObj.code === user', async () => {
-    prisma.role.count.mockResolvedValue(3);
-    prisma.department.count
-      .mockResolvedValueOnce(1)
-      .mockResolvedValueOnce(1);
-    // Simulate: even if there's a leader in a dept, user.count with roleObj filter returns 0
-    prisma.user.count.mockResolvedValue(0);
-
-    const status = await service.getStatus();
-
-    expect(status.completed).toBe(false);
-    expect(status.step).toBe('department_members');
-
-    // Verify the user.count query included roleObj filter
-    const userCountCall = prisma.user.count.mock.calls[0][0];
-    expect(userCountCall.where.roleObj).toBeDefined();
-    expect(userCountCall.where.roleObj.code).toBe('user');
-    expect(userCountCall.where.roleObj.deletedAt).toBeNull();
-  });
-
-  it('添加普通 user 角色业务成员后 completed', async () => {
-    prisma.role.count.mockResolvedValue(3);
-    prisma.department.count
-      .mockResolvedValueOnce(1)
-      .mockResolvedValueOnce(1);
-    prisma.user.count.mockResolvedValue(1); // one 'user' role member in dept
-    prisma.systemConfig.upsert.mockResolvedValue({});
-
-    const status = await service.getStatus();
-
-    expect(status.completed).toBe(true);
+    expect(status.deprecated).toBe(true);
     expect(status.step).toBe('completed');
-    expect(prisma.systemConfig.upsert).toHaveBeenCalled();
-  });
-
-  it('缺部门负责人时返回 department_manager 步骤', async () => {
-    prisma.role.count.mockResolvedValue(3);
-    prisma.department.count
-      .mockResolvedValueOnce(1)  // departments >= 1
-      .mockResolvedValueOnce(0); // managedDepartments == 0
-    prisma.user.count.mockResolvedValue(0);
-
-    const status = await service.getStatus();
-
-    expect(status.completed).toBe(false);
-    expect(status.step).toBe('department_manager');
-    expect(status.reasons).toContain('missing_department_manager');
+    expect(status.reasons).toHaveLength(0);
   });
 });

--- a/server/src/modules/org-bootstrap/org-bootstrap.service.ts
+++ b/server/src/modules/org-bootstrap/org-bootstrap.service.ts
@@ -1,76 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import { BootstrapReason, BootstrapStep, OrgBootstrapStatusDto } from './dto/org-bootstrap-status.dto';
+import { OrgBootstrapStatusDto } from './dto/org-bootstrap-status.dto';
 
-const BOOTSTRAP_CONFIG_KEY = 'org_permission_bootstrap_completed';
-
+// Deprecated: kept for short-term authenticated diagnostic compatibility only.
+// This service does NOT gate product access and does NOT write any system configuration.
 @Injectable()
 export class OrgBootstrapService {
   constructor(private readonly prisma: PrismaService) {}
 
-  private pending(step: BootstrapStep, reasons: BootstrapReason[]): OrgBootstrapStatusDto {
-    return { completed: false, step, reasons };
-  }
-
   async getStatus(): Promise<OrgBootstrapStatusDto> {
-    const completedFlag = await this.prisma.systemConfig.findUnique({
-      where: { key: BOOTSTRAP_CONFIG_KEY },
+    const systemRoles = await this.prisma.role.count({
+      where: { code: { in: ['admin', 'leader', 'user'] }, deletedAt: null },
     });
-    if (completedFlag?.value === 'true') {
-      return { completed: true, step: 'completed', reasons: [] };
+
+    if (systemRoles < 3) {
+      return { deprecated: true, completed: false, step: 'system_role_baseline', reasons: ['missing_system_roles'] };
     }
 
-    const [systemRoles, departments, managedDepartments, businessMembers] = await Promise.all([
-      this.prisma.role.count({
-        where: { code: { in: ['admin', 'leader', 'user'] }, deletedAt: null },
-      }),
-      this.prisma.department.count({ where: { deletedAt: null } }),
-      this.prisma.department.count({
-        where: {
-          deletedAt: null,
-          manager: {
-            deletedAt: null,
-            status: 'active',
-            roleObj: { code: 'leader', deletedAt: null },
-          },
-        },
-      }),
-      this.prisma.user.count({
-        where: {
-          deletedAt: null,
-          status: 'active',
-          username: { not: 'admin' },
-          departmentId: { not: null },
-          roleObj: { code: 'user', deletedAt: null },
-        },
-      }),
-    ]);
-
-    if (systemRoles < 3) return this.pending('system_role_baseline', ['missing_system_roles']);
-    if (departments < 1) return this.pending('departments', ['missing_department']);
-    if (managedDepartments < 1) return this.pending('department_manager', ['missing_department_manager']);
-    if (businessMembers < 1) return this.pending('department_members', ['missing_business_member']);
-
-    await this.markCompleted();
-    return { completed: true, step: 'completed', reasons: [] };
-  }
-
-  private async markCompleted() {
-    await this.prisma.systemConfig.upsert({
-      where: { key: BOOTSTRAP_CONFIG_KEY },
-      update: {
-        value: 'true',
-        valueType: 'boolean',
-        category: 'system',
-        description: '组织与权限初始化已完成',
-      },
-      create: {
-        key: BOOTSTRAP_CONFIG_KEY,
-        value: 'true',
-        valueType: 'boolean',
-        category: 'system',
-        description: '组织与权限初始化已完成',
-      },
-    });
+    return { deprecated: true, completed: false, step: 'completed', reasons: [] };
   }
 }


### PR DESCRIPTION
## Summary

- Remove `markCompleted()` and all writes to `org_permission_bootstrap_completed` from `OrgBootstrapService`
- Remove B-class organization completeness checks (departments, managers, business members) from product gate semantics
- Add `deprecated: true` to `OrgBootstrapStatusDto` — the endpoint is now a read-only authenticated diagnostic only
- Replace old gate-semantics tests with diagnostic-semantics tests that assert no writes and no B-class gating

## Context

This is PR2 of the Remove Bootstrap Gate plan (`docs/superpowers/plans/2026-05-10-remove-bootstrap-gate-implementation.md`). PR1 (frontend gate removal, #203) is already merged.

`/org-bootstrap/status` is kept behind `JwtAuthGuard` for short-term compatibility. No product routing should consume it. The endpoint does not write any system configuration.

## Verification

```
npm run test -w server -- org-bootstrap.service.spec.ts --runInBand
# Result: 6 passed, 0 failed

rg -n "markCompleted|org_permission_bootstrap_completed|department\.count|businessMembers|manager" server/src/modules/org-bootstrap
# Result: only DTO type names and spec comment/assertion text — no executable write or B-class query paths
```

## Test plan

- [x] Service spec passes (6 tests)
- [x] No `markCompleted` in org-bootstrap module
- [x] No `org_permission_bootstrap_completed` write path in org-bootstrap service
- [x] No department/manager/member B-class count queries remain in service
- [x] Controller auth guard (`JwtAuthGuard`) unchanged
- [ ] PR3 (seed cleanup) and PR4 (E2E contract) to follow after merge