### PR TITLE
refactor(seed): PR3 - Baseline Seed And Compose Cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,6 @@ services:
       - MINIO_SECRET_KEY=noidear123
       - NODE_ENV=production
       - SWAGGER_ENABLED=true
-      - SEED_MINIMUM_ORG=true
     depends_on:
       postgres:
         condition: service_healthy

--- a/server/src/prisma/seed-baseline.spec.ts
+++ b/server/src/prisma/seed-baseline.spec.ts
@@ -1,19 +1,18 @@
 import { buildBaselineSeedOptions } from './seed-baseline';
 
 describe('buildBaselineSeedOptions', () => {
-  it('keeps minimum organization disabled by default', () => {
-    expect(buildBaselineSeedOptions({})).toEqual({
+  it('returns only A-class baseline options without minimum organization', () => {
+    const options = buildBaselineSeedOptions({});
+    expect(options).toEqual({
       adminPassword: 'ChangeMe123!',
       seedUserPassword: 'ChangeMe123!',
-      ensureMinimumOrganization: false,
     });
+    expect(options).not.toHaveProperty('ensureMinimumOrganization');
   });
 
-  it('enables minimum organization only for exact true', () => {
-    expect(buildBaselineSeedOptions({ SEED_MINIMUM_ORG: 'true' }).ensureMinimumOrganization).toBe(true);
-    expect(buildBaselineSeedOptions({ SEED_MINIMUM_ORG: 'True' }).ensureMinimumOrganization).toBe(false);
-    expect(buildBaselineSeedOptions({ SEED_MINIMUM_ORG: '1' }).ensureMinimumOrganization).toBe(false);
-    expect(buildBaselineSeedOptions({ SEED_MINIMUM_ORG: 'yes' }).ensureMinimumOrganization).toBe(false);
+  it('does not produce ensureMinimumOrganization even when SEED_MINIMUM_ORG env is set', () => {
+    const options = buildBaselineSeedOptions({ SEED_MINIMUM_ORG: 'true' } as Record<string, string>);
+    expect(options).not.toHaveProperty('ensureMinimumOrganization');
   });
 
   it('uses admin password as the seed user password fallback', () => {

--- a/server/src/prisma/seed-baseline.ts
+++ b/server/src/prisma/seed-baseline.ts
@@ -5,13 +5,11 @@ import { ensureSystemRoleBaseline } from './seeds/baseline/system-role-baseline'
 export type BaselineSeedEnv = {
   DEFAULT_ADMIN_PASSWORD?: string;
   DEFAULT_SEED_PASSWORD?: string;
-  SEED_MINIMUM_ORG?: string;
 };
 
 export type BaselineSeedOptionsInput = {
   adminPassword: string;
   seedUserPassword: string;
-  ensureMinimumOrganization: boolean;
 };
 
 export function buildBaselineSeedOptions(env: BaselineSeedEnv): BaselineSeedOptionsInput {
@@ -21,23 +19,17 @@ export function buildBaselineSeedOptions(env: BaselineSeedEnv): BaselineSeedOpti
   return {
     adminPassword,
     seedUserPassword,
-    ensureMinimumOrganization: env.SEED_MINIMUM_ORG === 'true',
   };
 }
 
 async function main() {
   const prisma = new PrismaClient();
   const seedOptions = buildBaselineSeedOptions(process.env);
-  const [adminPasswordHash, seedUserPasswordHash] = await Promise.all([
-    bcrypt.hash(seedOptions.adminPassword, 10),
-    bcrypt.hash(seedOptions.seedUserPassword, 10),
-  ]);
+  const adminPasswordHash = await bcrypt.hash(seedOptions.adminPassword, 10);
 
   await ensureSystemRoleBaseline(prisma, {
     ensureAdminUser: true,
-    ensureMinimumOrganization: seedOptions.ensureMinimumOrganization,
     adminPasswordHash,
-    seedUserPasswordHash,
   });
 
   await prisma.$disconnect();

--- a/server/src/prisma/seeds/baseline/system-role-baseline.spec.ts
+++ b/server/src/prisma/seeds/baseline/system-role-baseline.spec.ts
@@ -4,15 +4,11 @@ describe('ensureSystemRoleBaseline', () => {
   const prisma = {
     role: { upsert: jest.fn() },
     department: {
-      findUnique: jest.fn(),
       create: jest.fn(),
-      update: jest.fn(),
     },
     user: {
       findFirst: jest.fn(),
-      findUnique: jest.fn(),
       create: jest.fn(),
-      update: jest.fn(),
       updateMany: jest.fn(),
     },
   } as any;
@@ -44,197 +40,64 @@ describe('ensureSystemRoleBaseline', () => {
     });
   });
 
-  describe('ensureMinimumOrganization', () => {
-    it('creates department, leader, member and sets department manager when opt-in', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-      prisma.department.findUnique.mockResolvedValue(null);
-      prisma.user.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce(null);
-      prisma.department.create.mockResolvedValue({
-        id: 'dept_seed_baseline',
-        code: 'SEED_BASELINE',
-        name: '基线部门',
-        status: 'active',
-      });
-      prisma.user.create
-        .mockResolvedValueOnce({
-          id: 'user_seed_baseline_leader',
-          username: 'seed_leader',
-        })
-        .mockResolvedValueOnce({
-          id: 'user_seed_baseline_member',
-          username: 'seed_user',
-        });
-      prisma.department.update.mockResolvedValue({});
+  it('does not create any department during baseline seed', async () => {
+    mockRoles();
+    prisma.user.findFirst.mockResolvedValue(null);
 
-      const result = await ensureSystemRoleBaseline(prisma, {
-        ensureMinimumOrganization: true,
-        seedUserPasswordHash: 'hashed-seed-password',
-      });
-
-      expect(prisma.department.create).toHaveBeenCalledWith({
-        data: expect.objectContaining({
-          id: 'dept_seed_baseline',
-          code: 'SEED_BASELINE',
-          name: '基线部门',
-          status: 'active',
-        }),
-      });
-      expect(prisma.user.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            id: 'user_seed_baseline_leader',
-            username: 'seed_leader',
-            roleId: 'r-leader',
-          }),
-        }),
-      );
-      expect(prisma.user.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            id: 'user_seed_baseline_member',
-            username: 'seed_user',
-            roleId: 'r-user',
-          }),
-        }),
-      );
-      expect(prisma.department.update).toHaveBeenCalledWith({
-        where: { id: 'dept_seed_baseline' },
-        data: { managerId: 'user_seed_baseline_leader' },
-      });
-      expect(result.minimumOrganization).toEqual({
-        departmentCode: 'SEED_BASELINE',
-        leaderUsername: 'seed_leader',
-        userUsername: 'seed_user',
-      });
+    await ensureSystemRoleBaseline(prisma, {
+      ensureAdminUser: true,
+      adminPasswordHash: 'hash',
     });
 
-    it('repairs existing seed-owned records without resetting passwords', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-      prisma.department.findUnique.mockResolvedValue({
-        id: 'dept_seed_baseline',
-        code: 'SEED_BASELINE',
-      });
-      prisma.user.findUnique
-        .mockResolvedValueOnce({ id: 'user_seed_baseline_leader', username: 'seed_leader' })
-        .mockResolvedValueOnce({ id: 'user_seed_baseline_member', username: 'seed_user' });
-      prisma.department.update.mockResolvedValue({
-        id: 'dept_seed_baseline',
-        code: 'SEED_BASELINE',
-      });
-      prisma.user.update.mockResolvedValue({});
+    expect(prisma.department.create).not.toHaveBeenCalled();
+  });
 
-      await ensureSystemRoleBaseline(prisma, {
-        ensureMinimumOrganization: true,
-        seedUserPasswordHash: 'hashed-seed-password',
-      });
+  it('does not create seed_leader or seed_user during baseline seed', async () => {
+    mockRoles();
+    prisma.user.findFirst.mockResolvedValue(null);
+    prisma.user.create.mockResolvedValue({ id: 'u-admin', username: 'admin' });
 
-      expect(prisma.department.create).not.toHaveBeenCalled();
-      expect(prisma.user.create).not.toHaveBeenCalled();
-      expect(prisma.department.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'dept_seed_baseline' },
-          data: expect.objectContaining({
-            name: '基线部门',
-            status: 'active',
-            deletedAt: null,
-          }),
-        }),
-      );
-      expect(prisma.user.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { id: 'user_seed_baseline_leader' },
-          data: expect.not.objectContaining({ password: expect.anything() }),
-        }),
-      );
+    await ensureSystemRoleBaseline(prisma, {
+      ensureAdminUser: true,
+      adminPasswordHash: 'hash',
     });
 
-    it('throws when SEED_BASELINE department code is owned by a different id', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-      prisma.department.findUnique.mockResolvedValue({
-        id: 'some-other-id',
-        code: 'SEED_BASELINE',
-      });
+    expect(prisma.user.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ username: 'seed_leader' }),
+      }),
+    );
+    expect(prisma.user.create).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ username: 'seed_user' }),
+      }),
+    );
+  });
 
