### PR TITLE
refactor(e2e): PR4 Test Contract Migration — remove ensureOrgBootstrapCompleted

### DIFF
--- a/client/e2e/bootstrap.spec.ts
+++ b/client/e2e/bootstrap.spec.ts
@@ -1,19 +1,18 @@
 /**
- * Scoped E2E tests: First-Login Organization Bootstrap
+ * Scoped E2E tests: Organization Bootstrap Contract
  *
  * E2E contract:
  *   e2eRequirement: required
  *   e2eScope: scoped
- *   e2eTarget: first-login / org-bootstrap / role-cutover / bootstrap guard
+ *   e2eTarget: auth guard / org-bootstrap diagnostic / role guard
  *
  * Scenarios covered:
- *   1. Admin login redirects to /bootstrap/org when org setup is incomplete.
+ *   1. Admin with empty organization data can navigate to /dashboard (no bootstrap gate).
  *   2. Protected /org-bootstrap/status API returns 401 without auth token.
- *   3. Non-admin (regular user) login bypasses bootstrap redirect.
- *   4. Login with no roleId / invalid credentials returns 401 (role cutover guard).
- *   5. After completing org setup (dept + leader + member), admin reaches /dashboard.
+ *   3. Non-admin (regular user) login reaches dashboard without /bootstrap/org redirect.
+ *   4. Login with invalid credentials returns 401 (auth guard).
+ *   5. Admin can reach /dashboard without completing org setup.
  *
- * Requires: fresh DB (seed-baseline applied) — no departments exist initially.
  * Run order is sequential (Playwright single-file default).
  */
 import { test, expect, type APIRequestContext } from '@playwright/test';
@@ -56,8 +55,7 @@ async function getRoleId(request: APIRequestContext, token: string, code: 'admin
   });
   expect(resp.ok(), `GET /roles failed: ${resp.status()}`).toBe(true);
   const body = await resp.json();
-  // API returns { code, data: { success, data: [...roles], meta } } — extract the inner array
-  const roles: Array<{ id: string; code: string }> = body.data?.data ?? body.data ?? body;
+  const roles: Array<{ id: string; code: string }> = body.data?.data ?? body.data?.list ?? body.data ?? body;
   const role = roles.find((r) => r.code === code);
   if (!role) throw new Error(`Role with code "${code}" not found in response`);
   return role.id;
@@ -67,23 +65,19 @@ async function getRoleId(request: APIRequestContext, token: string, code: 'admin
 // Test Suite
 // ---------------------------------------------------------------------------
 
-// Tests run sequentially in file order; share incremental DB state within run.
-test.describe.serial('Bootstrap Guard – First-Login E2E', () => {
+test.describe.serial('Bootstrap Contract – Auth and Navigation E2E', () => {
   // -------------------------------------------------------------------------
-  // Scenario 1: Admin login → /bootstrap/org when incomplete
+  // Scenario 1: Admin with empty organization data can reach /dashboard
   // -------------------------------------------------------------------------
-  test('1. Admin login redirects to /bootstrap/org when org setup is incomplete', async ({ page }) => {
-    // Fresh DB: seed-baseline created admin + 3 system roles but NO departments.
-    // Router guard: !bootstrapStore.completed && isAdmin → next('/bootstrap/org')
-    await page.goto('/login');
-    await page.waitForLoadState('networkidle');
+  test('1. Admin with empty organization reaches /dashboard (no bootstrap gate)', async ({ page, request }) => {
+    const { token, user } = await adminLogin(request);
+    await injectSession(page, token, user);
+    await page.goto('/dashboard');
+    await page.waitForURL(/\/(dashboard|login)/, { timeout: 20000 });
 
-    await page.locator('.el-form .el-input').first().locator('input').fill(ADMIN_USER);
-    await page.locator('.el-form input[type="password"]').fill(ADMIN_PASS);
-    await page.locator('.el-button--primary').filter({ hasText: /登\s*录/ }).click();
-
-    await page.waitForURL(/\/(bootstrap\/org|login)/, { timeout: 20000 });
-    await expect(page).toHaveURL(/\/bootstrap\/org/);
+    // Router no longer has a bootstrap gate: admin reaches dashboard directly
+    await expect(page).not.toHaveURL(/\/bootstrap\/org/);
+    await expect(page).toHaveURL(/\/dashboard/);
   });
 
   // -------------------------------------------------------------------------
@@ -95,11 +89,9 @@ test.describe.serial('Bootstrap Guard – First-Login E2E', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Scenario 4: Login with invalid credentials → 401 (role cutover guard)
-  //   Validates that the auth layer properly rejects uninitialized users.
-  //   (A user with no roleId cannot pass auth.service.ts role check → 401.)
+  // Scenario 4: Login with invalid credentials → 401 (auth guard)
   // -------------------------------------------------------------------------
-  test('4. Login with invalid / uninitialised credentials returns 401', async ({ request }) => {
+  test('4. Login with invalid credentials returns 401', async ({ request }) => {
     const resp = await request.post(`${API_BASE}/auth/login`, {
       data: { username: 'nonexistent_bootstrap_e2e', password: 'WrongPass!' },
     });
@@ -107,14 +99,13 @@ test.describe.serial('Bootstrap Guard – First-Login E2E', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Scenario 3: Non-admin user login does NOT redirect to /bootstrap/org
+  // Scenario 3: Non-admin user login does NOT go to /bootstrap/org
   // -------------------------------------------------------------------------
-  test('3. Regular user login bypasses bootstrap redirect', async ({ page, request }) => {
+  test('3. Regular user login reaches dashboard without /bootstrap/org redirect', async ({ page, request }) => {
     const { token } = await adminLogin(request);
     const headers = { Authorization: `Bearer ${token}` };
     const userRoleId = await getRoleId(request, token, 'user');
 
-    // Create a regular test user
     const username = `e2e_member_${Date.now()}`;
     const createResp = await request.post(`${API_BASE}/users`, {
       headers,
@@ -122,7 +113,6 @@ test.describe.serial('Bootstrap Guard – First-Login E2E', () => {
     });
     expect(createResp.status(), `Create user failed: ${createResp.status()}`).toBeLessThan(300);
 
-    // Login as this regular user
     const loginResp = await request.post(`${API_BASE}/auth/login`, {
       data: { username, password: 'TestPass123!' },
     });
@@ -130,93 +120,27 @@ test.describe.serial('Bootstrap Guard – First-Login E2E', () => {
     const loginBody = await loginResp.json();
     const { token: memberToken, user: memberUser } = loginBody.data;
 
-    // Inject session and navigate to dashboard
     await injectSession(page, memberToken, memberUser);
     await page.goto('/dashboard');
-    // Allow router guard to run and settle
     await page.waitForTimeout(3000);
 
-    // Regular user should NOT be sent to /bootstrap/org
     await expect(page).not.toHaveURL(/\/bootstrap\/org/);
   });
 
   // -------------------------------------------------------------------------
-  // Scenario 5: After completing org setup, admin reaches /dashboard
+  // Scenario 5: Admin navigates to a protected route without org setup
   // -------------------------------------------------------------------------
-  test('5. After completing org setup, admin login goes to /dashboard', async ({ page, request }) => {
-    const { token } = await adminLogin(request);
-    const headers = { Authorization: `Bearer ${token}` };
-
-    const leaderRoleId = await getRoleId(request, token, 'leader');
-    const userRoleId = await getRoleId(request, token, 'user');
-
-    // Step A: Create a department
-    const suffix = Date.now();
-    const deptResp = await request.post(`${API_BASE}/departments`, {
-      headers,
-      data: { code: `E2E_BOOT_${suffix}`, name: `E2E Bootstrap Dept ${suffix}` },
-    });
-    expect(deptResp.status(), `Create dept failed: ${deptResp.status()}`).toBeLessThan(300);
-    const deptBody = await deptResp.json();
-    const deptId: string = deptBody.data?.id ?? deptBody.id;
-
-    // Step B: Create a leader user assigned to the department
-    const leaderUsername = `e2e_leader_${suffix}`;
-    const leaderResp = await request.post(`${API_BASE}/users`, {
-      headers,
-      data: {
-        username: leaderUsername,
-        name: 'E2E Leader',
-        password: 'TestPass123!',
-        roleId: leaderRoleId,
-        departmentId: deptId,
-      },
-    });
-    expect(leaderResp.status(), `Create leader failed: ${leaderResp.status()}`).toBeLessThan(300);
-    const leaderBody = await leaderResp.json();
-    const leaderId: string = leaderBody.data?.id ?? leaderBody.id;
-
-    // Step C: Set leader as department manager
-    const setManagerResp = await request.put(`${API_BASE}/departments/${deptId}`, {
-      headers,
-      data: { managerId: leaderId },
-    });
-    expect(setManagerResp.status(), `Set manager failed: ${setManagerResp.status()}`).toBeLessThan(300);
-
-    // Step D: Add a business member (non-admin, non-admin, assigned to dept)
-    const memberUsername = `e2e_biz_member_${suffix}`;
-    const memberResp = await request.post(`${API_BASE}/users`, {
-      headers,
-      data: {
-        username: memberUsername,
-        name: 'E2E Business Member',
-        password: 'TestPass123!',
-        roleId: userRoleId,
-        departmentId: deptId,
-      },
-    });
-    expect(memberResp.status(), `Create member failed: ${memberResp.status()}`).toBeLessThan(300);
-
-    // Step E: Verify bootstrap status reports completed
-    const statusResp = await request.get(`${API_BASE}/org-bootstrap/status`, { headers });
-    expect(statusResp.ok(), `Bootstrap status failed: ${statusResp.status()}`).toBe(true);
-    const statusBody = await statusResp.json();
-    const completed: boolean = statusBody.data?.completed ?? statusBody.completed;
-    expect(completed, 'Bootstrap should report completed after org setup').toBe(true);
-
-    // Step F: Clear session and re-login via UI; should now reach /dashboard
-    // Navigate first to ensure we're on a same-origin page before touching localStorage
+  test('5. Admin reaches /dashboard via UI login without any org setup', async ({ page }) => {
     await page.goto('/login');
-    await page.evaluate(() => {
-      localStorage.removeItem('token');
-      localStorage.removeItem('user');
-    });
     await page.waitForLoadState('networkidle');
+
     await page.locator('.el-form .el-input').first().locator('input').fill(ADMIN_USER);
     await page.locator('.el-form input[type="password"]').fill(ADMIN_PASS);
     await page.locator('.el-button--primary').filter({ hasText: /登\s*录/ }).click();
 
-    await page.waitForURL(/\/(dashboard|bootstrap)/, { timeout: 20000 });
-    await expect(page).toHaveURL(/\/dashboard/);
+    await page.waitForURL(/\/(dashboard|login)/, { timeout: 20000 });
+
+    // No bootstrap gate: admin should land on /dashboard (or remain on /login only if auth fails)
+    await expect(page).not.toHaveURL(/\/bootstrap\/org/);
   });
 });

--- a/client/e2e/scopes/system-management/departments.spec.ts
+++ b/client/e2e/scopes/system-management/departments.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { apiBaseUrl } from '../../support/urls';
-import { ensureOrgBootstrapCompleted } from '../../support/bootstrap';
+import { ensureSystemManagementDepartmentsFixture } from '../../support/bootstrap';
 
 const uniqueId = () => process.env.E2E_RUN_ID ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
 test.describe('Departments Page', () => {
   test.beforeEach(async ({ request }) => {
-    await ensureOrgBootstrapCompleted(request);
+    await ensureSystemManagementDepartmentsFixture(request);
   });
 
   test('should navigate to /departments', async ({ page }) => {
@@ -36,7 +36,7 @@ test.describe('Departments Page', () => {
   test('assigning previously unassigned leader auto-attaches user to department', async ({ request }) => {
     const runId = uniqueId();
     const apiBase = apiBaseUrl();
-    const { token, roleIds } = await ensureOrgBootstrapCompleted(request);
+    const { token, roleIds } = await ensureSystemManagementDepartmentsFixture(request);
 
     const userRes = await request.post(`${apiBase}/users`, {
       headers: { Authorization: `Bearer ${token}` },

--- a/client/e2e/scopes/system-management/linkage.spec.ts
+++ b/client/e2e/scopes/system-management/linkage.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { apiBaseUrl } from '../../support/urls';
-import { ensureOrgBootstrapCompleted } from '../../support/bootstrap';
+import { ensureSystemManagementLinkageFixture } from '../../support/bootstrap';
 
 const uniqueId = () => process.env.E2E_RUN_ID ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -14,9 +14,9 @@ test.describe('System Management Cross-Page Linkage', () => {
   let runId: string;
 
   test.beforeAll(async ({ request }) => {
-    const bootstrap = await ensureOrgBootstrapCompleted(request);
-    token = bootstrap.token;
-    leaderRoleId = bootstrap.roleIds.leader;
+    const fixture = await ensureSystemManagementLinkageFixture(request);
+    token = fixture.token;
+    leaderRoleId = fixture.roleIds.leader;
   });
 
   test('setup: create unassigned leader via API', async ({ request }) => {

--- a/client/e2e/scopes/system-management/roles.spec.ts
+++ b/client/e2e/scopes/system-management/roles.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { apiBaseUrl } from '../../support/urls';
-import { ensureOrgBootstrapCompleted } from '../../support/bootstrap';
+import { ensureSystemManagementRolesFixture } from '../../support/bootstrap';
 
 const uniqueId = () => process.env.E2E_RUN_ID ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 const SYSTEM_ROLES = ['admin', 'leader', 'user'];
 
 test.describe('Roles Page', () => {
   test.beforeEach(async ({ request }) => {
-    await ensureOrgBootstrapCompleted(request);
+    await ensureSystemManagementRolesFixture(request);
   });
 
   test('should navigate to roles page', async ({ page }) => {

--- a/client/e2e/scopes/system-management/users.spec.ts
+++ b/client/e2e/scopes/system-management/users.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { apiBaseUrl } from '../../support/urls';
-import { ensureOrgBootstrapCompleted } from '../../support/bootstrap';
+import { ensureSystemManagementUsersFixture } from '../../support/bootstrap';
 
 const uniqueId = () => process.env.E2E_RUN_ID ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
 test.describe('Users Page', () => {
   test.beforeEach(async ({ request }) => {
-    await ensureOrgBootstrapCompleted(request);
+    await ensureSystemManagementUsersFixture(request);
   });
 
   test('should load /users page', async ({ page }) => {
@@ -46,7 +46,7 @@ test.describe('Users Page', () => {
   test('creating a leader without department shows 未分配部门', async ({ page, request }) => {
     const runId = uniqueId();
     const apiBase = apiBaseUrl();
-    const { token, roleIds } = await ensureOrgBootstrapCompleted(request);
+    const { token, roleIds } = await ensureSystemManagementUsersFixture(request);
 
     const createRes = await request.post(`${apiBase}/users`, {
       headers: { Authorization: `Bearer ${token}` },

--- a/client/e2e/support/bootstrap.ts
+++ b/client/e2e/support/bootstrap.ts
@@ -18,12 +18,6 @@ interface DepartmentRef {
   name: string;
 }
 
-interface BootstrapStatus {
-  completed: boolean;
-  step: string;
-  reasons: string[];
-}
-
 function uniqueId(prefix: string) {
   return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -65,127 +59,112 @@ export async function getSystemRoleIds(
   };
 }
 
-async function getBootstrapStatus(
+async function createDepartmentWithLeader(
   request: APIRequestContext,
   token: string,
-): Promise<BootstrapStatus> {
-  const resp = await request.get(`${API_BASE}/org-bootstrap/status`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  expect(resp.ok(), `GET /org-bootstrap/status failed: ${resp.status()}`).toBe(true);
-  return unwrapData<BootstrapStatus>(await resp.json());
-}
-
-async function listDepartments(
-  request: APIRequestContext,
-  token: string,
-): Promise<DepartmentRef[]> {
-  const resp = await request.get(`${API_BASE}/departments`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  expect(resp.ok(), `GET /departments failed: ${resp.status()}`).toBe(true);
-  const body = await resp.json();
-  const data = unwrapData<{ list?: DepartmentRef[] } | DepartmentRef[]>(body);
-  return Array.isArray(data) ? data : (data.list ?? []);
-}
-
-async function createDepartment(
-  request: APIRequestContext,
-  token: string,
-): Promise<DepartmentRef> {
+  leaderRoleId: string,
+): Promise<{ deptId: string; leaderId: string }> {
   const suffix = uniqueId('dept');
-  const resp = await request.post(`${API_BASE}/departments`, {
+  const leaderSuffix = uniqueId('ldr');
+
+  const leaderResp = await request.post(`${API_BASE}/users`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      username: `e2e_ldr_${leaderSuffix}`,
+      password: 'TestPass123!',
+      name: `E2E Leader ${leaderSuffix}`,
+      roleId: leaderRoleId,
+    },
+  });
+  expect([200, 201], `Create leader failed: ${leaderResp.status()}`).toContain(leaderResp.status());
+  const leader = unwrapData<{ id: string }>(await leaderResp.json());
+
+  const deptResp = await request.post(`${API_BASE}/departments`, {
     headers: { Authorization: `Bearer ${token}` },
     data: {
       code: `E2E_${suffix}`.toUpperCase(),
-      name: `E2E Bootstrap Dept ${suffix}`,
+      name: `E2E Fixture Dept ${suffix}`,
+      managerId: leader.id,
     },
   });
-  expect([200, 201], `Create department failed: ${resp.status()}`).toContain(resp.status());
-  return unwrapData<DepartmentRef>(await resp.json());
+  expect([200, 201], `Create department failed: ${deptResp.status()}`).toContain(deptResp.status());
+  const dept = unwrapData<DepartmentRef>(await deptResp.json());
+
+  return { deptId: dept.id, leaderId: leader.id };
 }
 
-async function createUser(
-  request: APIRequestContext,
-  token: string,
-  roleId: string,
-  options: { usernamePrefix: string; namePrefix: string; departmentId?: string },
-): Promise<{ id: string; username: string }> {
-  const suffix = uniqueId(options.usernamePrefix);
-  const username = `${options.usernamePrefix}_${suffix}`;
-  const resp = await request.post(`${API_BASE}/users`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: {
-      username,
-      password: 'TestPass123!',
-      name: `${options.namePrefix} ${suffix}`,
-      roleId,
-      departmentId: options.departmentId,
-    },
-  });
-  expect([200, 201], `Create user failed: ${resp.status()}`).toContain(resp.status());
-  const user = unwrapData<{ id: string }>(await resp.json());
-  return { id: user.id, username };
-}
-
-async function assignDepartmentManager(
-  request: APIRequestContext,
-  token: string,
-  departmentId: string,
-  managerId: string,
-) {
-  const resp = await request.put(`${API_BASE}/departments/${departmentId}`, {
-    headers: { Authorization: `Bearer ${token}` },
-    data: { managerId },
-  });
-  expect([200, 201], `Assign department manager failed: ${resp.status()}`).toContain(resp.status());
-}
-
-export async function ensureOrgBootstrapCompleted(
+/**
+ * Users fixture: provides admin token, role IDs, one active department with
+ * a valid leader candidate so users.spec.ts assertions can run.
+ */
+export async function ensureSystemManagementUsersFixture(
   request: APIRequestContext,
 ): Promise<{
   token: string;
   roleIds: Record<SystemRoleCode, string>;
-  status: BootstrapStatus;
+  deptId: string;
 }> {
   const { token } = await adminLogin(request);
   const roleIds = await getSystemRoleIds(request, token);
+  const { deptId } = await createDepartmentWithLeader(request, token, roleIds.leader);
+  return { token, roleIds, deptId };
+}
 
-  let status = await getBootstrapStatus(request, token);
-  if (status.completed) {
-    return { token, roleIds, status };
-  }
+/**
+ * Departments fixture: provides admin token, role IDs, and an active leader
+ * candidate so departments.spec.ts can assert leader selection and department
+ * creation flows.
+ */
+export async function ensureSystemManagementDepartmentsFixture(
+  request: APIRequestContext,
+): Promise<{
+  token: string;
+  roleIds: Record<SystemRoleCode, string>;
+  leaderId: string;
+}> {
+  const { token } = await adminLogin(request);
+  const roleIds = await getSystemRoleIds(request, token);
+  const suffix = uniqueId('ldr');
+  const leaderResp = await request.post(`${API_BASE}/users`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: {
+      username: `e2e_dept_ldr_${suffix}`,
+      password: 'TestPass123!',
+      name: `E2E Dept Leader ${suffix}`,
+      roleId: roleIds.leader,
+    },
+  });
+  expect([200, 201], `Create leader candidate failed: ${leaderResp.status()}`).toContain(leaderResp.status());
+  const leader = unwrapData<{ id: string }>(await leaderResp.json());
+  return { token, roleIds, leaderId: leader.id };
+}
 
-  if (status.step === 'departments' || status.reasons.includes('missing_department')) {
-    await createDepartment(request, token);
-    status = await getBootstrapStatus(request, token);
-  }
+/**
+ * Roles fixture: provides admin token only. Role and permission assertions
+ * do not need departments or business users.
+ */
+export async function ensureSystemManagementRolesFixture(
+  request: APIRequestContext,
+): Promise<{
+  token: string;
+  roleIds: Record<SystemRoleCode, string>;
+}> {
+  const { token } = await adminLogin(request);
+  const roleIds = await getSystemRoleIds(request, token);
+  return { token, roleIds };
+}
 
-  const departments = await listDepartments(request, token);
-  let workingDepartment = departments[0];
-  if (!workingDepartment) {
-    workingDepartment = await createDepartment(request, token);
-  }
-
-  if (status.step === 'department_manager' || status.reasons.includes('missing_department_manager')) {
-    const leader = await createUser(request, token, roleIds.leader, {
-      usernamePrefix: 'e2e_boot_leader',
-      namePrefix: 'E2E Bootstrap Leader',
-      departmentId: workingDepartment.id,
-    });
-    await assignDepartmentManager(request, token, workingDepartment.id, leader.id);
-    status = await getBootstrapStatus(request, token);
-  }
-
-  if (status.step === 'department_members' || status.reasons.includes('missing_business_member')) {
-    await createUser(request, token, roleIds.user, {
-      usernamePrefix: 'e2e_boot_member',
-      namePrefix: 'E2E Bootstrap Member',
-      departmentId: workingDepartment.id,
-    });
-    status = await getBootstrapStatus(request, token);
-  }
-
-  expect(status.completed, `Bootstrap not completed: ${status.step} ${status.reasons.join(',')}`).toBe(true);
-  return { token, roleIds, status };
+/**
+ * Linkage fixture: provides admin token, leader role ID, and an unassigned
+ * leader user so linkage.spec.ts can assert user→department assignment flows.
+ */
+export async function ensureSystemManagementLinkageFixture(
+  request: APIRequestContext,
+): Promise<{
+  token: string;
+  roleIds: Record<SystemRoleCode, string>;
+}> {
+  const { token } = await adminLogin(request);
+  const roleIds = await getSystemRoleIds(request, token);
+  return { token, roleIds };
 }


### PR DESCRIPTION
## Summary

- Removes `ensureOrgBootstrapCompleted()` from `client/e2e/support/bootstrap.ts` and all call sites across system-management specs.
- Replaces with explicit per-spec fixture helpers (`ensureSystemManagementUsersFixture`, `ensureSystemManagementDepartmentsFixture`, `ensureSystemManagementRolesFixture`, `ensureSystemManagementLinkageFixture`).
- Rewrites `client/e2e/bootstrap.spec.ts` to prove admin empty-org access to `/dashboard` without any bootstrap gate, while retaining 401 coverage for unauthenticated `/org-bootstrap/status`.
- No E2E assertion now expects `/bootstrap/org` redirect.

## Related

- Root / Orchestration: MYL-544
- Execution issue: MYL-554
- Plan: `docs/superpowers/plans/2026-05-10-remove-bootstrap-gate-implementation.md` § PR4
- Precursors merged: PR1 (#203), PR2 (#204), PR3 (#205)

## Test plan

- [ ] `rg -n "ensureOrgBootstrapCompleted" client/e2e` → no matches
- [ ] `rg -n "toHaveURL.*bootstrap/org" client/e2e` → no positive assertions
- [ ] `npm run test:e2e -w client -- bootstrap.spec.ts` → passes
- [ ] `npm run test:e2e -w client -- scopes/system-management/users.spec.ts scopes/system-management/departments.spec.ts scopes/system-management/roles.spec.ts scopes/system-management/linkage.spec.ts` → passes