-      await expect(
-        ensureSystemRoleBaseline(prisma, {
-          ensureMinimumOrganization: true,
-          seedUserPasswordHash: 'hashed-seed-password',
-        }),
-      ).rejects.toThrow('SEED_BASELINE 部门编码已被非基线记录占用');
+  it('creates only admin user when ensureAdminUser is true and admin does not exist', async () => {
+    mockRoles();
+    prisma.user.findFirst.mockResolvedValue(null);
+    prisma.user.create.mockResolvedValue({ id: 'u-admin', username: 'admin' });
+
+    await ensureSystemRoleBaseline(prisma, {
+      ensureAdminUser: true,
+      adminPasswordHash: 'hash',
     });
 
-    it('throws when seed_leader username is owned by a different id', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-      prisma.department.findUnique.mockResolvedValue(null);
-      prisma.department.create.mockResolvedValue({
-        id: 'dept_seed_baseline',
-        code: 'SEED_BASELINE',
-      });
-      prisma.user.findUnique.mockResolvedValueOnce({
-        id: 'some-other-id',
-        username: 'seed_leader',
-      });
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ username: 'admin' }),
+      }),
+    );
+    expect(prisma.user.create).toHaveBeenCalledTimes(1);
+  });
 
-      await expect(
-        ensureSystemRoleBaseline(prisma, {
-          ensureMinimumOrganization: true,
-          seedUserPasswordHash: 'hashed-seed-password',
-        }),
-      ).rejects.toThrow('seed_leader 用户名已被非基线记录占用');
-    });
+  it('returns systemRoleCodes without minimumOrganization', async () => {
+    mockRoles();
 
-    it('throws when seed_user username is owned by a different id', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-      prisma.department.findUnique.mockResolvedValue(null);
-      prisma.department.create.mockResolvedValue({
-        id: 'dept_seed_baseline',
-        code: 'SEED_BASELINE',
-      });
-      prisma.user.findUnique
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce({ id: 'some-other-id', username: 'seed_user' });
-      prisma.user.create.mockResolvedValueOnce({
-        id: 'user_seed_baseline_leader',
-        username: 'seed_leader',
-      });
+    const result = await ensureSystemRoleBaseline(prisma, {});
 
-      await expect(
-        ensureSystemRoleBaseline(prisma, {
-          ensureMinimumOrganization: true,
-          seedUserPasswordHash: 'hashed-seed-password',
-        }),
-      ).rejects.toThrow('seed_user 用户名已被非基线记录占用');
-    });
-
-    it('does not create department or users when ensureMinimumOrganization is false', async () => {
-      mockRoles();
-      prisma.user.findFirst.mockResolvedValue(null);
-
-      const result = await ensureSystemRoleBaseline(prisma, {
-        ensureMinimumOrganization: false,
-      });
-
-      expect(prisma.department.findUnique).not.toHaveBeenCalled();
-      expect(prisma.department.create).not.toHaveBeenCalled();
-      expect(prisma.user.findUnique).not.toHaveBeenCalled();
-      expect(result.minimumOrganization).toBeUndefined();
-    });
-
-    it('does not create department or users when ensureMinimumOrganization is omitted', async () => {
-      mockRoles();
-
-      const result = await ensureSystemRoleBaseline(prisma, {});
-
-      expect(prisma.department.findUnique).not.toHaveBeenCalled();
-      expect(prisma.department.create).not.toHaveBeenCalled();
-      expect(result.minimumOrganization).toBeUndefined();
-    });
+    expect(result.systemRoleCodes).toEqual(['admin', 'leader', 'user']);
+    expect(result).not.toHaveProperty('minimumOrganization');
   });
 });

--- a/server/src/prisma/seeds/baseline/system-role-baseline.ts
+++ b/server/src/prisma/seeds/baseline/system-role-baseline.ts
@@ -9,9 +9,7 @@ const SYSTEM_ROLES = [
 
 type EnsureOptions = {
   ensureAdminUser?: boolean;
-  ensureMinimumOrganization?: boolean;
   adminPasswordHash?: string;
-  seedUserPasswordHash?: string;
 };
 
 export async function ensureSystemRoleBaseline(prisma: PrismaClient, options: EnsureOptions = {}) {
@@ -65,114 +63,8 @@ export async function ensureSystemRoleBaseline(prisma: PrismaClient, options: En
     }
   }
 
-  let minimumOrganization:
-    | { departmentCode: string; leaderUsername: string; userUsername: string }
-    | undefined;
-
-  if (options.ensureMinimumOrganization) {
-    const seedUserPasswordHash = options.seedUserPasswordHash ?? options.adminPasswordHash;
-    if (!seedUserPasswordHash) {
-      throw new Error('创建最小组织基线需要 seedUserPasswordHash 或 adminPasswordHash');
-    }
-
-    const existingDepartment = await prisma.department.findUnique({
-      where: { code: 'SEED_BASELINE' },
-    });
-    if (existingDepartment && existingDepartment.id !== 'dept_seed_baseline') {
-      throw new Error('SEED_BASELINE 部门编码已被非基线记录占用');
-    }
-
-    const department = existingDepartment
-      ? await prisma.department.update({
-          where: { id: 'dept_seed_baseline' },
-          data: {
-            name: '基线部门',
-            status: 'active',
-            deletedAt: null,
-          },
-        })
-      : await prisma.department.create({
-          data: {
-            id: 'dept_seed_baseline',
-            code: 'SEED_BASELINE',
-            name: '基线部门',
-            status: 'active',
-          },
-        });
-
-    const existingLeader = await prisma.user.findUnique({ where: { username: 'seed_leader' } });
-    if (existingLeader && existingLeader.id !== 'user_seed_baseline_leader') {
-      throw new Error('seed_leader 用户名已被非基线记录占用');
-    }
-
-    const leader = existingLeader
-      ? await prisma.user.update({
-          where: { id: 'user_seed_baseline_leader' },
-          data: {
-            name: '基线部门负责人',
-            status: 'active',
-            departmentId: department.id,
-            roleId: leaderRole.id,
-            deletedAt: null,
-          },
-        })
-      : await prisma.user.create({
-          data: {
-            id: 'user_seed_baseline_leader',
-            username: 'seed_leader',
-            name: '基线部门负责人',
-            password: seedUserPasswordHash,
-            status: 'active',
-            roleId: leaderRole.id,
-            departmentId: department.id,
-          },
-        });
-
-    const existingMember = await prisma.user.findUnique({ where: { username: 'seed_user' } });
-    if (existingMember && existingMember.id !== 'user_seed_baseline_member') {
-      throw new Error('seed_user 用户名已被非基线记录占用');
-    }
-
-    if (existingMember) {
-      await prisma.user.update({
-        where: { id: 'user_seed_baseline_member' },
-        data: {
-          name: '基线业务用户',
-          status: 'active',
-          departmentId: department.id,
-          roleId: userRole.id,
-          deletedAt: null,
-        },
-      });
-    } else {
-      await prisma.user.create({
-        data: {
-          id: 'user_seed_baseline_member',
-          username: 'seed_user',
-          name: '基线业务用户',
-          password: seedUserPasswordHash,
-          status: 'active',
-          roleId: userRole.id,
-          departmentId: department.id,
-        },
-      });
-    }
-
-    await prisma.department.update({
-      where: { id: department.id },
-      data: { managerId: leader.id },
-    });
-
-    minimumOrganization = {
-      departmentCode: department.code,
-      leaderUsername: 'seed_leader',
-      userUsername: 'seed_user',
-    };
-  }
-
   return {
     systemRoleCodes: roles.map((item) => item.code),
     adminRoleId: adminRole.id,
-    minimumOrganization,
   };
 }


### PR DESCRIPTION
## Summary

- Remove `SEED_MINIMUM_ORG` env contract from `seed-baseline.ts` and `BaselineSeedEnv` type
- Remove `ensureMinimumOrganization` option and all minimum organization seed code from `system-role-baseline.ts` (SEED_BASELINE dept, seed_leader, seed_user, related upsert/create/update logic)
- Remove `SEED_MINIMUM_ORG=true` from `docker-compose.yml`
- Update `seed-baseline.spec.ts`: delete old SEED_MINIMUM_ORG exact-parse assertions; add assertions proving `ensureMinimumOrganization` is not produced
- Update `system-role-baseline.spec.ts`: delete minimum organization creation/repair/conflict/password preservation tests; add tests proving no department or non-admin user is created by baseline seed

## Behavior Change

Baseline seed now guarantees A-class system baseline only:
- System roles (admin, leader, user) are upserted
- Admin user is created/updated when `ensureAdminUser: true`
- No department, seed_leader, or seed_user is created

`server/src/prisma/seed.ts` development convenience accounts are untouched.

## Predecessor PRs

- PR1 (#203, `026eaed3c898f46180f15e036e2bdb19008a1e6e`): Frontend Gate And Wizard Removal
- PR2 (#204, `cff533836e3a52609055d9babf4d0719e9e18be7`): Backend Deprecated Diagnostic Contraction

## Test Plan

- [x] `npm run test -w server -- seed-baseline.spec.ts system-role-baseline.spec.ts --runInBand` — 9 tests pass
- [x] `rg -n "SEED_MINIMUM_ORG|ensureMinimumOrganization|SEED_BASELINE|seed_leader|seed_user|dept_seed_baseline|user_seed_baseline" server/src/prisma docker-compose.yml docker-compose.e2e.yml` — no baseline production references remain (spec file negative assertions and seed.ts dev data are expected and acceptable)